### PR TITLE
feat: RNGH Pressable preset export + reanimated animated matchers

### DIFF
--- a/.changeset/rngh-pressable-animated-matchers.md
+++ b/.changeset/rngh-pressable-animated-matchers.md
@@ -1,0 +1,8 @@
+---
+"vitest-native": minor
+---
+
+Add `Pressable` to the gesture-handler preset and register reanimated-compatible `toHaveAnimatedStyle` / `toHaveAnimatedProps` matchers
+
+- The `react-native-gesture-handler` preset now exports `Pressable`, mirroring React Native's `Pressable` (including suppressing press handlers when `disabled`).
+- `toHaveAnimatedStyle` and `toHaveAnimatedProps` are auto-registered on `expect()`, replacing reanimated's Jest-only `setUpTests()` matchers. Opt into types with `"types": ["vitest-native/matchers"]`.

--- a/packages/vitest-native/README.md
+++ b/packages/vitest-native/README.md
@@ -15,6 +15,7 @@ A Vitest plugin for React Native. One install, zero config.
 - [Test Helpers](#test-helpers)
 - [Auto-Detect Presets](#auto-detect-presets)
 - [RNTL Matchers](#rntl-matchers)
+- [Animated Matchers (Reanimated)](#animated-matchers-reanimated)
 - [Snapshot Serializer](#snapshot-serializer)
 - [Platform Extensions](#platform-extensions)
 - [Asset Stubs](#asset-stubs)
@@ -385,6 +386,77 @@ test('greeting is visible with correct style', () => {
   expect(text).toHaveStyle({ color: 'red' });
   expect(text).toHaveTextContent('Hello');
 });
+```
+
+---
+
+## Animated Matchers (Reanimated)
+
+`react-native-reanimated` ships `toHaveAnimatedStyle` and `toHaveAnimatedProps` through its Jest setup, which isn't available under Vitest. `vitest-native` registers Vitest-native equivalents automatically — no `setUpTests()` call or setup file needed.
+
+| Matcher | Description |
+|---|---|
+| `toHaveAnimatedStyle(style, config?)` | Element's (flattened) style contains the given entries. Pass `{ shouldMatchAllProps: true }` to require an exact match. |
+| `toHaveAnimatedProps(props)` | Element's animated props contain the given entries. |
+
+Because the `reanimated` preset resolves `useAnimatedStyle`/`useAnimatedProps` synchronously, the animated values land on the rendered element and these matchers read straight from it:
+
+```tsx
+import { render, screen } from '@testing-library/react-native';
+import Animated, { useSharedValue, useAnimatedStyle } from 'react-native-reanimated';
+
+function Skeleton({ visible }: { visible: boolean }) {
+  const opacity = useSharedValue(visible ? 1 : 0);
+  const style = useAnimatedStyle(() => ({ opacity: opacity.value }));
+  return <Animated.View testID="bone" style={style} />;
+}
+
+test('starts with full opacity', () => {
+  render(<Skeleton visible />);
+  expect(screen.getByTestId('bone')).toHaveAnimatedStyle({ opacity: 1 });
+});
+```
+
+### Reanimated + Gesture Handler without manual mocks
+
+Both libraries are auto-detected, so a component using a `Gesture` + `GestureDetector` driving an animated style needs no `vi.mock()` calls:
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated, { useSharedValue, useAnimatedStyle } from 'react-native-reanimated';
+
+function Card() {
+  const pressed = useSharedValue(false);
+  const style = useAnimatedStyle(() => ({ opacity: pressed.value ? 0.5 : 1 }));
+  const tap = Gesture.Tap().onStart(() => {
+    pressed.value = true;
+  });
+  return (
+    <GestureDetector gesture={tap}>
+      <Animated.View testID="card" style={style} />
+    </GestureDetector>
+  );
+}
+
+test('card renders at full opacity', () => {
+  render(<Card />);
+  expect(screen.getByTestId('card')).toHaveAnimatedStyle({ opacity: 1 });
+});
+```
+
+> RNGH's `Pressable` is also exported by the preset and mirrors React Native's `Pressable` (including not firing `onPress` when `disabled`), so you can swap `import { Pressable } from 'react-native-gesture-handler'` straight into tests.
+
+### TypeScript
+
+To type the matchers on `expect()`, add the matcher types to your `tsconfig.json`:
+
+```jsonc
+{
+  "compilerOptions": {
+    "types": ["vitest-native/matchers"]
+  }
+}
 ```
 
 ---

--- a/packages/vitest-native/package.json
+++ b/packages/vitest-native/package.json
@@ -77,6 +77,16 @@
         "types": "./dist/presets.d.cts",
         "default": "./dist/presets.cjs"
       }
+    },
+    "./matchers": {
+      "import": {
+        "types": "./dist/matchers.d.mts",
+        "default": "./dist/matchers.mjs"
+      },
+      "require": {
+        "types": "./dist/matchers.d.cts",
+        "default": "./dist/matchers.cjs"
+      }
     }
   },
   "files": [

--- a/packages/vitest-native/src/matchers/animated.ts
+++ b/packages/vitest-native/src/matchers/animated.ts
@@ -1,0 +1,179 @@
+/**
+ * Reanimated-compatible matchers: `toHaveAnimatedStyle` and `toHaveAnimatedProps`.
+ *
+ * react-native-reanimated ships these matchers via its Jest setup
+ * (`setUpTests()`), so they are unavailable under Vitest by default — calling
+ * `expect(node).toHaveAnimatedStyle(...)` throws `Invalid Chai property`.
+ *
+ * vitest-native's reanimated preset resolves animated hooks synchronously:
+ * `useAnimatedStyle(updater)` returns `updater()` and the result is passed
+ * through as the element's `style` prop (and `animatedProps` is passed through
+ * verbatim). These matchers therefore read straight from the rendered element's
+ * props, flattening style arrays the same way React Native does.
+ */
+
+type StyleLike = Record<string, unknown> | StyleLike[] | null | undefined | false;
+
+/** Flatten a React Native `style` prop (object, array, or nested arrays). */
+function flattenStyle(style: StyleLike): Record<string, unknown> {
+  if (!style) return {};
+  if (Array.isArray(style)) {
+    return style.reduce<Record<string, unknown>>(
+      (acc, entry) => Object.assign(acc, flattenStyle(entry)),
+      {},
+    );
+  }
+  if (typeof style === "object") return style as Record<string, unknown>;
+  return {};
+}
+
+/** Narrow an unknown value to something with a `props` bag. */
+function getProps(received: unknown): Record<string, unknown> | null {
+  if (received && typeof received === "object" && "props" in received) {
+    const props = (received as { props?: unknown }).props;
+    if (props && typeof props === "object") return props as Record<string, unknown>;
+  }
+  return null;
+}
+
+interface MatcherContext {
+  isNot: boolean;
+  equals: (a: unknown, b: unknown) => boolean;
+  utils: {
+    matcherHint: (name: string, received?: string, expected?: string, options?: unknown) => string;
+    printExpected: (value: unknown) => string;
+    printReceived: (value: unknown) => string;
+    diff?: (a: unknown, b: unknown) => string | null;
+  };
+}
+
+interface MatcherResult {
+  pass: boolean;
+  message: () => string;
+}
+
+export interface AnimatedStyleConfig {
+  /** When true, every key of the current style must match `expectedStyle` exactly. */
+  shouldMatchAllProps?: boolean;
+}
+
+function notAnElementResult(
+  ctx: MatcherContext,
+  matcherName: string,
+  received: unknown,
+): MatcherResult {
+  return {
+    pass: false,
+    message: () =>
+      `${ctx.utils.matcherHint(matcherName, "element", "expected")}\n\n` +
+      `Expected a rendered element with a \`props\` object, but received:\n` +
+      `  ${ctx.utils.printReceived(received)}`,
+  };
+}
+
+/** Pick only the keys present in `expected` from `actual`, for readable diffs. */
+function subset(
+  actual: Record<string, unknown>,
+  expected: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(expected)) result[key] = actual[key];
+  return result;
+}
+
+export function toHaveAnimatedStyle(
+  this: MatcherContext,
+  received: unknown,
+  expectedStyle: Record<string, unknown>,
+  config: AnimatedStyleConfig = {},
+): MatcherResult {
+  const props = getProps(received);
+  if (!props) return notAnElementResult(this, "toHaveAnimatedStyle", received);
+
+  const currentStyle = flattenStyle(props.style as StyleLike);
+  const compared = config.shouldMatchAllProps ? currentStyle : subset(currentStyle, expectedStyle);
+  const pass = this.equals(compared, expectedStyle);
+
+  return {
+    pass,
+    message: () => {
+      const hint = this.utils.matcherHint("toHaveAnimatedStyle", "element", "expectedStyle", {
+        isNot: this.isNot,
+      });
+      if (pass) {
+        return (
+          `${hint}\n\n` +
+          `Expected element not to have animated style:\n` +
+          `  ${this.utils.printExpected(expectedStyle)}\n` +
+          `Received:\n  ${this.utils.printReceived(compared)}`
+        );
+      }
+      const diff = this.utils.diff?.(expectedStyle, compared);
+      return diff
+        ? `${hint}\n\n${diff}`
+        : `${hint}\n\n` +
+            `Expected: ${this.utils.printExpected(expectedStyle)}\n` +
+            `Received: ${this.utils.printReceived(compared)}`;
+    },
+  };
+}
+
+export function toHaveAnimatedProps(
+  this: MatcherContext,
+  received: unknown,
+  expectedProps: Record<string, unknown>,
+): MatcherResult {
+  const props = getProps(received);
+  if (!props) return notAnElementResult(this, "toHaveAnimatedProps", received);
+
+  // The preset passes `animatedProps` through verbatim; fall back to the
+  // element's own props for components that spread them directly.
+  const source =
+    props.animatedProps && typeof props.animatedProps === "object"
+      ? (props.animatedProps as Record<string, unknown>)
+      : props;
+  const compared = subset(source, expectedProps);
+  const pass = this.equals(compared, expectedProps);
+
+  return {
+    pass,
+    message: () => {
+      const hint = this.utils.matcherHint("toHaveAnimatedProps", "element", "expectedProps", {
+        isNot: this.isNot,
+      });
+      if (pass) {
+        return (
+          `${hint}\n\n` +
+          `Expected element not to have animated props:\n` +
+          `  ${this.utils.printExpected(expectedProps)}\n` +
+          `Received:\n  ${this.utils.printReceived(compared)}`
+        );
+      }
+      const diff = this.utils.diff?.(expectedProps, compared);
+      return diff
+        ? `${hint}\n\n${diff}`
+        : `${hint}\n\n` +
+            `Expected: ${this.utils.printExpected(expectedProps)}\n` +
+            `Received: ${this.utils.printReceived(compared)}`;
+    },
+  };
+}
+
+/** All reanimated-compatible matchers, keyed by name for `expect.extend`. */
+export const animatedMatchers = {
+  toHaveAnimatedStyle,
+  toHaveAnimatedProps,
+};
+
+// Augment Vitest's matcher interfaces so the matchers type-check for consumers.
+// The matchers are auto-registered by vitest-native's setup file.
+declare module "vitest" {
+  interface Assertion<T = any> {
+    toHaveAnimatedStyle(style: Record<string, unknown>, config?: AnimatedStyleConfig): T;
+    toHaveAnimatedProps(props: Record<string, unknown>): T;
+  }
+  interface AsymmetricMatchersContaining {
+    toHaveAnimatedStyle(style: Record<string, unknown>, config?: AnimatedStyleConfig): unknown;
+    toHaveAnimatedProps(props: Record<string, unknown>): unknown;
+  }
+}

--- a/packages/vitest-native/src/presets/gesture-handler.ts
+++ b/packages/vitest-native/src/presets/gesture-handler.ts
@@ -1,6 +1,7 @@
 import type { Preset } from "../types.js";
 import { vi } from "vitest";
 import React from "react";
+import { createPressableMock } from "../mocks/components/Pressable.js";
 
 export function gestureHandler(): Preset {
   return {
@@ -30,6 +31,7 @@ export function gestureHandler(): Preset {
           "TouchableHighlight",
           "TouchableWithoutFeedback",
           "TouchableNativeFeedback",
+          "Pressable",
         ],
         factory: () => {
           const State = {
@@ -149,6 +151,9 @@ export function gestureHandler(): Preset {
             TouchableHighlight: createGestureHandler("GH-TouchableHighlight"),
             TouchableWithoutFeedback: createGestureHandler("GH-TouchableWithoutFeedback"),
             TouchableNativeFeedback: createGestureHandler("GH-TouchableNativeFeedback"),
+            // RNGH's Pressable mirrors RN's Pressable API. Reuse the RN mock so
+            // it inherits behaviors like suppressing press handlers when disabled.
+            Pressable: createPressableMock(),
           };
         },
       },

--- a/packages/vitest-native/src/setup.ts
+++ b/packages/vitest-native/src/setup.ts
@@ -25,6 +25,7 @@ import path from "node:path";
 import type { Preset } from "./types.js";
 import { AUTO_DETECT_PRESETS } from "./preset-map.js";
 import { serializer as rnSerializer } from "./serializer.js";
+import { animatedMatchers } from "./matchers/animated.js";
 
 // --- Read options from process.env ---
 
@@ -246,11 +247,20 @@ try {
   }
 }
 
-// --- 7. Register snapshot serializer for readable RN component output ---
+// --- 7. Register reanimated-compatible matchers (toHaveAnimatedStyle, etc.) ---
+
+vitestExpect.extend(animatedMatchers as Record<string, (...args: any[]) => any>);
+if (diagnostics) {
+  console.log(
+    `[vitest-native] Registered ${Object.keys(animatedMatchers).length} animated matchers: ${Object.keys(animatedMatchers).join(", ")}`,
+  );
+}
+
+// --- 8. Register snapshot serializer for readable RN component output ---
 
 vitestExpect.addSnapshotSerializer(rnSerializer);
 
-// --- 8. Cleanup ---
+// --- 9. Cleanup ---
 
 afterAll(() => {
   uninstallCjsBridge();

--- a/packages/vitest-native/tests/animated-matchers.test.tsx
+++ b/packages/vitest-native/tests/animated-matchers.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Tests for the reanimated-compatible matchers `toHaveAnimatedStyle` and
+ * `toHaveAnimatedProps`, auto-registered by vitest-native's setup.
+ *
+ * The matchers read straight from a rendered element's `style` / `animatedProps`,
+ * which is exactly what the reanimated preset produces. We drive them both
+ * directly (plain elements) and through the real reanimated preset factory so
+ * the whole hook → render → matcher pipeline is covered without needing
+ * react-native-reanimated installed.
+ */
+import { describe, it, expect } from "vitest";
+import React from "react";
+import { render, screen } from "@testing-library/react-native";
+import { View, Text, StyleSheet } from "react-native";
+import { reanimated } from "../src/presets/index.js";
+
+const rea = reanimated().modules["react-native-reanimated"].factory();
+
+describe("toHaveAnimatedStyle", () => {
+  it("matches a subset of the element's style", () => {
+    render(<View testID="box" style={{ opacity: 1, width: 100 }} />);
+    expect(screen.getByTestId("box")).toHaveAnimatedStyle({ opacity: 1 });
+  });
+
+  it("fails when the value differs", () => {
+    render(<View testID="box" style={{ opacity: 0.5 }} />);
+    expect(screen.getByTestId("box")).not.toHaveAnimatedStyle({ opacity: 1 });
+  });
+
+  it("flattens style arrays", () => {
+    const styles = StyleSheet.create({ base: { width: 50 } });
+    render(<View testID="box" style={[styles.base, { opacity: 0.2 }]} />);
+    expect(screen.getByTestId("box")).toHaveAnimatedStyle({ opacity: 0.2, width: 50 });
+  });
+
+  it("matches all props when shouldMatchAllProps is set", () => {
+    render(<View testID="box" style={{ opacity: 1, width: 100 }} />);
+    expect(screen.getByTestId("box")).toHaveAnimatedStyle(
+      { opacity: 1, width: 100 },
+      { shouldMatchAllProps: true },
+    );
+    expect(screen.getByTestId("box")).not.toHaveAnimatedStyle(
+      { opacity: 1 },
+      { shouldMatchAllProps: true },
+    );
+  });
+
+  it("works end-to-end through the reanimated preset", () => {
+    const AnimatedView = rea.createAnimatedComponent(View);
+    function Box() {
+      const opacity = rea.useSharedValue(1);
+      const style = rea.useAnimatedStyle(() => ({ opacity: opacity.value }));
+      return (
+        <AnimatedView testID="animated" style={style}>
+          <Text>Hello</Text>
+        </AnimatedView>
+      );
+    }
+    render(<Box />);
+    expect(screen.getByTestId("animated")).toHaveAnimatedStyle({ opacity: 1 });
+  });
+});
+
+describe("toHaveAnimatedProps", () => {
+  it("reads from the animatedProps prop", () => {
+    render(<View testID="box" {...{ animatedProps: { fill: "red" } }} />);
+    expect(screen.getByTestId("box")).toHaveAnimatedProps({ fill: "red" });
+  });
+
+  it("falls back to the element's own props", () => {
+    render(<View testID="box" {...{ pointerEvents: "none" }} />);
+    expect(screen.getByTestId("box")).toHaveAnimatedProps({ pointerEvents: "none" });
+  });
+
+  it("fails when the value differs", () => {
+    render(<View testID="box" {...{ animatedProps: { fill: "blue" } }} />);
+    expect(screen.getByTestId("box")).not.toHaveAnimatedProps({ fill: "red" });
+  });
+
+  it("works end-to-end through the reanimated preset", () => {
+    const AnimatedView = rea.createAnimatedComponent(View);
+    function Box() {
+      const progress = rea.useSharedValue(0.75);
+      const animatedProps = rea.useAnimatedProps(() => ({ accessibilityValue: progress.value }));
+      return <AnimatedView testID="animated" animatedProps={animatedProps} />;
+    }
+    render(<Box />);
+    expect(screen.getByTestId("animated")).toHaveAnimatedProps({ accessibilityValue: 0.75 });
+  });
+});

--- a/packages/vitest-native/tests/presets.test.ts
+++ b/packages/vitest-native/tests/presets.test.ts
@@ -654,6 +654,11 @@ describe("preset: gestureHandler", () => {
     const MyComponent = () => null;
     expect(mock.gestureHandlerRootHOC(MyComponent)).toBe(MyComponent);
   });
+
+  it("exposes a Pressable component", () => {
+    expect(mock.Pressable).toBeDefined();
+    expect(mock.Pressable.displayName).toBe("Pressable");
+  });
 });
 
 // --- Safe Area Context ---

--- a/packages/vitest-native/tsdown.config.ts
+++ b/packages/vitest-native/tsdown.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     setup: 'src/setup.ts',
     serializer: 'src/serializer.ts',
     presets: 'src/presets/index.ts',
+    matchers: 'src/matchers/animated.ts',
   },
   format: ['esm', 'cjs'],
   dts: true,


### PR DESCRIPTION
Resolves the two open enhancement issues.

## Closes #5 — RNGH `Pressable` preset export
The `react-native-gesture-handler` preset now exports `Pressable`, reusing the RN `Pressable` mock. This means it inherits real RN behavior (including not firing press handlers when `disabled`, per #3/#4) and removes the need for the manual `vi.mock` workaround in the issue.

## Closes #2 — Reanimated animated matchers + examples
`react-native-reanimated` registers `toHaveAnimatedStyle` / `toHaveAnimatedProps` through its Jest-only `setUpTests()`, so under Vitest they throw `Invalid Chai property: toHaveAnimatedStyle`.

This adds Vitest-native equivalents that are **auto-registered** by the setup file (like the RNTL matchers) — no `setUpTests()` or manual `expect.extend` needed:

- `toHaveAnimatedStyle(style, config?)` — flattened style contains the given entries (`{ shouldMatchAllProps: true }` for an exact match).
- `toHaveAnimatedProps(props)` — animated props contain the given entries.

They read straight from the rendered element, which is exactly what the `reanimated` preset produces (`useAnimatedStyle` resolves synchronously onto `style`).

Types ship via a new `vitest-native/matchers` subpath; opt in with `"types": ["vitest-native/matchers"]`.

The README gains an **Animated Matchers** section with a Reanimated + RNGH example that needs no manual mocks.

## Verification
- `bun run test` — 1153 passed, 18 skipped (added matcher + RNGH Pressable tests)
- `bun run typecheck` — clean
- `bun run lint` — 0 warnings/errors
- `bun run format:check` — clean
- `bun run build` — produces `dist/matchers.*` with the `declare module "vitest"` augmentation

A changeset (`minor`) is included.