### PR TITLE
fix: suppress press handlers on disabled Pressable and Touchable mocks

### DIFF
--- a/.changeset/fresh-moose-create.md
+++ b/.changeset/fresh-moose-create.md
@@ -1,0 +1,5 @@
+---
+"vitest-native": patch
+---
+
+Suppress press handlers on disabled Pressable and Touchable mocks

--- a/packages/vitest-native/src/mocks/components/Pressable.ts
+++ b/packages/vitest-native/src/mocks/components/Pressable.ts
@@ -9,6 +9,13 @@ export function createPressableMock() {
       disabled || accessibilityState
         ? { ...accessibilityState, ...(disabled ? { disabled: true } : {}) }
         : undefined;
+    // Strip press handlers when disabled to match real RN behavior.
+    if (disabled) {
+      delete rest.onPress;
+      delete rest.onPressIn;
+      delete rest.onPressOut;
+      delete rest.onLongPress;
+    }
     return React.createElement("Pressable", {
       accessible: true,
       ...rest,

--- a/packages/vitest-native/src/mocks/components/TouchableHighlight.ts
+++ b/packages/vitest-native/src/mocks/components/TouchableHighlight.ts
@@ -7,6 +7,12 @@ export function createTouchableHighlightMock() {
       disabled || accessibilityState
         ? { ...accessibilityState, ...(disabled ? { disabled: true } : {}) }
         : undefined;
+    if (disabled) {
+      delete rest.onPress;
+      delete rest.onPressIn;
+      delete rest.onPressOut;
+      delete rest.onLongPress;
+    }
     return React.createElement("TouchableHighlight", {
       accessible: true,
       ...rest,

--- a/packages/vitest-native/src/mocks/components/TouchableNativeFeedback.ts
+++ b/packages/vitest-native/src/mocks/components/TouchableNativeFeedback.ts
@@ -7,6 +7,12 @@ export function createTouchableNativeFeedbackMock() {
       disabled || accessibilityState
         ? { ...accessibilityState, ...(disabled ? { disabled: true } : {}) }
         : undefined;
+    if (disabled) {
+      delete rest.onPress;
+      delete rest.onPressIn;
+      delete rest.onPressOut;
+      delete rest.onLongPress;
+    }
     return React.createElement("TouchableNativeFeedback", {
       accessible: true,
       ...rest,

--- a/packages/vitest-native/src/mocks/components/TouchableOpacity.ts
+++ b/packages/vitest-native/src/mocks/components/TouchableOpacity.ts
@@ -7,6 +7,12 @@ export function createTouchableOpacityMock() {
       disabled || accessibilityState
         ? { ...accessibilityState, ...(disabled ? { disabled: true } : {}) }
         : undefined;
+    if (disabled) {
+      delete rest.onPress;
+      delete rest.onPressIn;
+      delete rest.onPressOut;
+      delete rest.onLongPress;
+    }
     return React.createElement("TouchableOpacity", {
       accessible: true,
       ...rest,

--- a/packages/vitest-native/src/mocks/components/TouchableWithoutFeedback.ts
+++ b/packages/vitest-native/src/mocks/components/TouchableWithoutFeedback.ts
@@ -7,6 +7,12 @@ export function createTouchableWithoutFeedbackMock() {
       disabled || accessibilityState
         ? { ...accessibilityState, ...(disabled ? { disabled: true } : {}) }
         : undefined;
+    if (disabled) {
+      delete rest.onPress;
+      delete rest.onPressIn;
+      delete rest.onPressOut;
+      delete rest.onLongPress;
+    }
     return React.createElement("TouchableWithoutFeedback", {
       accessible: true,
       ...rest,

--- a/packages/vitest-native/tests/components.test.tsx
+++ b/packages/vitest-native/tests/components.test.tsx
@@ -1,7 +1,19 @@
 import { describe, it, expect, vi } from "vitest";
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react-native";
-import { View, Text, TextInput, Pressable, Image, ScrollView, Button } from "react-native";
+import {
+  View,
+  Text,
+  TextInput,
+  Pressable,
+  Image,
+  ScrollView,
+  Button,
+  TouchableOpacity,
+  TouchableHighlight,
+  TouchableWithoutFeedback,
+  TouchableNativeFeedback,
+} from "react-native";
 
 describe("Component rendering", () => {
   it("renders View with children", () => {
@@ -78,5 +90,60 @@ describe("Component rendering", () => {
     expect(btn.props.accessibilityRole).toBe("button");
     expect(btn.props.accessible).toBe(true);
     expect(btn.props.accessibilityLabel).toBe("Action");
+  });
+
+  it("Pressable does not fire onPress when disabled", () => {
+    const onPress = vi.fn();
+    render(
+      <Pressable testID="disabled-pressable" onPress={onPress} disabled>
+        <Text>Press me</Text>
+      </Pressable>,
+    );
+    fireEvent.press(screen.getByTestId("disabled-pressable"));
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it("TouchableOpacity does not fire onPress when disabled", () => {
+    const onPress = vi.fn();
+    render(
+      <TouchableOpacity testID="disabled-to" onPress={onPress} disabled>
+        <Text>Tap</Text>
+      </TouchableOpacity>,
+    );
+    fireEvent.press(screen.getByTestId("disabled-to"));
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it("TouchableHighlight does not fire onPress when disabled", () => {
+    const onPress = vi.fn();
+    render(
+      <TouchableHighlight testID="disabled-th" onPress={onPress} disabled>
+        <Text>Tap</Text>
+      </TouchableHighlight>,
+    );
+    fireEvent.press(screen.getByTestId("disabled-th"));
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it("TouchableWithoutFeedback does not fire onPress when disabled", () => {
+    const onPress = vi.fn();
+    render(
+      <TouchableWithoutFeedback testID="disabled-twf" onPress={onPress} disabled>
+        <Text>Tap</Text>
+      </TouchableWithoutFeedback>,
+    );
+    fireEvent.press(screen.getByTestId("disabled-twf"));
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it("TouchableNativeFeedback does not fire onPress when disabled", () => {
+    const onPress = vi.fn();
+    render(
+      <TouchableNativeFeedback testID="disabled-tnf" onPress={onPress} disabled>
+        <Text>Tap</Text>
+      </TouchableNativeFeedback>,
+    );
+    fireEvent.press(screen.getByTestId("disabled-tnf"));
+    expect(onPress).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
When `disabled={true}`, `onPress`, `onPressIn`, `onPressOut`, and `onLongPress` are now stripped from Pressable, TouchableOpacity, TouchableHighlight, TouchableWithoutFeedback, and TouchableNativeFeedback mocks, matching real React Native behavior.

- Closes #3