### PR TITLE
feat(native): asset require() stubbing + vectorIcons preset

### DIFF
--- a/.changeset/native-asset-require-stub.md
+++ b/.changeset/native-asset-require-stub.md
@@ -1,0 +1,20 @@
+---
+"vitest-native": patch
+---
+
+Native engine: stub asset `require()`s reaching Node's CJS loader. A literal
+`const img = require('./logo.png')` (common in real RN components) escapes Vite's
+asset handling and hits Node's loader, where the binary was compiled as JS and
+threw `SyntaxError: Invalid or unexpected token`, taking down the whole test file.
+The Node require-hook now stubs image/media asset extensions to their basename
+string, matching the Vite graph and Metro/Jest behaviour.
+
+Font extensions (`.ttf`/`.otf`/`.woff`/`.woff2`) are intentionally left
+unstubbed on this path: font loaders such as `@react-native-vector-icons`
+inspect the `require()` result, and a basename-string stub makes them proceed
+past their availability guard and crash on the boundary-mocked native font
+module. Leaving the font require to normal resolution preserves their graceful
+degradation.
+
+Surfaced by a real bake-off of the `@rneui/base` (react-native-elements) Jest +
+RNTL suite under the native engine.

--- a/.changeset/native-asset-require-stub.md
+++ b/.changeset/native-asset-require-stub.md
@@ -3,18 +3,12 @@
 ---
 
 Native engine: stub asset `require()`s reaching Node's CJS loader. A literal
-`const img = require('./logo.png')` (common in real RN components) escapes Vite's
-asset handling and hits Node's loader, where the binary was compiled as JS and
-threw `SyntaxError: Invalid or unexpected token`, taking down the whole test file.
-The Node require-hook now stubs image/media asset extensions to their basename
-string, matching the Vite graph and Metro/Jest behaviour.
-
-Font extensions (`.ttf`/`.otf`/`.woff`/`.woff2`) are intentionally left
-unstubbed on this path: font loaders such as `@react-native-vector-icons`
-inspect the `require()` result, and a basename-string stub makes them proceed
-past their availability guard and crash on the boundary-mocked native font
-module. Leaving the font require to normal resolution preserves their graceful
-degradation.
+`const img = require('./logo.png')` or `require('./Icon.ttf')` (common in real RN
+components) escapes Vite's asset handling and hits Node's loader, where the binary
+was compiled as JS and threw `SyntaxError: Invalid or unexpected token`, taking
+down the whole test file. The Node require-hook now stubs asset extensions
+(images, media, and fonts) to their basename string, matching the Vite graph and
+Metro/Jest behaviour.
 
 Surfaced by a real bake-off of the `@rneui/base` (react-native-elements) Jest +
 RNTL suite under the native engine.

--- a/.changeset/vector-icons-preset.md
+++ b/.changeset/vector-icons-preset.md
@@ -1,0 +1,19 @@
+---
+"vitest-native": minor
+---
+
+Add a built-in `vectorIcons` preset for `@react-native-vector-icons` (v10+),
+auto-detected like the other third-party presets.
+
+The library's v10 icon sets (`@react-native-vector-icons/material-icons`, …) are
+all built on the shared `@react-native-vector-icons/common` module, whose dynamic
+font loader runs at import time and queries the native `ExpoFontLoader` — which
+cannot exist in Node. Without shadowing, importing any icon set throws and the set
+is wrongly reported "not available", so icons render nothing. The preset shadows
+the single `common` module (the way jest mocks vector-icons) so `createIconSet(...)`
+returns a lightweight Text-based stub that forwards `name`/`size`/`color`/`style`/
+`testID` — fixing every icon set at once. The legacy `react-native-vector-icons`
+package is mapped to the same preset.
+
+Surfaced by the `@rneui/base` bake-off, where every `Icon` test failure traced to
+this import-time crash.

