### PR TITLE
fix: block press on disabled mocks under RNTL v14 via pointerEvents:"none"

### DIFF
--- a/.changeset/disabled-press-pointer-events.md
+++ b/.changeset/disabled-press-pointer-events.md
@@ -1,0 +1,5 @@
+---
+"vitest-native": patch
+---
+
+Block press events on disabled Pressable/Touchable/Button under @testing-library/react-native v14 by marking disabled host props with pointerEvents:"none".

--- a/packages/vitest-native/src/mocks/components/TouchableNativeFeedback.ts
+++ b/packages/vitest-native/src/mocks/components/TouchableNativeFeedback.ts
@@ -15,6 +15,8 @@ export function createTouchableNativeFeedbackMock() {
     }
     return React.createElement("TouchableNativeFeedback", {
       accessible: true,
+      // See pressableHost.ts: disabled must block press under RNTL >=14.
+      ...(disabled ? { pointerEvents: "none" } : {}),
       ...rest,
       ...(mergedA11yState ? { accessibilityState: mergedA11yState } : {}),
       ref,

--- a/packages/vitest-native/src/mocks/components/pressableHost.ts
+++ b/packages/vitest-native/src/mocks/components/pressableHost.ts
@@ -38,6 +38,10 @@ export function buildPressableHostProps(props: any, ref: any): Record<string, an
 
   return {
     accessible: true,
+    // Disabled controls must not be touch targets. Host-prop stripping alone is not
+    // enough under RNTL >=14 (findEventHandlerFromFiber re-finds onPress on the
+    // composite mock); pointerEvents:"none" makes isEventEnabled() block the press.
+    ...(disabled ? { pointerEvents: "none" } : {}),
     ...pressProps,
     ...rest,
     ...(mergedA11yState ? { accessibilityState: mergedA11yState } : {}),


### PR DESCRIPTION
## Description

- Disabled `Pressable`/`Touchable*`/`Button` mocks still fired `onPress` via `fireEvent.press` under `@testing-library/react-native` v14, despite #4 stripping the host press handlers.
- RNTL v14's `findEventHandler` adds a `findEventHandlerFromFiber` fallback that walks the composite fiber tree and re-finds `onPress` on the wrapping `forwardRef` mock (React keeps the composite's props in `memoizedProps` regardless of what it renders). Host-prop stripping alone no longer blocks the press.
- Fix: mark disabled host props with `pointerEvents: "none"`. RNTL's `isEventEnabled` short-circuits `press`/`onPress` when `isPointerEventEnabled` is false, so the fiber-walked handler is rejected before it's accepted. Behaviorally accurate (a disabled control is not a touch target) and a no-op under RNTL ≤13.
### Root cause (RNTL 14.0.0, `dist/fire-event.js`)

```js
const handler =
  getEventHandlerFromProps(instance.props, eventName, { loose: true }) // host: stripped -> null
  ?? findEventHandlerFromFiber(instance.unstable_fiber, eventName);     // walks composites -> re-finds onPress
if (handler && isEventEnabled(instance, eventName, touchResponder)) return handler;
```

`isEventEnabled` returns `false` for `press`/`onPress` when `isPointerEventEnabled(instance)`
is false, and `isPointerEventEnabled` reads `props.pointerEvents === "none"`. Setting it on
the disabled host is what stops the press.

### Changes

- `pressableHost.ts` (`buildPressableHostProps`) — injects `pointerEvents: "none"` when `disabled`; covers `Pressable`, `TouchableOpacity`, `TouchableHighlight`, `TouchableWithoutFeedback`, and `Button` (all route through it).
- `TouchableNativeFeedback.ts` — same line for the variant with its own builder.
- Changeset (patch).

The line is injected before `...rest`, so an explicit consumer `pointerEvents` still wins.
Only applied when `disabled` is truthy; enabled presses are unchanged.

### Testing

Existing suite (`tests/components.test.tsx`, pinned RNTL 12.9.0): all pass — the fix is a
no-op there, since v12 lacks the fiber fallback.

Verified end-to-end against real RNTL **14.0.0** (mock engine). Without the fix, all six
disabled variants fire `onPress`; with the fix, all pass and enabled presses are unaffected:

| Variant | Before | After |
| --- | --- | --- |
| Pressable / TouchableOpacity / TouchableHighlight / TouchableWithoutFeedback / TouchableNativeFeedback / Button (disabled) | fail | pass |
| Pressable (enabled) | pass | pass |

Full mock suite, typecheck, lint, and format all green.

### Note

The disabled-press regression is only caught under RNTL ≥14, but dev-deps pin `@testing-library/react-native@^12.9.0`, so CI is green either way. Recommend adding a v14 test lane to guard this.

## Checklist

- [x] Tests pass (`bun run test`)
- [x] Lint passes (`bun run lint`)
- [x] Changeset added (if user-facing change): `bunx changeset`
- [ ] Docs updated (if API changed)
