### PR TITLE
fix(mock): Animated.* host name + Animated.Value style resolution

### DIFF
--- a/.changeset/animated-host-and-style-fidelity.md
+++ b/.changeset/animated-host-and-style-fidelity.md
@@ -1,0 +1,14 @@
+---
+"vitest-native": patch
+---
+
+Fix two `Animated` mock fidelity gaps surfaced by the mock-vs-real-RN cross-check:
+
+- `Animated.Text` (and the other `Animated.*` components) now render the base host
+  component (`Text`, `View`, …) instead of a host literally named `Animated.Text`,
+  so RNTL's `getByText`/`queryByText` can find their text children — matching real
+  React Native.
+- An `Animated.Value` (or interpolation/color node) used in a `style` prop now
+  resolves to its current value on the host's style, so assertions like
+  `toHaveStyle({ opacity: 0.3 })` against `new Animated.Value(0.3)` pass — matching
+  how real React Native writes the live value onto the host.

--- a/packages/vitest-native/crosscheck/crosscheck.test.tsx
+++ b/packages/vitest-native/crosscheck/crosscheck.test.tsx
@@ -18,10 +18,13 @@
 import { afterAll, afterEach, expect, test } from "vitest";
 import * as React from "react";
 import {
+  ActivityIndicator,
+  Animated,
   Button,
   Dimensions,
   FlatList,
   Image,
+  KeyboardAvoidingView,
   Modal,
   PixelRatio,
   Platform,
@@ -37,7 +40,7 @@ import {
   TouchableWithoutFeedback,
   View,
 } from "react-native";
-import { cleanup, fireEvent, render, screen, userEvent } from "@testing-library/react-native";
+import { cleanup, fireEvent, render, screen, userEvent, within } from "@testing-library/react-native";
 import fs from "node:fs";
 
 afterEach(cleanup);
@@ -243,10 +246,44 @@ probe("modal-visible-children", () => {
   return { whenVisible, whenHidden: !!screen.queryByTestId("mb") };
 });
 
-// (Animated value internals like __getValue() are exercised by the conformance
-// suite — tests/rn-conformance/rn-Animated.test.ts, ported from RN's own tests —
-// rather than the cross-check, which focuses on observable component/interaction
-// behavior. The mock intentionally doesn't expose every internal accessor.)
+// --- Animated (observable rendering/behavior only) ---
+// Animated value *internals* (__getValue(), interpolation math) are exercised by
+// the conformance suite — tests/rn-conformance/rn-Animated.test.ts. Here we gate
+// only what a real test observes: that Animated.* host components render and are
+// queryable, and that an Animated.Value drives a flattened style the same way under
+// both engines. Anything timer/RAF-driven (timing/spring over a duration) is left
+// out — it's nondeterministic across engines and belongs in the conformance suite.
+probe("animated-view-renders", () => {
+  render(<Animated.View testID="av" />);
+  return { found: !!screen.queryByTestId("av") };
+});
+
+probe("animated-text-renders", () => {
+  render(<Animated.Text>animated-copy</Animated.Text>);
+  return { found: !!screen.queryByText("animated-copy") };
+});
+
+probe("animated-image-renders", () => {
+  render(<Animated.Image testID="ai" source={{ uri: "https://example.com/a.png" }} />);
+  return { found: !!screen.queryByTestId("ai") };
+});
+
+probe("animated-scrollview-renders", () => {
+  render(
+    <Animated.ScrollView testID="asv">
+      <Text>scroll-body</Text>
+    </Animated.ScrollView>,
+  );
+  return { found: !!screen.queryByTestId("asv"), body: !!screen.queryByText("scroll-body") };
+});
+
+probe("animated-value-initial-style", () => {
+  // An Animated.Value at its initial value must resolve to that number in the
+  // flattened style a test would assert against (toHaveStyle relies on this).
+  const opacity = new Animated.Value(0.3);
+  render(<Animated.View testID="av" style={{ opacity }} />);
+  return { hit: passes(() => expect(screen.getByTestId("av")).toHaveStyle({ opacity: 0.3 })) };
+});
 
 // --- accessibility props (what RNTL byRole / toBeDisabled depend on) ---
 probe("a11y-role", () => {
@@ -472,6 +509,106 @@ probe("platform-os", () => ({ os: Platform.OS }));
 probe("stylesheet-create-identity", () => {
   const s = StyleSheet.create({ a: { flex: 1 } });
   return { a: s.a };
+});
+
+// --- more components ---
+probe("activityindicator-renders", () => {
+  render(<ActivityIndicator testID="spin" />);
+  return { found: !!screen.queryByTestId("spin") };
+});
+
+probe("keyboardavoidingview-children", () => {
+  render(
+    <KeyboardAvoidingView testID="kav">
+      <Text>kav-body</Text>
+    </KeyboardAvoidingView>,
+  );
+  return { found: !!screen.queryByTestId("kav"), body: !!screen.queryByText("kav-body") };
+});
+
+// --- composite / nested text matching (a core RNTL behavior tests rely on) ---
+probe("composite-text-match", () => {
+  // getByText must match across nested <Text> as one string ("Hello World").
+  render(
+    <Text testID="t">
+      Hello <Text>World</Text>
+    </Text>,
+  );
+  return {
+    composite: !!screen.queryByText("Hello World"),
+    substring: !!screen.queryByText("Hello", { exact: false }),
+    exactMiss: !!screen.queryByText("Hello"),
+  };
+});
+
+probe("query-by-text-regex", () => {
+  render(<Text>Order #4815162342</Text>);
+  return { found: !!screen.queryByText(/Order #\d+/) };
+});
+
+// --- within() scoping (scoped queries inside a subtree) ---
+probe("within-scoping", () => {
+  render(
+    <View>
+      <View testID="header">
+        <Text>Title</Text>
+      </View>
+      <View testID="footer">
+        <Text>Title</Text>
+      </View>
+    </View>,
+  );
+  const header = within(screen.getByTestId("header"));
+  return {
+    scopedHit: !!header.queryByText("Title"),
+    globalCount: screen.queryAllByText("Title").length,
+  };
+});
+
+probe("get-all-by-role-count", () => {
+  render(
+    <View>
+      <Pressable accessibilityRole="button">
+        <Text>One</Text>
+      </Pressable>
+      <Pressable accessibilityRole="button">
+        <Text>Two</Text>
+      </Pressable>
+    </View>,
+  );
+  return { count: screen.queryAllByRole("button").length };
+});
+
+// --- accessibility value (sliders / progress — toHaveAccessibilityValue) ---
+probe("accessibility-value", () => {
+  render(
+    <View
+      testID="slider"
+      accessibilityRole="adjustable"
+      accessibilityValue={{ min: 0, max: 100, now: 40 }}
+    />,
+  );
+  const el = screen.getByTestId("slider");
+  // Read fields individually — comparing the whole object is key-order-sensitive
+  // under JSON.stringify (an authoring artifact, not a behavior difference).
+  const v = el.props.accessibilityValue ?? {};
+  return {
+    min: v.min,
+    max: v.max,
+    now: v.now,
+    matcher: passes(() => expect(el).toHaveAccessibilityValue({ now: 40 })),
+  };
+});
+
+// --- toHaveProp (a generic matcher many suites use) ---
+probe("matcher-have-prop", () => {
+  render(<View testID="v" accessibilityLabel="hi" pointerEvents="none" />);
+  const el = screen.getByTestId("v");
+  return {
+    label: passes(() => expect(el).toHaveProp("accessibilityLabel", "hi")),
+    pointer: passes(() => expect(el).toHaveProp("pointerEvents", "none")),
+    miss: passes(() => expect(el).toHaveProp("accessibilityLabel", "bye")),
+  };
 });
 
 afterAll(() => {

--- a/packages/vitest-native/src/mocks/apis/Animated.ts
+++ b/packages/vitest-native/src/mocks/apis/Animated.ts
@@ -552,9 +552,52 @@ function createAnimation(onStart?: () => void) {
   };
 }
 
+// Resolve an animated leaf (Value / Interpolation / Color) to its current plain
+// value. Real RN writes the *current* numeric/string value onto the host's style,
+// so a test asserting `toHaveStyle({ opacity: 0.3 })` against an Animated.Value(0.3)
+// must see the number, not the node.
+function resolveAnimatedLeaf(v: any): any {
+  if (v instanceof AnimatedValue) return v.getValue();
+  if (v && typeof v === "object" && typeof v.__getValue === "function") return v.__getValue();
+  if (v && typeof v === "object" && typeof v.getValue === "function") return v.getValue();
+  return v;
+}
+
+function resolveAnimatedStyle(style: any): any {
+  if (Array.isArray(style)) return style.map(resolveAnimatedStyle);
+  // The style itself might be an animated node (e.g. style={anim}).
+  const asLeaf = resolveAnimatedLeaf(style);
+  if (asLeaf !== style) return asLeaf;
+  if (style && typeof style === "object") {
+    const out: Record<string, any> = {};
+    for (const key of Object.keys(style)) {
+      const val = style[key];
+      if (key === "transform" && Array.isArray(val)) {
+        out[key] = val.map((t: any) =>
+          t && typeof t === "object" && !(t instanceof AnimatedValue)
+            ? Object.fromEntries(Object.keys(t).map((tk) => [tk, resolveAnimatedLeaf(t[tk])]))
+            : resolveAnimatedLeaf(t),
+        );
+      } else {
+        out[key] = resolveAnimatedLeaf(val);
+      }
+    }
+    return out;
+  }
+  return style;
+}
+
 function createAnimatedWrapper(displayName: string) {
+  // Render the *base* host (e.g. "Text", "View") — not "Animated.Text" — so RNTL's
+  // host-component detection (queryByText only descends into Text hosts) and real RN
+  // agree. The Animated.* component still carries its own displayName for identity.
+  const hostName = displayName.replace(/^Animated\./, "");
   const Component = React.forwardRef((props: any, ref: any) => {
-    return React.createElement(displayName, { ...props, ref });
+    if (props && props.style !== undefined) {
+      const { style, ...rest } = props;
+      return React.createElement(hostName, { ...rest, style: resolveAnimatedStyle(style), ref });
+    }
+    return React.createElement(hostName, { ...props, ref });
   });
   Component.displayName = displayName;
   return Component;


### PR DESCRIPTION
## What

Fixes two `Animated` mock fidelity gaps that were surfaced by the mock-vs-real-RN cross-check, and expands the cross-check corpus that caught them.

### Bugs fixed (`src/mocks/apis/Animated.ts`)

1. **`Animated.Text` was invisible to `queryByText`.** `createAnimatedWrapper` rendered a host element literally named `"Animated.Text"`. RNTL's text queries only descend into `Text` hosts, so text children of `Animated.Text` couldn't be found — whereas real React Native renders a real `Text` host. The wrapper now strips the `Animated.` prefix and renders the base host (`Text`/`View`/…), while keeping the component's own `displayName` (so `Animated.View.displayName === "Animated.View"` still holds).

2. **`Animated.Value` in `style` didn't resolve.** A `new Animated.Value(0.3)` passed through as a `style` value stayed an object, so `toHaveStyle({ opacity: 0.3 })` failed. The wrapper now resolves Animated `Value`/`Interpolation`/`Color` leaves (including inside `transform`) to their current values, matching how real RN writes the live value onto the host style.

### Cross-check expansion (`crosscheck/crosscheck.test.tsx`)

Grew the differential corpus **42 → 56 probes**: Animated observable rendering (View/Text/Image/ScrollView + Value-in-style), composite/nested `getByText`, `within()` scoping, `getAllByRole`, `toHaveProp`, accessibility-value, `ActivityIndicator`/`KeyboardAvoidingView`. This expansion is what surfaced both bugs above.

## Verification

- cross-check **56/56** (mock matches real RN)
- mock suite **1240 passed**
- native suite **93 passed**
- typecheck clean, lint 0 warnings