### PR TITLE
fix(mock): silence RNTL 14 "Unknown option: hostComponentNames" warning

### DIFF
--- a/packages/vitest-native/src/setup.ts
+++ b/packages/vitest-native/src/setup.ts
@@ -211,7 +211,20 @@ for (const preset of presets) {
 
 try {
   const rntl = projectReq("@testing-library/react-native");
-  if (rntl?.configure) {
+  // RNTL >=14 removed the `hostComponentNames` configure option: it now
+  // auto-detects host components by rendering a probe (which works with the
+  // mock's host names). Passing the option there is a no-op that logs an
+  // "Unknown option(s) passed to configure" warning, so only set it for
+  // RNTL <=13. If the version can't be read, fall back to configuring it
+  // (the historical behavior, required by older RNTL).
+  let rntlMajor = 0;
+  try {
+    const { version } = projectReq("@testing-library/react-native/package.json") as {
+      version?: string;
+    };
+    rntlMajor = Number(String(version).split(".")[0]) || 0;
+  } catch {}
+  if (rntl?.configure && rntlMajor < 14) {
     rntl.configure({
       hostComponentNames: {
         text: "Text",


### PR DESCRIPTION
## Summary

The mock-engine setup calls `rntl.configure({ hostComponentNames })`. **RNTL 14 removed that option** (it now auto-detects host components by rendering a probe — which works with the mock's host names), so on RNTL ≥14 the call is a no-op that logs `Unknown option(s) passed to configure: hostComponentNames` on every run (visible in the #21 `mock-rntl14` fixture output).

Fix: read the RNTL major version and only set `hostComponentNames` for RNTL ≤13. If the version can't be read, fall back to configuring it (historical behavior — older RNTL needs it for the mock's host names).

## Validation

- **Warning gone**: the mock + RNTL 14 consumer fixture (#21) no longer logs it, still **7/7**.
- **No regression on older RNTL**: the RNTL 12.9 mock unit suite still configures `hostComponentNames` and passes (**57/57**).
- typecheck, lint, format, build clean.

Follow-up to #18 / #21.