### PR TITLE
fix(native): restore Vitest 4.0.x compatibility in hot runner

### DIFF
--- a/bench/package.json
+++ b/bench/package.json
@@ -22,7 +22,7 @@
     "react": "19.2.4",
     "react-native": "0.84.1",
     "react-test-renderer": "19.2.4",
-    "vite": "6.4.1",
+    "vite": "6.4.3",
     "vitest": "4.0.18",
     "vitest-native": "file:../packages/vitest-native"
   }

--- a/packages/vitest-native/src/native/runner.mjs
+++ b/packages/vitest-native/src/native/runner.mjs
@@ -8,7 +8,18 @@
 // (resident-library lazy init — must be preserved across files, it never
 // re-runs) and test-phase state (pollution the next file's reset removes).
 // See reset.mjs for the full attribution model.
-import { TestRunner } from "vitest";
+// vitest >=4.1 exports TestRunner from the main entry; <4.1 only exposes it as
+// VitestTestRunner via the (now-deprecated) "vitest/runners" subpath. Prefer the
+// main entry so 4.1+ doesn't print a deprecation warning, and fall back for
+// 4.0.x — the deprecated path is imported ONLY when the main export is absent,
+// so 4.1+ never triggers the warning. A namespace import (not a named one) keeps
+// a missing export as `undefined` instead of an ESM link error on 4.0.x.
+import * as vitest from "vitest";
+
+let TestRunner = vitest.TestRunner;
+if (!TestRunner) {
+  ({ VitestTestRunner: TestRunner } = await import("vitest/runners"));
+}
 
 export default class NativeHotRunner extends TestRunner {
   async onBeforeRunFiles(files) {


### PR DESCRIPTION
## What

PR #27 changed the hot runner to `import { TestRunner } from "vitest"` to drop a Vitest 4.1 deprecation warning. But **Vitest 4.0.x doesn't export `TestRunner` from the main entry** — it only exposes it as `VitestTestRunner` via the (now-deprecated in 4.1) `vitest/runners` subpath. That made the hot runner **4.1-only**, while the package declares `vitest >=4 <5`.

It surfaced as a hard failure on 4.0.x:

```
TypeError: Class extends value undefined is not a constructor or null
  at runBaseTests (vitest/dist/chunks/base.*.js)
```

(Caught while re-running the scale benchmark, whose isolated install pins Vitest 4.0.18.)

## Fix

Namespace-import `vitest`, prefer `vitest.TestRunner` (4.1+), and fall back to `vitest/runners` **only when it's absent** (4.0.x):

```js
import * as vitest from "vitest";

let TestRunner = vitest.TestRunner;
if (!TestRunner) {
  ({ VitestTestRunner: TestRunner } = await import("vitest/runners"));
}
```

- 4.1+ uses the main export → **no deprecation warning** (the original goal of #27, preserved).
- 4.0.x falls back to the deprecated subpath → **works again**.
- The deprecated path is imported *only* when the main export is missing, so 4.1+ never triggers the warning.
- A namespace import keeps a missing export as `undefined` rather than an ESM link error on 4.0.x.

## Also

`bench/package.json`: bump `vite` `6.4.1 → 6.4.3` to satisfy the package's peer floor (`>=6.4.2`). That mismatch is what surfaced the regression when re-running the scale benchmark.

## Verification

- Hot suite **97/97** on Vitest 4.1 (this repo) — and **no deprecation warning**.
- Hot config green on Vitest **4.0.18** (the bench install) — previously failed with `Class extends value undefined`.
- `oxlint` + `tsc` clean.

## Note

This is a follow-up regression fix to #27 (merged). Recommend backporting awareness: any 4.0.x consumer using `hotRuntime: true` on the current release is affected until this lands.
