### PR TITLE
docs(release): document mock-engine RNTL 14 fixes in 0.5.0 changelog

### DIFF
--- a/.changeset/disabled-press-pointer-events.md
+++ b/.changeset/disabled-press-pointer-events.md
@@ -1,5 +1,0 @@
----
-"vitest-native": patch
----
-
-Block press events on disabled Pressable/Touchable/Button under @testing-library/react-native v14 by marking disabled host props with pointerEvents:"none".

--- a/packages/vitest-native/CHANGELOG.md
+++ b/packages/vitest-native/CHANGELOG.md
@@ -11,6 +11,19 @@
 - Reject mock-only `mocks` overrides under the native engine instead of silently
   ignoring them.
 
+### Mock engine
+
+- Block `onPress` on disabled `Pressable`/`Touchable*`/`Button` under
+  `@testing-library/react-native` v14. RNTL 14 resolves press handlers by walking
+  the composite fiber, which re-finds `onPress` on the wrapping `forwardRef` mock,
+  so the earlier host-prop stripping no longer blocked the press; disabled hosts
+  are now marked `pointerEvents: "none"` so RNTL's `isEventEnabled` rejects it
+  (no-op under RNTL ≤13). Thanks @jakeboone02.
+- Stop passing the `hostComponentNames` option to `configure()` on RNTL ≥14,
+  which removed it in favor of auto-detection; this silences an "Unknown
+  option(s) passed to configure" warning while preserving the option for
+  RNTL ≤13.
+
 ### Reliability
 
 - Fix hot-runtime cross-file leaks from import-time globals, direct environment
@@ -25,7 +38,8 @@
 ### Compatibility and release engineering
 
 - Validate packed release tarballs in bare RN 0.83/RNTL 12, Expo 56/RNTL 13,
-  Vite 8 monorepo/RNTL 14, and RN 0.86 Android consumers.
+  Vite 8 monorepo/RNTL 14, RN 0.86 Android, and a mock-engine RNTL 14 consumer
+  (the combination that guards the disabled-press fix above).
 - Support Vite 8's Oxc JSX configuration without the deprecated `esbuild`
   option, while retaining Vite 6–7 support.
 - Load RNTL matchers across the public, `build`, and `dist` layouts used by


### PR DESCRIPTION
## Summary

Release prep for **0.5.0** (currently staged but unreleased — npm `latest` is 0.4.1). The 0.5.0 CHANGELOG was written in #19; three fixes landed afterward and weren't documented. This folds them in and removes a stray changeset.

### Changes
- **CHANGELOG**: new `### Mock engine` section under 0.5.0 documenting:
  - #18 — block `onPress` on disabled `Pressable`/`Touchable*`/`Button` under RNTL v14 (`pointerEvents:"none"`). Credits @jakeboone02.
  - #22 — stop passing the removed `hostComponentNames` option to `configure()` on RNTL ≥14 (silences the warning).
  - #21 — noted the new mock-engine RNTL 14 consumer fixture in the validation matrix.
- **Removed** `.changeset/disabled-press-pointer-events.md` — this repo documents releases manually in CHANGELOG.md, so the changeset would linger unconsumed.

### Notes
- **No version bump** — 0.5.0 is unreleased, so these fold into it.
- Docs/changeset only; no source or test changes.

Once merged, `v0.5.0` can be tagged to trigger the publish workflow (build → full gate → `npm publish --provenance`, with the tag-vs-version gate from #19).