### PR TITLE
style: fix format:check on main (oxfmt loader.mjs)

### DIFF
--- a/packages/vitest-native/src/native/loader.mjs
+++ b/packages/vitest-native/src/native/loader.mjs
@@ -125,9 +125,7 @@ export async function load(url, context, nextLoad) {
     if (RN_INDEX.test(norm)) {
       const src = fs.readFileSync(file, "utf8");
       const names = [
-        ...new Set(
-          [...src.matchAll(/\bget\s+([A-Za-z_$][\w$]*)\s*\(/g)].map((m) => m[1]),
-        ),
+        ...new Set([...src.matchAll(/\bget\s+([A-Za-z_$][\w$]*)\s*\(/g)].map((m) => m[1])),
       ].filter((n) => n !== "default" && n !== "__esModule");
       const facade = [
         `const { createRequire } = require("node:module");`,


### PR DESCRIPTION
Restores green main. PR #32 auto-merged before the Full gate finished and tripped `format:check` (a one-line `oxfmt` formatting diff in `loader.mjs`). Formatting only — no logic change. Verified locally: build, lint, typecheck, format:check, mock (1240), native (98), hot (97), crosscheck (56) all pass.