### PR TITLE
chore: release 0.6.1 + fix changelog link

### DIFF
--- a/.changeset/rn-getter-named-exports.md
+++ b/.changeset/rn-getter-named-exports.md
@@ -1,9 +1,0 @@
----
-"vitest-native": patch
----
-
-Native engine: fix `import { Appearance } from 'react-native'` (and other lazy-getter RN exports) failing with "does not provide an export named …" when the import comes from an **externalized ESM dependency**.
-
-React Native's index exposes everything via lazy getters (`module.exports = { get Appearance() {…} }`), which `cjs-module-lexer` can't surface as named exports when Node imports the CommonJS module from the ESM graph. The Node ESM loader now serves RN's main index as a thin re-export of the real (Flow-stripped) module plus a `cjs-module-lexer`-recognized export hint, so named imports resolve while the real getters stay lazy (no eager load of RN's surface). The `require('react-native')` path is unchanged.
-
-Previously this needed a manual `transform: ['the-lib']` workaround (e.g. for `uniwind`); that's no longer required. Surfaced by the obytes-template bake-off.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,6 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
-This project uses [changesets](https://github.com/changesets/changesets) for versioning.
+The published package's changelog lives with the package and is maintained by
+[changesets](https://github.com/changesets/changesets):
 
-## 0.1.0
-
-Initial release.
-
-- Complete `react-native` module mock (21 components, 25+ APIs)
-- Native bridge mocks (NativeModules, TurboModuleRegistry, UIManager, NativeEventEmitter)
-- 7 built-in presets: Reanimated, Gesture Handler, Safe Area, Navigation, Async Storage, Screens, Expo
-- Auto-detect presets from installed packages
-- Platform extension resolution (`.ios.ts`, `.android.ts`, `.native.ts`)
-- Asset stub imports (images, fonts, video, audio)
-- Test helpers: `setPlatform`, `setDimensions`, `setColorScheme`, `mockNativeModule`, `resetAllMocks`
-- Snapshot serializer with clean JSX-like output
-- Auto-registered RNTL matchers when `@testing-library/react-native` is installed
-- Dual ESM/CJS build
+→ **[packages/vitest-native/CHANGELOG.md](packages/vitest-native/CHANGELOG.md)**

--- a/packages/vitest-native/CHANGELOG.md
+++ b/packages/vitest-native/CHANGELOG.md
@@ -1,5 +1,15 @@
 # vitest-native
 
+## 0.6.1
+
+### Patch Changes
+
+- 40a5147: Native engine: fix `import { Appearance } from 'react-native'` (and other lazy-getter RN exports) failing with "does not provide an export named …" when the import comes from an **externalized ESM dependency**.
+
+  React Native's index exposes everything via lazy getters (`module.exports = { get Appearance() {…} }`), which `cjs-module-lexer` can't surface as named exports when Node imports the CommonJS module from the ESM graph. The Node ESM loader now serves RN's main index as a thin re-export of the real (Flow-stripped) module plus a `cjs-module-lexer`-recognized export hint, so named imports resolve while the real getters stay lazy (no eager load of RN's surface). The `require('react-native')` path is unchanged.
+
+  Previously this needed a manual `transform: ['the-lib']` workaround (e.g. for `uniwind`); that's no longer required. Surfaced by the obytes-template bake-off.
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/vitest-native/package.json
+++ b/packages/vitest-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vitest-native",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "description": "Run real React Native tests under Vitest. One install, zero config.",
   "license": "MIT",

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -42,7 +42,7 @@ export default defineConfig({
       {
         text: 'Resources',
         items: [
-          { text: 'Changelog', link: 'https://github.com/danfry1/vitest-native/blob/main/CHANGELOG.md' },
+          { text: 'Changelog', link: 'https://github.com/danfry1/vitest-native/blob/main/packages/vitest-native/CHANGELOG.md' },
           { text: 'npm', link: 'https://www.npmjs.com/package/vitest-native' },
           { text: 'llms.txt', link: '/llms.txt', target: '_blank' },
         ],


### PR DESCRIPTION
## Release 0.6.1

Version bump and changelog for **0.6.1**, consuming the pending changeset:

- **Native engine: externalized ESM libraries can named-import getter-based React Native exports** (#32) — fixes `import { Appearance } from 'react-native'` (and other lazy-getter RN exports) throwing "does not provide an export named …" when the import comes from an externalized ESM dependency. Removes the need for a manual `transform` workaround.

## Changelog link fix

The documentation site's **Changelog** nav link pointed at the repository-root `CHANGELOG.md`, which was stale (it only listed `0.1.0`). The maintained changelog is `packages/vitest-native/CHANGELOG.md` (updated by changesets). This change:

- repoints the docs link to `packages/vitest-native/CHANGELOG.md`, and
- replaces the root `CHANGELOG.md` with a pointer to the package changelog.

## Releasing

After merge, push the `v0.6.1` tag to trigger the OIDC publish workflow:

```bash
git tag v0.6.1 && git push origin v0.6.1
```

Then approve the staged publish with 2FA (`npm stage approve <id>`).

No source changes beyond the version bump, changelog, and docs link.