--- a/bun.lock
+++ b/bun.lock
@@ -43,6 +43,8 @@
       },
       "devDependencies": {
         "@babel/core": "^7.29.7",
+        "@react-native-vector-icons/common": "^13.0.1",
+        "@react-native-vector-icons/material-icons": "^13.1.2",
         "@react-native/babel-preset": "^0.85.3",
         "@react-navigation/native": "7.2.5",
         "@react-navigation/native-stack": "7.16.0",
@@ -457,6 +459,10 @@
 
     "@quansync/fs": ["@quansync/fs@1.0.0", "", { "dependencies": { "quansync": "^1.0.0" } }, "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ=="],
 
+    "@react-native-vector-icons/common": ["@react-native-vector-icons/common@13.0.1", "", { "dependencies": { "find-up": "^8.0.0", "picocolors": "^1.1.1", "plist": "^3.1.0" }, "peerDependencies": { "@react-native-vector-icons/get-image": "^13.0.0", "@react-native/assets-registry": "*", "expo-font": "*", "react": "*", "react-native": "*" }, "optionalPeers": ["@react-native-vector-icons/get-image", "@react-native/assets-registry", "expo-font"], "bin": { "rnvi-update-plist": "lib/commonjs/scripts/updatePlist.js" } }, "sha512-UPC6L3tW5rXCjBn4kgw9RPURUILIg8tFpEY2uaYwU8aCjEHkywNCMcAO8+PvMCDkR6aICPeHYA0OXvMgrjsF4g=="],
+
+    "@react-native-vector-icons/material-icons": ["@react-native-vector-icons/material-icons@13.1.2", "", { "dependencies": { "@react-native-vector-icons/common": "^13.0.1" }, "peerDependencies": { "@expo/config-plugins": ">=10.0.0", "react": "*", "react-native": "*" }, "optionalPeers": ["@expo/config-plugins"] }, "sha512-z8fckMFeYvvVzqfWpsM8AkSFf0pFwlwueKq8/HAKetrZEl3GsK29Mr+sv7me0N6kAl9Z+AaNXqD7gNQpCjkZgg=="],
+
     "@react-native/assets-registry": ["@react-native/assets-registry@0.85.3", "", {}, "sha512-u9ZiYP23vA2IFtdFQFmetzSmk6SM0xgKIoiOsr1hXNHjHaLhOm+/Ph1ud57wX6+Dbwdzx8coJgnzSKL3W21PCg=="],
 
     "@react-native/babel-plugin-codegen": ["@react-native/babel-plugin-codegen@0.85.3", "", { "dependencies": { "@babel/traverse": "^7.29.0", "@react-native/codegen": "0.85.3" } }, "sha512-Wc94zGfeFG8Njf9SHMPfYZP04kjigkOps6F1TYTvd7ZVXuGxqseCDgxc50LWcOhOCLypI9n3oVVqz81C3p44ZA=="],
@@ -579,7 +585,7 @@
 
     "@vitest/utils": ["@vitest/utils@4.1.8", "", { "dependencies": { "@vitest/pretty-format": "4.1.8", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg=="],
 
-    "@xmldom/xmldom": ["@xmldom/xmldom@0.8.13", "", {}, "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw=="],
+    "@xmldom/xmldom": ["@xmldom/xmldom@0.9.10", "", {}, "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw=="],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
@@ -815,7 +821,7 @@
 
     "finalhandler": ["finalhandler@1.1.2", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~1.0.2", "escape-html": "~1.0.3", "on-finished": "~2.3.0", "parseurl": "~1.3.3", "statuses": "~1.5.0", "unpipe": "~1.0.0" } }, "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA=="],
 
-    "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
+    "find-up": ["find-up@8.0.0", "", { "dependencies": { "locate-path": "^8.0.0", "unicorn-magic": "^0.3.0" } }, "sha512-JGG8pvDi2C+JxidYdIwQDyS/CgcrIdh18cvgxcBge3wSHRQOrooMD3GlFBcmMJAN9M42SAZjDp5zv1dglJjwww=="],
 
     "flow-enums-runtime": ["flow-enums-runtime@0.0.6", "", {}, "sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw=="],
 
@@ -969,7 +975,7 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
-    "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
+    "locate-path": ["locate-path@8.0.0", "", { "dependencies": { "p-locate": "^6.0.0" } }, "sha512-XT9ewWAC43tiAV7xDAPflMkG0qOPn2QjHqlgX8FOqmWa/rxnyYDulF9T0F7tRy1u+TVTmK/M//6VIOye+2zDXg=="],
 
     "lodash.debounce": ["lodash.debounce@4.0.8", "", {}, "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="],
 
@@ -1095,9 +1101,9 @@
 
     "p-filter": ["p-filter@2.1.0", "", { "dependencies": { "p-map": "^2.0.0" } }, "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw=="],
 
-    "p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
+    "p-limit": ["p-limit@4.0.0", "", { "dependencies": { "yocto-queue": "^1.0.0" } }, "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ=="],
 
-    "p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+    "p-locate": ["p-locate@6.0.0", "", { "dependencies": { "p-limit": "^4.0.0" } }, "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw=="],
 
     "p-map": ["p-map@2.1.0", "", {}, "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="],
 
@@ -1367,6 +1373,8 @@
 
     "unicode-property-aliases-ecmascript": ["unicode-property-aliases-ecmascript@2.2.0", "", {}, "sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ=="],
 
+    "unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
+
     "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
@@ -1429,6 +1437,8 @@
 
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
+    "yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
+
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
@@ -1457,9 +1467,13 @@
 
     "@expo/metro-config/hermes-parser": ["hermes-parser@0.33.3", "", { "dependencies": { "hermes-estree": "0.33.3" } }, "sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA=="],
 
+    "@expo/plist/@xmldom/xmldom": ["@xmldom/xmldom@0.8.13", "", {}, "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw=="],
+
     "@expo/router-server/expo-constants": ["expo-constants@56.0.17", "", { "dependencies": { "@expo/env": "~2.3.0" }, "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-bU8iU1+7cI7QzfGQVnz2C1nlbXD08YPwD6h8ZEuNspgUuD2prXfmrhrdLe1GjCPYGw4hB3BNjWPjpenNyyymfQ=="],
 
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
+
+    "@manypkg/find-root/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
     "@manypkg/find-root/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
@@ -1533,8 +1547,6 @@
 
     "path-scurry/lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
 
-    "plist/@xmldom/xmldom": ["@xmldom/xmldom@0.9.10", "", {}, "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw=="],
-
     "pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
     "read-yaml-file/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
@@ -1568,6 +1580,8 @@
     "@expo/cli/accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
     "@expo/metro-config/hermes-parser/hermes-estree": ["hermes-estree@0.33.3", "", {}, "sha512-6kzYZHCk8Fy1Uc+t3HGYyJn3OL4aeqKLTyina4UFtWl8I0kSL7OmKThaiX+Uh2f8nGw3mo4Ifxg0M5Zk3/Oeqg=="],
+
+    "@manypkg/find-root/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "@react-native/codegen/hermes-parser/hermes-estree": ["hermes-estree@0.33.3", "", {}, "sha512-6kzYZHCk8Fy1Uc+t3HGYyJn3OL4aeqKLTyina4UFtWl8I0kSL7OmKThaiX+Uh2f8nGw3mo4Ifxg0M5Zk3/Oeqg=="],
 
@@ -1645,6 +1659,8 @@
 
     "@expo/cli/accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
+    "@manypkg/find-root/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+
     "ast-kit/@babel/parser/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0-rc.6", "", {}, "sha512-BCkFy+zN6kXQed3YOT7aJl93NfDSzQc3pBfsvTVPs9gU9X3V0aefEF5kwBT0E+mDWH9QgKaZstYUQN9VdQZT4g=="],
 
     "log-symbols/chalk/ansi-styles/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
@@ -1654,6 +1670,8 @@
     "ora/chalk/ansi-styles/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
 
     "ora/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
+
+    "@manypkg/find-root/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
     "log-symbols/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -43,8 +43,8 @@
       },
       "devDependencies": {
         "@babel/core": "^7.29.7",
-        "@react-native-vector-icons/common": "^13.0.1",
-        "@react-native-vector-icons/material-icons": "^13.1.2",
+        "@react-native-vector-icons/common": "13.0.1",
+        "@react-native-vector-icons/material-icons": "13.1.2",
         "@react-native/babel-preset": "^0.85.3",
         "@react-navigation/native": "7.2.5",
         "@react-navigation/native-stack": "7.16.0",

--- a/packages/vitest-native/package.json
+++ b/packages/vitest-native/package.json
@@ -150,8 +150,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",
-    "@react-native-vector-icons/common": "^13.0.1",
-    "@react-native-vector-icons/material-icons": "^13.1.2",
+    "@react-native-vector-icons/common": "13.0.1",
+    "@react-native-vector-icons/material-icons": "13.1.2",
     "@react-native/babel-preset": "^0.85.3",
     "@react-navigation/native": "7.2.5",
     "@react-navigation/native-stack": "7.16.0",

--- a/packages/vitest-native/package.json
+++ b/packages/vitest-native/package.json
@@ -150,6 +150,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",
+    "@react-native-vector-icons/common": "^13.0.1",
+    "@react-native-vector-icons/material-icons": "^13.1.2",
     "@react-native/babel-preset": "^0.85.3",
     "@react-navigation/native": "7.2.5",
     "@react-navigation/native-stack": "7.16.0",

--- a/packages/vitest-native/src/native/hooks.mjs
+++ b/packages/vitest-native/src/native/hooks.mjs
@@ -24,30 +24,15 @@ export function installRequireHooks(
   if (globalThis.__vitest_native_require_hooks_installed) return;
   globalThis.__vitest_native_require_hooks_installed = true;
 
-  // Asset requires (`require('./logo.png')`) reaching Node's CJS loader must be
-  // stubbed, not compiled — otherwise the binary falls through to the `.js`
-  // handler and throws "SyntaxError: Invalid or unexpected token". RN's packager
-  // and Jest's asset transform both stub these; the Vite graph already does too,
-  // so we match it here (module.exports = basename string) for the Node path.
-  //
-  // Fonts (.ttf/.otf/.woff*) are deliberately NOT stubbed on the Node path: font
-  // loaders like @react-native-vector-icons inspect the require() result, so a
-  // basename-string stub makes them proceed past their "is this font available?"
-  // guard and then crash on the (boundary-mocked) native font module. Leaving the
-  // font require to its normal resolution preserves their graceful degradation.
-  const NON_ASSET = new Set([
-    ".js",
-    ".cjs",
-    ".mjs",
-    ".ts",
-    ".tsx",
-    ".json",
-    ".node",
-    ".ttf",
-    ".otf",
-    ".woff",
-    ".woff2",
-  ]);
+  // Asset requires (`require('./logo.png')`, `require('./Icon.ttf')`) reaching
+  // Node's CJS loader must be stubbed, not compiled — otherwise the binary falls
+  // through to the `.js` handler and throws "SyntaxError: Invalid or unexpected
+  // token". RN's packager and Jest's asset transform both stub these (incl.
+  // fonts); the Vite graph already does too, so we match it here (module.exports =
+  // basename string) for the Node path. (Font-loading libraries like
+  // @react-native-vector-icons are shadowed by their preset, so they never inspect
+  // the stubbed font require.)
+  const NON_ASSET = new Set([".js", ".cjs", ".mjs", ".ts", ".tsx", ".json", ".node"]);
   for (const raw of assetExts) {
     const ext = "." + String(raw).replace(/^\./, "");
     if (NON_ASSET.has(ext) || Module._extensions[ext]) continue;

--- a/packages/vitest-native/src/native/hooks.mjs
+++ b/packages/vitest-native/src/native/hooks.mjs
@@ -19,9 +19,43 @@ export function installRequireHooks(
   transformPkgs = [],
   platform = "ios",
   reactNativeVersion = "0.0.0",
+  assetExts = [],
 ) {
   if (globalThis.__vitest_native_require_hooks_installed) return;
   globalThis.__vitest_native_require_hooks_installed = true;
+
+  // Asset requires (`require('./logo.png')`) reaching Node's CJS loader must be
+  // stubbed, not compiled — otherwise the binary falls through to the `.js`
+  // handler and throws "SyntaxError: Invalid or unexpected token". RN's packager
+  // and Jest's asset transform both stub these; the Vite graph already does too,
+  // so we match it here (module.exports = basename string) for the Node path.
+  //
+  // Fonts (.ttf/.otf/.woff*) are deliberately NOT stubbed on the Node path: font
+  // loaders like @react-native-vector-icons inspect the require() result, so a
+  // basename-string stub makes them proceed past their "is this font available?"
+  // guard and then crash on the (boundary-mocked) native font module. Leaving the
+  // font require to its normal resolution preserves their graceful degradation.
+  const NON_ASSET = new Set([
+    ".js",
+    ".cjs",
+    ".mjs",
+    ".ts",
+    ".tsx",
+    ".json",
+    ".node",
+    ".ttf",
+    ".otf",
+    ".woff",
+    ".woff2",
+  ]);
+  for (const raw of assetExts) {
+    const ext = "." + String(raw).replace(/^\./, "");
+    if (NON_ASSET.has(ext) || Module._extensions[ext]) continue;
+    Module._extensions[ext] = function (mod, filename) {
+      const basename = filename.replace(/\\/g, "/").split("/").pop() || filename;
+      mod.exports = basename;
+    };
+  }
 
   // Configured third-party packages to also transform (Flow/TS/JSX stripped).
   const isExtra = buildPkgMatcher(transformPkgs);

--- a/packages/vitest-native/src/native/setup.mjs
+++ b/packages/vitest-native/src/native/setup.mjs
@@ -45,6 +45,12 @@ try {
   if (process.env.VITEST_NATIVE_TRANSFORM)
     transformPkgs = JSON.parse(process.env.VITEST_NATIVE_TRANSFORM);
 } catch {}
+// Asset extensions the Node require-hook should stub (matches the Vite graph).
+let assetExts = [];
+try {
+  if (process.env.VITEST_NATIVE_ASSET_EXTS)
+    assetExts = JSON.parse(process.env.VITEST_NATIVE_ASSET_EXTS);
+} catch {}
 
 // --- Third-party preset mocks ---
 //
@@ -103,7 +109,7 @@ if (!globalThis.__vitest_native_loader_registered) {
     data: { projectRoot, platform, reactNativeVersion, transformPkgs, presetExports },
   });
 }
-installRequireHooks(projectRoot, transformPkgs, platform, reactNativeVersion);
+installRequireHooks(projectRoot, transformPkgs, platform, reactNativeVersion, assetExts);
 
 // Build the mock objects now that the require hooks are installed (preset
 // factories may lazily resolve react-native at render time).

--- a/packages/vitest-native/src/native/worker.mjs
+++ b/packages/vitest-native/src/native/worker.mjs
@@ -27,9 +27,14 @@ const platform = process.env.VITEST_NATIVE_PLATFORM === "android" ? "android" : 
 const reactNativeVersion = process.env.VITEST_NATIVE_RN_VERSION || "0.0.0";
 let transformPkgs = [];
 let preserveGlobals = [];
+let assetExts = [];
 try {
   if (process.env.VITEST_NATIVE_TRANSFORM)
     transformPkgs = JSON.parse(process.env.VITEST_NATIVE_TRANSFORM);
+} catch {}
+try {
+  if (process.env.VITEST_NATIVE_ASSET_EXTS)
+    assetExts = JSON.parse(process.env.VITEST_NATIVE_ASSET_EXTS);
 } catch {}
 try {
   if (process.env.VITEST_NATIVE_HOT_PRESERVE_GLOBALS)
@@ -48,7 +53,7 @@ if (diagnostics) {
 // listener tracking in reset.mjs, so RN's own boot state is preserved across
 // per-file resets rather than wrongly torn down with test pollution.
 installGlobals();
-installRequireHooks(projectRoot, transformPkgs, platform, reactNativeVersion);
+installRequireHooks(projectRoot, transformPkgs, platform, reactNativeVersion, assetExts);
 try {
   const req = createRequire(path.join(projectRoot, "package.json"));
   const RN = req("react-native");

--- a/packages/vitest-native/src/plugin.ts
+++ b/packages/vitest-native/src/plugin.ts
@@ -368,6 +368,13 @@ export function reactNative(options?: VitestNativeOptions): Plugin {
       };
       const reactNativeVersion = resolvePackageVersion("react-native", resolvedRoot);
       if (reactNativeVersion) env.VITEST_NATIVE_RN_VERSION = reactNativeVersion;
+      // Asset extensions for the Node require-hook to stub (matches the Vite-graph
+      // asset stubbing): a CJS `require('./logo.png')` reaching Node's loader must
+      // resolve to the basename string, not be compiled as JS.
+      env.VITEST_NATIVE_ASSET_EXTS = JSON.stringify([
+        ...DEFAULT_ASSET_EXTS,
+        ...(options?.assetExts ?? []).map((e) => e.replace(/^\./, "")),
+      ]);
       if (hotRuntime && hotRecycle.preserveGlobals?.length) {
         env.VITEST_NATIVE_HOT_PRESERVE_GLOBALS = JSON.stringify(hotRecycle.preserveGlobals);
       }

--- a/packages/vitest-native/src/preset-map.ts
+++ b/packages/vitest-native/src/preset-map.ts
@@ -23,4 +23,6 @@ export const AUTO_DETECT_PRESETS = {
   "react-native-mmkv": "mmkv",
   "react-native-svg": "svg",
   "react-native-webview": "webview",
+  "@react-native-vector-icons/common": "vectorIcons",
+  "react-native-vector-icons": "vectorIcons",
 } as const satisfies Record<string, PresetName>;

--- a/packages/vitest-native/src/presets/index.ts
+++ b/packages/vitest-native/src/presets/index.ts
@@ -9,3 +9,4 @@ export { deviceInfo } from "./device-info.js";
 export { mmkv } from "./mmkv.js";
 export { svg } from "./svg.js";
 export { webview } from "./webview.js";
+export { vectorIcons } from "./vector-icons.js";

--- a/packages/vitest-native/src/presets/vector-icons.ts
+++ b/packages/vitest-native/src/presets/vector-icons.ts
@@ -1,0 +1,71 @@
+import type { Preset } from "../types.js";
+import React from "react";
+
+// @react-native-vector-icons v10+ split each icon set into its own package
+// (`@react-native-vector-icons/material-icons`, …), all built on a single shared
+// factory in `@react-native-vector-icons/common`. That common module's dynamic
+// font loader runs at import time and queries the native ExpoFontLoader, which
+// can't exist in Node — so importing any icon set throws and the set is wrongly
+// reported "not available". Shadowing the ONE common module (the way jest mocks
+// vector-icons) fixes every set at once: `createIconSet(...)` returns a simple
+// Text-based stub that forwards name/size/color/style/testID, so icons render and
+// are queryable without running the native font machinery.
+const DEFAULT_ICON_SIZE = 12;
+const DEFAULT_ICON_COLOR = "black";
+
+export function vectorIcons(): Preset {
+  return {
+    name: "vectorIcons",
+    modules: {
+      "@react-native-vector-icons/common": {
+        exports: [
+          "createIconSet",
+          "DEFAULT_ICON_COLOR",
+          "DEFAULT_ICON_SIZE",
+          "isDynamicLoadingEnabled",
+          "isDynamicLoadingSupported",
+          "setDynamicLoadingEnabled",
+          "setDynamicLoadingErrorCallback",
+        ],
+        factory: () => {
+          const createIconSet = (_glyphMap?: any, _options?: any) => {
+            const Icon = React.forwardRef((props: any, ref: any) => {
+              const {
+                size = DEFAULT_ICON_SIZE,
+                color = DEFAULT_ICON_COLOR,
+                style,
+                children,
+                ...rest
+              } = props;
+              return React.createElement(
+                "Text",
+                { ref, selectable: false, ...rest, style: [{ fontSize: size, color }, style] },
+                children,
+              );
+            });
+            Icon.displayName = "Icon";
+            // Static helpers some consumers reach for; safe no-ops here.
+            (Icon as any).getImageSource = async () => null;
+            (Icon as any).getImageSourceSync = () => null;
+            (Icon as any).getFontFamily = () => "";
+            (Icon as any).hasIcon = () => false;
+            (Icon as any).getRawGlyphMap = () => ({});
+            (Icon as any).loadFont = async () => {};
+            return Icon;
+          };
+          const noop = () => {};
+          return {
+            createIconSet,
+            DEFAULT_ICON_COLOR,
+            DEFAULT_ICON_SIZE,
+            isDynamicLoadingEnabled: () => false,
+            isDynamicLoadingSupported: () => false,
+            setDynamicLoadingEnabled: noop,
+            setDynamicLoadingErrorCallback: noop,
+            default: { createIconSet, DEFAULT_ICON_COLOR, DEFAULT_ICON_SIZE },
+          };
+        },
+      },
+    },
+  };
+}

--- a/packages/vitest-native/tests-native/contract.test.ts
+++ b/packages/vitest-native/tests-native/contract.test.ts
@@ -19,6 +19,15 @@ describe("native engine: shared package contract", () => {
     expect(asset).toBe("test-asset.png");
   });
 
+  it("stubs assets required through Node's CJS loader (not just Vite imports)", () => {
+    // RN components commonly do `const img = require('./logo.png')`. A literal
+    // require escapes Vite's asset handling and hits Node's loader; without an
+    // asset handler there it would compile the binary as JS and throw
+    // "SyntaxError: Invalid or unexpected token". Must match the import path.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    expect(require("./fixtures/test-asset.png")).toBe("test-asset.png");
+  });
+
   it("drives real Dimensions state through setDimensions", () => {
     setDimensions({ width: 768, height: 1024, scale: 2, fontScale: 1 });
     expect(Dimensions.get("window")).toMatchObject({

--- a/packages/vitest-native/tests-native/vector-icons.test.tsx
+++ b/packages/vitest-native/tests-native/vector-icons.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * Proof: @react-native-vector-icons renders under the native engine via the
+ * `vectorIcons` preset. The library's v10 icon sets (here material-icons) are all
+ * built on `@react-native-vector-icons/common`, whose dynamic font loader queries
+ * the native ExpoFontLoader at import time — which can't exist in Node, so without
+ * the preset, importing any icon set throws and the set is wrongly "not available".
+ *
+ * The preset shadows the single `common` module so `createIconSet(...)` returns a
+ * Text-based stub that forwards name/size/color/style/testID. material-icons is a
+ * devDependency so this proves auto-detection (via common) + correct shadowing.
+ *
+ * Surfaced by the @rneui/base bake-off, where every Icon failure traced to this
+ * import-time crash.
+ */
+import { describe, it, expect } from "vitest";
+import React from "react";
+import { render, screen } from "@testing-library/react-native";
+import { MaterialIcons } from "@react-native-vector-icons/material-icons";
+
+describe("@react-native-vector-icons under native engine", () => {
+  it("renders an icon set without crashing on the native font loader", () => {
+    render(<MaterialIcons name="home" size={24} color="red" testID="home-icon" />);
+    expect(screen.getByTestId("home-icon")).toBeTruthy();
+  });
+
+  it("forwards size/color/style to the rendered host (queryable like real tests)", () => {
+    render(<MaterialIcons name="star" size={32} color="gold" testID="star-icon" />);
+    const icon = screen.getByTestId("star-icon");
+    // Flattened style carries the size/color the consumer passed.
+    expect(icon).toHaveStyle({ fontSize: 32, color: "gold" });
+  });
+
+  it("forwards onPress-related props (icon stays a usable element)", () => {
+    render(
+      <MaterialIcons name="settings" testID="settings-icon" accessibilityLabel="settings" />,
+    );
+    expect(screen.getByLabelText("settings")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## What

Two coupled native-engine fixes, both surfaced by a real bake-off of the **`@rneui/base` (react-native-elements)** Jest + RNTL suite (RN 0.81.4, React 19, RNTL 13). Bake-off result: **338 jest baseline → 317/344 under the native engine** (remaining failures are jest-mock-coupling — Image `source` shape, PixelRatio/fontScale device-default differences — not vitest-native bugs).

### 1. Stub asset `require()`s on Node's CJS loader path

A literal `const img = require('./logo.png')` / `require('./Icon.ttf')` in an RN component escapes Vite's asset handling and reaches **Node's CJS loader**, where the native engine's require-hook had no asset handler — so the binary fell through to the `.js` compiler and threw `SyntaxError: Invalid or unexpected token`, failing the entire test file at collection. The require-hook now registers `Module._extensions` handlers for the configured asset extensions (threaded via `VITEST_NATIVE_ASSET_EXTS`) that resolve to the basename string — matching the Vite graph and Metro/Jest. Regression test in `tests-native/contract.test.ts` (the `require()` path alongside the existing `import` path).

### 2. `vectorIcons` preset for `@react-native-vector-icons` (v10+)

`@react-native-vector-icons` v10 splits each icon set into its own package, all built on the shared `@react-native-vector-icons/common`, whose dynamic font loader queries the native `ExpoFontLoader` **at import time** — impossible in Node, so importing any icon set throws and the set is wrongly reported "not available" (icons render nothing). The new preset shadows the **single `common` module** (the way jest mocks vector-icons) so `createIconSet(...)` returns a lightweight `Text`-based stub forwarding `name`/`size`/`color`/`style`/`testID` — fixing every set at once via the existing preset-redirect. Auto-detected via `common` (and legacy `react-native-vector-icons`).

With vector-icons shadowed, the require-hook can now safely stub **font** extensions too — removing an earlier font exclusion that only existed to avoid the vector-icons font-loader crash. Stubbing fonts matches Metro/Jest and lets icon-set packages' `require('./X.ttf')` resolve.

## Verification

- New `tests-native/vector-icons.test.tsx` renders real `MaterialIcons` under the native engine (material-icons added as devDep)
- `@rneui/base` bake-off: **311 → 317** (entire vector-icons failure category resolved)
- vitest-native gates: native **97**, mock **1240**, cross-check **43/43**, typecheck + lint clean