### PR TITLE
fix(compat): mock react-native 0.86 top-level exports

### DIFF
--- a/.changeset/rn-086-exports.md
+++ b/.changeset/rn-086-exports.md
@@ -1,0 +1,11 @@
+---
+"vitest-native": patch
+---
+
+Add mocks for react-native 0.86 top-level exports
+
+The weekly compatibility check flagged new stable exports in react-native 0.86.
+`EventEmitter`, `useAnimatedColor`, and `useAnimatedValueXY` are now mocked so
+named imports resolve under the mock engine. The experimental virtualized-collection
+API (`unstable_VirtualRow`, `unstable_createVirtualCollectionView`, and related)
+is added to the compatibility check's known-skipped list.

--- a/packages/vitest-native/scripts/check-compat.ts
+++ b/packages/vitest-native/scripts/check-compat.ts
@@ -26,6 +26,14 @@ const KNOWN_SKIPPED = new Set([
   "unstable_TextAncestorContext",
   "unstable_VirtualView",
   "VirtualViewMode",
+  // Experimental virtualized-collection API (RN 0.86+)
+  "unstable_DEFAULT_INITIAL_NUM_TO_RENDER",
+  "unstable_VirtualArray",
+  "unstable_VirtualColumn",
+  "unstable_VirtualColumnGenerator",
+  "unstable_VirtualRow",
+  "unstable_createVirtualCollectionView",
+  "unstable_getScrollParent",
 ]);
 
 // ─── Find react-native ──────────────────────────────────────────────────────

--- a/packages/vitest-native/src/mocks/registry.ts
+++ b/packages/vitest-native/src/mocks/registry.ts
@@ -278,6 +278,20 @@ function createUseAnimatedValueMock() {
   });
 }
 
