### PR TITLE
fix(native): externalized ESM libs can named-import getter-based RN exports

### DIFF
--- a/.changeset/rn-getter-named-exports.md
+++ b/.changeset/rn-getter-named-exports.md
@@ -1,0 +1,9 @@
+---
+"vitest-native": patch
+---
+
+Native engine: fix `import { Appearance } from 'react-native'` (and other lazy-getter RN exports) failing with "does not provide an export named …" when the import comes from an **externalized ESM dependency**.
+
+React Native's index exposes everything via lazy getters (`module.exports = { get Appearance() {…} }`), which `cjs-module-lexer` can't surface as named exports when Node imports the CommonJS module from the ESM graph. The Node ESM loader now serves RN's main index as a thin re-export of the real (Flow-stripped) module plus a `cjs-module-lexer`-recognized export hint, so named imports resolve while the real getters stay lazy (no eager load of RN's surface). The `require('react-native')` path is unchanged.
+
+Previously this needed a manual `transform: ['the-lib']` workaround (e.g. for `uniwind`); that's no longer required. Surfaced by the obytes-template bake-off.

--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,7 @@
     },
     "packages/vitest-native": {
       "name": "vitest-native",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "flow-remove-types": "^2.304.0",
         "magic-string": "^0.30.21",
@@ -56,6 +56,7 @@
         "@vitest/coverage-v8": "4.1.8",
         "expo-constants": "56.0.16",
         "expo-status-bar": "56.0.4",
+        "ext-rn-named-lib": "file:./tests-native/fixtures/ext-rn-named-lib",
         "react": "^19.2.3",
         "react-native": "^0.85.3",
         "react-native-gesture-handler": "3.0.0",
@@ -1780,6 +1781,8 @@
     "unconfig-core/quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
 
     "vite/rolldown": ["rolldown@1.0.3", "", { "dependencies": { "@oxc-project/types": "=0.133.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.3", "@rolldown/binding-darwin-arm64": "1.0.3", "@rolldown/binding-darwin-x64": "1.0.3", "@rolldown/binding-freebsd-x64": "1.0.3", "@rolldown/binding-linux-arm-gnueabihf": "1.0.3", "@rolldown/binding-linux-arm64-gnu": "1.0.3", "@rolldown/binding-linux-arm64-musl": "1.0.3", "@rolldown/binding-linux-ppc64-gnu": "1.0.3", "@rolldown/binding-linux-s390x-gnu": "1.0.3", "@rolldown/binding-linux-x64-gnu": "1.0.3", "@rolldown/binding-linux-x64-musl": "1.0.3", "@rolldown/binding-openharmony-arm64": "1.0.3", "@rolldown/binding-wasm32-wasi": "1.0.3", "@rolldown/binding-win32-arm64-msvc": "1.0.3", "@rolldown/binding-win32-x64-msvc": "1.0.3" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g=="],
+
+    "vitest-native/ext-rn-named-lib": ["ext-rn-named-lib@file:packages/vitest-native/tests-native/fixtures/ext-rn-named-lib", {}],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 

--- a/packages/vitest-native/package.json
+++ b/packages/vitest-native/package.json
@@ -161,6 +161,7 @@
     "@vitest/coverage-v8": "4.1.8",
     "expo-constants": "56.0.16",
     "expo-status-bar": "56.0.4",
+    "ext-rn-named-lib": "file:./tests-native/fixtures/ext-rn-named-lib",
     "react": "^19.2.3",
     "react-native": "^0.85.3",
     "react-native-gesture-handler": "3.0.0",

--- a/packages/vitest-native/src/native/loader.mjs
+++ b/packages/vitest-native/src/native/loader.mjs
@@ -9,6 +9,8 @@ import { resolvePlatformFile } from "./resolve.mjs";
 import { buildPkgMatcher } from "./match.mjs";
 
 const RN_PATH = /[\\/](react-native|@react-native)[\\/]/;
+// React Native's main entry (`react-native/index.js`).
+const RN_INDEX = /[\\/]react-native[\\/]index\.js$/;
 const TRANSFORMABLE = /\.(jsx?|tsx?|mjs|cjs)$/;
 // Extensions/index candidates for bundler-style extensionless resolution.
 const RESOLVE_EXTS = [".js", ".cjs", ".mjs", ".json", ".jsx", ".ts", ".tsx"];
@@ -109,6 +111,31 @@ export async function load(url, context, nextLoad) {
   if (!isRN && !isExtra(norm)) return nextLoad(url, context);
 
   if (isRN) {
+    // RN's main index exports everything via lazy getters (`module.exports = {
+    // get Appearance() {…}, … }`). When Node imports that CommonJS module from an
+    // externalized ESM lib, cjs-module-lexer can't see getter exports, so
+    // `import { Appearance } from 'react-native'` throws "does not provide an
+    // export named 'Appearance'". Serve a thin CJS re-export of the real
+    // (Flow-stripped) index, plus a dead `0 && (module.exports = { … })` hint that
+    // cjs-module-lexer DOES recognize — so Node sees the named exports while the
+    // real getters stay lazy (no eager load of RN's whole surface). The require()
+    // of react-native here goes through the separate Module._extensions hook
+    // (hooks.mjs), not this loader, so there's no recursion. Names come from the
+    // index's own `get X()` declarations.
+    if (RN_INDEX.test(norm)) {
+      const src = fs.readFileSync(file, "utf8");
+      const names = [
+        ...new Set(
+          [...src.matchAll(/\bget\s+([A-Za-z_$][\w$]*)\s*\(/g)].map((m) => m[1]),
+        ),
+      ].filter((n) => n !== "default" && n !== "__esModule");
+      const facade = [
+        `const { createRequire } = require("node:module");`,
+        `module.exports = createRequire(${JSON.stringify(url)})(${JSON.stringify(file)});`,
+        `0 && (module.exports = { ${names.join(", ")} });`,
+      ].join("\n");
+      return { format: "commonjs", source: facade, shortCircuit: true };
+    }
     const boundary = boundarySourceFor(norm, PLATFORM, REACT_NATIVE_VERSION);
     if (boundary != null) return { format: "commonjs", source: boundary, shortCircuit: true };
     if (norm.endsWith(".js")) {

--- a/packages/vitest-native/tests-native/ext-rn-named-import.test.ts
+++ b/packages/vitest-native/tests-native/ext-rn-named-import.test.ts
@@ -1,0 +1,19 @@
+// Regression: an externalized ESM dependency that does a NAMED import of
+// getter-based React Native exports (`import { Appearance } from 'react-native'`).
+//
+// RN's index exports everything via lazy getters (`module.exports = { get
+// Appearance() {…} }`), which cjs-module-lexer can't surface as named exports when
+// Node imports the CommonJS module from the ESM graph. Without the loader's ESM
+// facade, importing `ext-rn-named-lib` throws "does not provide an export named
+// 'Appearance'". (Surfaced by the obytes bake-off, where `uniwind` does exactly
+// this and previously needed a manual `transform: ['uniwind']` workaround.)
+import { describe, it, expect } from "vitest";
+import { resolved } from "ext-rn-named-lib";
+
+describe("externalized ESM lib importing getter-based RN named exports", () => {
+  it("resolves the named imports via the loader's ESM facade", () => {
+    expect(resolved.Appearance).toBe(true);
+    expect(resolved.I18nManager).toBe(true);
+    expect(resolved.Vibration).toBe(true);
+  });
+});

--- a/packages/vitest-native/tests-native/fixtures/ext-rn-named-lib/index.js
+++ b/packages/vitest-native/tests-native/fixtures/ext-rn-named-lib/index.js
@@ -1,0 +1,11 @@
+// A stand-in for a real externalized ESM dependency (e.g. uniwind) that does a
+// NAMED import of getter-based React Native exports. RN's index defines these via
+// lazy getters, which cjs-module-lexer can't see — so without the loader's ESM
+// facade this import throws "does not provide an export named 'Appearance'".
+import { Appearance, I18nManager, Vibration } from 'react-native'
+
+export const resolved = {
+  Appearance: Appearance != null,
+  I18nManager: I18nManager != null,
+  Vibration: Vibration != null,
+}

--- a/packages/vitest-native/tests-native/fixtures/ext-rn-named-lib/package.json
+++ b/packages/vitest-native/tests-native/fixtures/ext-rn-named-lib/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "ext-rn-named-lib",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "exports": "./index.js"
+}

--- a/packages/vitest-native/tests-native/vitest.config.mts
+++ b/packages/vitest-native/tests-native/vitest.config.mts
@@ -16,5 +16,10 @@ export default defineConfig({
     setupFiles: [path.resolve(here, "../dist/jest-compat/setup.mjs")],
     include: ["tests-native/*.test.tsx", "tests-native/*.test.ts"],
     exclude: ["tests-native/android.test.ts"],
+    // Force the fixture lib to be externalized (loaded through Node, like a real
+    // node_modules dep) instead of inlined — so its `import { Appearance } from
+    // 'react-native'` exercises the loader's ESM facade. See
+    // ext-rn-named-import.test.ts.
+    server: { deps: { external: ["ext-rn-named-lib"] } },
   },
 });


### PR DESCRIPTION
## Problem

An externalized ESM dependency doing `import { Appearance } from 'react-native'` failed under the native engine:

```
SyntaxError: The requested module 'react-native' does not provide an export named 'Appearance'
```

React Native's index exposes everything via **lazy getters** (`module.exports = { get Appearance() {…}, … }`). When Node imports that CommonJS module from the ESM graph, `cjs-module-lexer` can't see getter exports, so named imports of anything getter-based throw. CJS `require('react-native')` was fine (getters resolve on access); only ESM named imports from externalized libs broke.

Surfaced by the **obytes bake-off**, where `uniwind` does exactly this and previously needed a manual `transform: ['uniwind']` workaround.

## Fix

The Node ESM loader (`loader.mjs`) now serves RN's **main index** as a thin facade:

```js
module.exports = require('<real flow-stripped index>');   // real RN, getters intact
0 && (module.exports = { Appearance, I18nManager, … });   // cjs-module-lexer export hint (never runs)
```

- The `0 && (module.exports = {…})` pattern is one `cjs-module-lexer` **does** recognize, so Node sees the named exports.
- The real getters stay **lazy** — no eager load of RN's whole surface (verified: import time stayed flat, ~1.3s, vs ~4.8s for an eager variant).
- `require('react-native')` is untouched — it goes through the separate `Module._extensions` hook, so no recursion.
- Names are extracted from the index's own `get X()` declarations.

No more manual `transform` workaround needed for libs that named-import RN getter exports.

## Tests

- New `tests-native/ext-rn-named-import.test.ts` + an externalized ESM fixture (`fixtures/ext-rn-named-lib`, a `file:` devDep, forced external in the config) that named-imports `Appearance`/`I18nManager`/`Vibration`.
- **Negative control verified**: with the facade disabled the test fails to collect (the original error); with it, it passes.
- Full gate green: native **98/98**, hot **97/97**, crosscheck **56/56**, lint/typecheck/syncpack clean.
- Re-confirmed end-to-end on the obytes bake-off: drops `uniwind` from its `transform` list and still passes (34/40).