### PR TITLE
fix(native): silence vitest/runners deprecation warning in hot runner

### DIFF
--- a/packages/vitest-native/src/native/runner.mjs
+++ b/packages/vitest-native/src/native/runner.mjs
@@ -8,9 +8,9 @@
 // (resident-library lazy init — must be preserved across files, it never
 // re-runs) and test-phase state (pollution the next file's reset removes).
 // See reset.mjs for the full attribution model.
-import { VitestTestRunner } from "vitest/runners";
+import { TestRunner } from "vitest";
 
-export default class NativeHotRunner extends VitestTestRunner {
+export default class NativeHotRunner extends TestRunner {
   async onBeforeRunFiles(files) {
     globalThis.__vitest_native_hot_bless?.();
     return super.onBeforeRunFiles?.(files);


### PR DESCRIPTION
## What

The hot-runtime test runner imported `VitestTestRunner` from `vitest/runners`, a path Vitest deprecated in 4.1. The warning fired **once per worker spawn**, so `test:native:hot` printed it ~9 times:

```
Importing from "vitest/runners" is deprecated since Vitest 4.1. Please use "vitest" instead.
```

## Fix

Vitest 4.1 re-exports the identical class as `TestRunner` from the main `vitest` entry (both resolve to the same internal symbol `T`), so the hot runner now imports that instead:

```diff
-import { VitestTestRunner } from "vitest/runners";
-export default class NativeHotRunner extends VitestTestRunner {
+import { TestRunner } from "vitest";
+export default class NativeHotRunner extends TestRunner {
```

One-line change in `src/native/runner.mjs` (shipped verbatim to `dist/native/runner.mjs` via the build's `build:done` copy hook).

## Verification

- Hot suite: 17 files / 97 tests pass, **deprecation warning gone**
- Native suite: 17 / 97 pass
- `tsc --noEmit`: clean
- `oxlint`: 0 warnings / 0 errors
- No remaining `vitest/runners` references in `src/` or `dist/`
