### PR TITLE
test(consumers): guard disabled-press fix with a mock + RNTL 14 fixture

### DIFF
--- a/packages/vitest-native/consumer-tests/mock-rntl14/package.json
+++ b/packages/vitest-native/consumer-tests/mock-rntl14/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "vitest-native-consumer-mock-rntl14",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@testing-library/react-native": "14.0.0",
+    "react": "19.2.4",
+    "react-native": "0.85.3",
+    "test-renderer": "1.2.0"
+  },
+  "devDependencies": {
+    "vite": "^8.0.5",
+    "vitest": "4.1.8"
+  }
+}

--- a/packages/vitest-native/consumer-tests/mock-rntl14/src/disabled-press.test.tsx
+++ b/packages/vitest-native/consumer-tests/mock-rntl14/src/disabled-press.test.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react-native";
+import {
+  Button,
+  Pressable,
+  Text,
+  TouchableHighlight,
+  TouchableNativeFeedback,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+} from "react-native";
+import { afterEach, expect, test, vi } from "vitest";
+
+// Regression guard for #18 (block press on disabled mocks under RNTL v14).
+//
+// RNTL >=14 made render/fireEvent async and resolves press handlers via
+// findEventHandlerFromFiber, which walks the composite fiber and re-finds
+// onPress on the wrapping forwardRef mock — so the host-prop stripping from #4
+// no longer blocks the press on its own. The mock marks disabled hosts with
+// pointerEvents:"none" so RNTL's isEventEnabled() rejects the press.
+//
+// This is the ONLY combination in CI that pairs the mock engine with RNTL 14
+// (unit tests run RNTL 12.9; the other consumer fixtures use the native
+// engine), so without this fixture the fix is unguarded. NOTE: render and
+// fireEvent MUST be awaited under RNTL 14.
+afterEach(() => cleanup());
+
+test("disabled Pressable does not fire onPress (mock + RNTL 14)", async () => {
+  const onPress = vi.fn();
+  await render(
+    <Pressable testID="p" onPress={onPress} disabled>
+      <Text>press</Text>
+    </Pressable>,
+  );
+  expect(screen.getByTestId("p").props.pointerEvents).toBe("none");
+  await fireEvent.press(screen.getByTestId("p"));
+  expect(onPress).not.toHaveBeenCalled();
+});
+
+test("disabled TouchableOpacity does not fire onPress (mock + RNTL 14)", async () => {
+  const onPress = vi.fn();
+  await render(
+    <TouchableOpacity testID="to" onPress={onPress} disabled>
+      <Text>press</Text>
+    </TouchableOpacity>,
+  );
+  await fireEvent.press(screen.getByTestId("to"));
+  expect(onPress).not.toHaveBeenCalled();
+});
+
+test("disabled TouchableHighlight does not fire onPress (mock + RNTL 14)", async () => {
+  const onPress = vi.fn();
+  await render(
+    <TouchableHighlight testID="th" onPress={onPress} disabled>
+      <Text>press</Text>
+    </TouchableHighlight>,
+  );
+  await fireEvent.press(screen.getByTestId("th"));
+  expect(onPress).not.toHaveBeenCalled();
+});
+
+test("disabled TouchableWithoutFeedback does not fire onPress (mock + RNTL 14)", async () => {
+  const onPress = vi.fn();
+  await render(
+    <TouchableWithoutFeedback testID="twf" onPress={onPress} disabled>
+      <Text>press</Text>
+    </TouchableWithoutFeedback>,
+  );
+  await fireEvent.press(screen.getByTestId("twf"));
+  expect(onPress).not.toHaveBeenCalled();
+});
+
+test("disabled TouchableNativeFeedback does not fire onPress (mock + RNTL 14)", async () => {
+  const onPress = vi.fn();
+  await render(
+    <TouchableNativeFeedback testID="tnf" onPress={onPress} disabled>
+      <Text>press</Text>
+    </TouchableNativeFeedback>,
+  );
+  await fireEvent.press(screen.getByTestId("tnf"));
+  expect(onPress).not.toHaveBeenCalled();
+});
+
+test("disabled Button does not fire onPress (mock + RNTL 14)", async () => {
+  const onPress = vi.fn();
+  await render(<Button testID="btn" title="press" onPress={onPress} disabled />);
+  await fireEvent.press(screen.getByTestId("btn"));
+  expect(onPress).not.toHaveBeenCalled();
+});
+
+test("enabled Pressable still fires onPress (mock + RNTL 14)", async () => {
+  const onPress = vi.fn();
+  await render(
+    <Pressable testID="enabled" onPress={onPress}>
+      <Text>press</Text>
+    </Pressable>,
+  );
+  expect(screen.getByTestId("enabled").props.pointerEvents).toBeUndefined();
+  await fireEvent.press(screen.getByTestId("enabled"));
+  expect(onPress).toHaveBeenCalledTimes(1);
+});

