### PR TITLE
fix(security): resolve code-scanning findings (ReDoS + workflow token-permissions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Full gate (${{ matrix.os }}, Node ${{ matrix.node-version }})

--- a/.github/workflows/compat-check.yml
+++ b/.github/workflows/compat-check.yml
@@ -6,10 +6,17 @@ on:
     - cron: '0 9 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check-latest-rn:
     name: Check against current React Native edge
     runs-on: ubuntu-latest
+    # github-script opens a tracking issue when the edge build breaks.
+    permissions:
+      contents: read
+      issues: write
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/.github/workflows/native-rn-matrix.yml
+++ b/.github/workflows/native-rn-matrix.yml
@@ -29,6 +29,9 @@ on:
     # Weekly, to catch new Vitest releases and RN patch releases within range.
     - cron: '0 9 * * 1'
 
+permissions:
+  contents: read
+
 jobs:
   matrix:
     name: native+hot — vitest ${{ matrix.vitest }} × RN ${{ matrix.rn }}

--- a/packages/vitest-native/src/mocks/apis/Animated.ts
+++ b/packages/vitest-native/src/mocks/apis/Animated.ts
@@ -124,10 +124,14 @@ function colorToRgba(input: string): [number, number, number, number] | null {
       parseInt(n.slice(6, 8), 16) / 255,
     ];
   }
-  if ((m = s.match(/^rgb\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*\)$/))) {
+  // Strip whitespace once (linear) so the rgb()/rgba() patterns need no \s*
+  // groups; overlapping \s* caused polynomial backtracking (ReDoS) on malformed
+  // input like "rgb(9,9,9" followed by many spaces.
+  const compact = s.replace(/\s+/g, "");
+  if ((m = compact.match(/^rgb\(([\d.]+),([\d.]+),([\d.]+)\)$/))) {
     return [+m[1], +m[2], +m[3], 1];
   }
-  if ((m = s.match(/^rgba\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*\)$/))) {
+  if ((m = compact.match(/^rgba\(([\d.]+),([\d.]+),([\d.]+),([\d.]+)\)$/))) {
     return [+m[1], +m[2], +m[3], +m[4]];
   }
   return null;
@@ -418,7 +422,11 @@ const namedColorMap: Record<string, [number, number, number, number]> = {
 };
 
 function parseColorString(color: string): [number, number, number, number] {
-  const rgba = color.match(/^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*([\d.]+))?\s*\)$/);
+  // Strip whitespace once (linear) so the rgb()/rgba() pattern needs no \s*
+  // groups; overlapping \s* caused polynomial backtracking (ReDoS) on malformed
+  // input like "rgb(9,9,9" followed by many spaces.
+  const compact = color.replace(/\s+/g, "");
+  const rgba = compact.match(/^rgba?\((\d+),(\d+),(\d+)(?:,([\d.]+))?\)$/);
   if (rgba)
     return [
       parseInt(rgba[1]),


### PR DESCRIPTION
Resolves open GitHub code-scanning alerts.

## CodeQL — `js/polynomial-redos` (high, real fix)
`Animated.ts` color parsers used overlapping `\s*` groups (`\s*(\d+)\s*,\s*...`) that backtrack **polynomially** on malformed input like `rgb(9,9,9` followed by many spaces. Both `colorToRgba()` and `parseColorString()` now strip whitespace once (linear `replace(/\s+/g,"")`) and match without `\s*`.

- **Verified:** the old pattern took **~1058ms** on a 50k-space attack string; the new approach **0ms**.
- Color/animation suite (191 tests) and full mock suite (1240) stay green; behavior preserved for valid `rgb()`/`rgba()`/hex/named inputs.

## Scorecard — Token-Permissions (high)
`ci.yml`, `native-rn-matrix.yml`, and `compat-check.yml` had no top-level `permissions:`. Added `permissions: contents: read`; `compat-check`'s job keeps `issues: write` (its `github-script` step opens a tracking issue when the RN edge build breaks). `release.yml`/`codeql.yml`/`scorecard.yml` already set `read-all`.

## Not addressed (out of scope / not code issues)
Remaining Scorecard alerts are repo-**posture**, not code bugs: Branch-Protection & Code-Review (need repo settings / >1 reviewer), Pinned-Dependencies on release.yml (already SHA-pinned in #19 — likely a stale alert), Fuzzing/SAST/CII-Best-Practices/CI-Tests (aspirational for a solo lib). Several should auto-close on the next Scorecard run.