+function createUseAnimatedValueXYMock() {
+  return vi.fn((initialValue?: { x: number; y: number }) => {
+    const AnimatedMod = createAnimatedMock();
+    return new AnimatedMod.ValueXY(initialValue);
+  });
+}
+
+function createUseAnimatedColorMock() {
+  return vi.fn((initialValue?: any) => {
+    const AnimatedMod = createAnimatedMock();
+    return new AnimatedMod.Color(initialValue);
+  });
+}
+
 // Re-export all factories
 export {
   // Components
@@ -405,6 +419,8 @@ export function buildReactNativeMock(platform: "ios" | "android" = "ios") {
     UIManager: createUIManagerMock(),
     NativeEventEmitter: createNativeEventEmitterMock(),
     NativeAppEventEmitter: createDeviceEventEmitterMock(),
+    // Generic event emitter base class (top-level export since RN 0.86)
+    EventEmitter: createNativeEventEmitterMock(),
     NativeComponentRegistry: createNativeComponentRegistryMock(),
     requireNativeComponent: createRequireNativeComponentMock(),
 
@@ -419,6 +435,8 @@ export function buildReactNativeMock(platform: "ios" | "android" = "ios") {
     Settings: createSettingsMock(),
     DeviceInfo: createDeviceInfoMock(),
     useAnimatedValue: createUseAnimatedValueMock(),
+    useAnimatedValueXY: createUseAnimatedValueXYMock(),
+    useAnimatedColor: createUseAnimatedColorMock(),
     RootTagContext: React.createContext(null as any),
     ReactNativeVersion: { major: 0, minor: 76, patch: 0 },
     Systrace: {

--- a/packages/vitest-native/src/plugin.ts
+++ b/packages/vitest-native/src/plugin.ts
@@ -221,6 +221,7 @@ const RN_EXPORT_NAMES = [
   "UIManager",
   "NativeEventEmitter",
   "NativeAppEventEmitter",
+  "EventEmitter",
   "NativeComponentRegistry",
   "requireNativeComponent",
   // Additional
@@ -234,6 +235,8 @@ const RN_EXPORT_NAMES = [
   "Settings",
   "DeviceInfo",
   "useAnimatedValue",
+  "useAnimatedValueXY",
+  "useAnimatedColor",
   "RootTagContext",
   "ReactNativeVersion",
   "Systrace",

--- a/packages/vitest-native/src/types.ts
+++ b/packages/vitest-native/src/types.ts
@@ -162,6 +162,7 @@ export interface ReactNativeMock {
   UIManager: Record<string, any>;
   NativeEventEmitter: new (...args: any[]) => any;
   NativeAppEventEmitter: Record<string, any>;
+  EventEmitter: new (...args: any[]) => any;
   NativeComponentRegistry: Record<string, any>;
   requireNativeComponent: Mock;
 
@@ -176,6 +177,8 @@ export interface ReactNativeMock {
   Settings: Record<string, Mock>;
   DeviceInfo: Record<string, any>;
   useAnimatedValue: Mock;
+  useAnimatedValueXY: Mock;
+  useAnimatedColor: Mock;
   RootTagContext: React.Context<any>;
   ReactNativeVersion: { major: number; minor: number; patch: number };
   Systrace: Record<string, Mock>;

--- a/packages/vitest-native/tests/rn-086-exports.test.ts
+++ b/packages/vitest-native/tests/rn-086-exports.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Regression coverage for top-level exports introduced in react-native 0.86.
+ *
+ * The weekly compatibility check (scripts/check-compat.ts) flagged these as new
+ * stable exports. They are mocked so suites running against RN 0.86+ resolve the
+ * named imports instead of failing with "does not provide an export named …".
+ */
+
+import { describe, it, expect } from "vitest";
+import { Animated, EventEmitter, useAnimatedColor, useAnimatedValueXY } from "react-native";
+
+describe("useAnimatedValueXY (RN 0.86)", () => {
+  it("returns an Animated.ValueXY", () => {
+    const value = useAnimatedValueXY({ x: 10, y: 20 });
+    expect(value).toBeInstanceOf(Animated.ValueXY);
+    expect(value.x.getValue()).toBe(10);
+    expect(value.y.getValue()).toBe(20);
+  });
+
+  it("defaults to the origin", () => {
+    const value = useAnimatedValueXY();
+    expect(value.x.getValue()).toBe(0);
+    expect(value.y.getValue()).toBe(0);
+  });
+});
+
+describe("useAnimatedColor (RN 0.86)", () => {
+  it("returns an Animated.Color parsed from a string", () => {
+    const color = useAnimatedColor("rgba(255, 0, 0, 1)");
+    expect(color).toBeInstanceOf(Animated.Color);
+    expect(color.r.getValue()).toBe(255);
+    expect(color.g.getValue()).toBe(0);
+    expect(color.b.getValue()).toBe(0);
+    expect(color.a.getValue()).toBe(1);
+  });
+});
+
+describe("EventEmitter (RN 0.86)", () => {
+  it("dispatches emitted events to listeners", () => {
+    const emitter = new EventEmitter();
+    let received: unknown;
+    emitter.addListener("ping", (payload: unknown) => {
+      received = payload;
+    });
+    emitter.emit("ping", 42);
+    expect(received).toBe(42);
+  });
+
+  it("stops dispatching after a subscription is removed", () => {
+    const emitter = new EventEmitter();
+    let count = 0;
+    const subscription = emitter.addListener("tick", () => {
+      count += 1;
+    });
+    emitter.emit("tick");
+    subscription.remove();
+    emitter.emit("tick");
+    expect(count).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

The weekly compatibility check installs `react-native@latest` (now 0.86.0) and compares its top-level exports against the mock registry. RN 0.86 introduced 10 new stable exports that were not covered, so the check failed and opened #37.

The 10 new exports fall into two groups:

**Real, stable exports — now mocked**
- `EventEmitter` — the generic base event-emitter class (reuses the existing `NativeEventEmitter` mock class, whose API matches)
- `useAnimatedColor` — returns an `Animated.Color`
- `useAnimatedValueXY` — returns an `Animated.ValueXY`

**Experimental virtualized-collection API — added to known-skipped**
`unstable_DEFAULT_INITIAL_NUM_TO_RENDER`, `unstable_VirtualArray`, `unstable_VirtualColumn`, `unstable_VirtualColumnGenerator`, `unstable_VirtualRow`, `unstable_createVirtualCollectionView`, `unstable_getScrollParent` — skipped alongside the existing `unstable_VirtualView` / `VirtualViewMode` family until RN promotes them to stable.

## Changes
- `src/mocks/registry.ts` — register the three new exports (the two hooks mirror the existing `useAnimatedValue` factory)
- `src/plugin.ts` — add the three to the named-export allowlist
- `src/types.ts` — extend the mock type
- `scripts/check-compat.ts` — add the seven experimental exports to `KNOWN_SKIPPED`
- `tests/rn-086-exports.test.ts` — regression coverage for the new exports
- `.changeset/rn-086-exports.md` — patch changeset

## Verification
- `check-compat` run against the real react-native 0.86.0 index: no missing stable exports remain
- Mock suite 1245 passed / 3 skipped, native suite 98 passed, new regression test 5 passed
- typecheck, lint (0 warnings), and oxfmt all clean

Note: `unstable_batchedUpdates` now reports as a stale mock (RN 0.86 dropped it), but this is a non-failing warning and the mock is retained for back-compat with RN 0.81–0.85.

Closes #37