--- a/packages/vitest-native/consumer-tests/mock-rntl14/vitest.config.mts
+++ b/packages/vitest-native/consumer-tests/mock-rntl14/vitest.config.mts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+import { reactNative } from "vitest-native";
+
+// Mock engine + RNTL 14 — the only combination in CI that pairs them, and the
+// one that surfaced the disabled-press regression fixed in #18. RNTL 14 made
+// render/fireEvent async and added findEventHandlerFromFiber, which re-finds
+// onPress on the wrapping forwardRef mock, so host-prop stripping alone no
+// longer blocks the press. The mock marks disabled hosts with
+// pointerEvents:"none" so RNTL's isEventEnabled() rejects the handler.
+export default defineConfig({
+  plugins: [reactNative({ engine: "mock" })],
+  test: {
+    environment: "node",
+    globals: true,
+  },
+});

--- a/packages/vitest-native/scripts/test-consumers.mjs
+++ b/packages/vitest-native/scripts/test-consumers.mjs
@@ -44,7 +44,7 @@ try {
   if (!tarballName) throw new Error("npm pack did not produce a tarball");
   const tarball = path.join(packRoot, tarballName);
 
-  for (const fixture of ["bare", "expo", "monorepo", "current-rn"]) {
+  for (const fixture of ["bare", "expo", "monorepo", "current-rn", "mock-rntl14"]) {
     const fixtureRoot = path.join(tempRoot, fixture);
     fs.cpSync(path.join(fixturesRoot, fixture), fixtureRoot, { recursive: true });
     addPackedDependency(fixtureRoot, tarball);


### PR DESCRIPTION
## Summary

Follow-up to #18. Adds the missing CI coverage for the combination #18 actually fixes: **mock engine + RNTL 14**.

#18 blocks `onPress` on disabled `Pressable`/`Touchable*`/`Button` mocks under RNTL ≥14 (via `pointerEvents:"none"`), but nothing in CI exercised that combination:
- unit tests run RNTL **12.9** (where the bug doesn't reproduce — RNTL ≤13 stripping is sufficient), and
- all existing consumer fixtures use the **native** engine.

So the fix shipped unguarded. This adds a packed consumer fixture (`consumer-tests/mock-rntl14`) wired into `test:consumers`.

## Why it's shaped this way

RNTL 14 made `render`/`fireEvent` **async** and resolves press handlers via `findEventHandlerFromFiber`, which walks the composite fiber and re-finds `onPress` on the wrapping `forwardRef` mock. The fixture therefore `await`s `render`/`fireEvent` and asserts:
- disabled `Pressable`, `TouchableOpacity`, `TouchableHighlight`, `TouchableWithoutFeedback`, `TouchableNativeFeedback`, and `Button` do **not** fire `onPress` (and carry `pointerEvents:"none"`),
- an enabled `Pressable` **still** fires `onPress` (and has no `pointerEvents`).

## Validation

- Confirmed the fixture **fails on the pre-#18 build** (disabled Pressable + Button fire `onPress`) and **passes with the fix** — i.e. it genuinely guards the regression.
- Full `test:consumers` green locally: all five fixtures pass; `mock-rntl14` is 7/7.
- lint, format clean.

## Note (out of scope, follow-up candidate)

Under RNTL 14 the mock setup logs a non-fatal `Unknown option(s) passed to configure: hostComponentNames` warning — RNTL 14 removed that `configure` option (it now auto-detects). Harmless (tests pass), but worth guarding the call for RNTL ≥14 in a later change.