### PR TITLE
test(native): cover control surface, platform-extension priority, globals, a11y

### DIFF
--- a/packages/vitest-native/tests-native/accessibility.test.tsx
+++ b/packages/vitest-native/tests-native/accessibility.test.tsx
@@ -1,0 +1,30 @@
+// Accessibility queries and the style matcher are core RNTL use cases that depend
+// on real RN prop handling (accessibilityRole/Label → role, StyleSheet ref →
+// resolved style object). matchers.test.tsx covers text/display/disabled matchers;
+// these cover the a11y query path and toHaveStyle, which it doesn't.
+import { render, screen } from "@testing-library/react-native";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { describe, expect, it } from "vitest";
+
+const styles = StyleSheet.create({
+  box: { width: 10, height: 20, opacity: 0.5 },
+});
+
+describe("native engine: accessibility queries", () => {
+  it("queries a real component by role and by label", () => {
+    render(
+      <Pressable accessibilityRole="button" accessibilityLabel="Submit form">
+        <Text>Go</Text>
+      </Pressable>,
+    );
+    expect(screen.getByRole("button")).toBeTruthy();
+    expect(screen.getByLabelText("Submit form")).toBeTruthy();
+  });
+});
+
+describe("native engine: toHaveStyle resolves StyleSheet refs", () => {
+  it("matches the resolved style object from StyleSheet.create", () => {
+    render(<View testID="box" style={styles.box} />);
+    expect(screen.getByTestId("box")).toHaveStyle({ width: 10, height: 20, opacity: 0.5 });
+  });
+});

--- a/packages/vitest-native/tests-native/android.test.ts
+++ b/packages/vitest-native/tests-native/android.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { Platform } from "react-native";
 import { selectedPlatform } from "./fixtures/platform";
+import { marker } from "./fixtures/plat/marker";
+import { nativeOnly } from "./fixtures/plat/nativeonly";
 
 describe("native engine: Android platform", () => {
   it("loads Android React Native and application modules", () => {
@@ -13,5 +15,12 @@ describe("native engine: Android platform", () => {
     expect(Platform.Version).toBe(34);
     expect(Platform.constants.systemName).toBeUndefined();
     expect(Platform.constants.reactNativeVersion.minor).toBeGreaterThan(0);
+  });
+
+  it("prefers the .android variant over .native and the base file", () => {
+    // Same fixtures as platform-resolution.test.ts (iOS): proves platform-specific
+    // resolution wins over `.native`, which wins over the base, on Android too.
+    expect(marker).toBe("android");
+    expect(nativeOnly).toBe("native");
   });
 });

--- a/packages/vitest-native/tests-native/control-surface.test.ts
+++ b/packages/vitest-native/tests-native/control-surface.test.ts
@@ -1,0 +1,51 @@
+// The native control surface's resetAllMocks(): contract.test.ts uses it in
+// afterEach but never asserts it actually restores state. These verify the
+// isolation guarantee — that setDimensions/setColorScheme/mockNativeModule are
+// all undone by resetAllMocks() so state doesn't leak between tests.
+import { afterEach, describe, expect, it } from "vitest";
+import { Appearance, Dimensions, NativeModules } from "react-native";
+import {
+  mockNativeModule,
+  resetAllMocks,
+  setColorScheme,
+  setDimensions,
+} from "vitest-native/helpers";
+
+afterEach(() => {
+  resetAllMocks();
+});
+
+describe("native engine: resetAllMocks restores driven state", () => {
+  it("restores Dimensions to their initial value", () => {
+    const initial = Dimensions.get("window");
+    setDimensions({ width: 111, height: 222, scale: 1, fontScale: 1 });
+    expect(Dimensions.get("window").width).toBe(111);
+
+    resetAllMocks();
+
+    expect(Dimensions.get("window")).toMatchObject({
+      width: initial.width,
+      height: initial.height,
+    });
+  });
+
+  it("restores the color scheme", () => {
+    setColorScheme("dark");
+    expect(Appearance.getColorScheme()).toBe("dark");
+
+    resetAllMocks();
+
+    expect(Appearance.getColorScheme()).not.toBe("dark");
+  });
+
+  it("removes an injected native module", () => {
+    mockNativeModule("VitestResetProbe", { ping: () => "pong" });
+    expect(NativeModules.VitestResetProbe.ping()).toBe("pong");
+
+    resetAllMocks();
+
+    // The injected implementation is gone (the module is undefined or, at most, a
+    // permissive stub — either way `ping()` no longer returns the injected value).
+    expect(NativeModules.VitestResetProbe?.ping?.()).not.toBe("pong");
+  });
+});

--- a/packages/vitest-native/tests-native/fixtures/plat/marker.android.ts
+++ b/packages/vitest-native/tests-native/fixtures/plat/marker.android.ts
@@ -1,0 +1,1 @@
+export const marker = "android";

--- a/packages/vitest-native/tests-native/fixtures/plat/marker.ios.ts
+++ b/packages/vitest-native/tests-native/fixtures/plat/marker.ios.ts
@@ -1,0 +1,1 @@
+export const marker = "ios";

--- a/packages/vitest-native/tests-native/fixtures/plat/marker.native.ts
+++ b/packages/vitest-native/tests-native/fixtures/plat/marker.native.ts
@@ -1,0 +1,1 @@
+export const marker = "native";

--- a/packages/vitest-native/tests-native/fixtures/plat/marker.ts
+++ b/packages/vitest-native/tests-native/fixtures/plat/marker.ts
@@ -1,0 +1,1 @@
+export const marker = "base";

--- a/packages/vitest-native/tests-native/fixtures/plat/nativeonly.native.ts
+++ b/packages/vitest-native/tests-native/fixtures/plat/nativeonly.native.ts
@@ -1,0 +1,1 @@
+export const nativeOnly = "native";

--- a/packages/vitest-native/tests-native/fixtures/plat/nativeonly.ts
+++ b/packages/vitest-native/tests-native/fixtures/plat/nativeonly.ts
@@ -1,0 +1,1 @@
+export const nativeOnly = "base";

--- a/packages/vitest-native/tests-native/globals.test.ts
+++ b/packages/vitest-native/tests-native/globals.test.ts
@@ -1,0 +1,25 @@
+// React Native's JS expects a handful of globals to exist at runtime (it reads
+// them during module init and rendering). The native setup installs them; without
+// them real RN throws on import. These assert the contract the engine provides.
+import { describe, expect, it } from "vitest";
+
+describe("native engine: React Native runtime globals", () => {
+  it("installs __DEV__", () => {
+    expect((globalThis as Record<string, unknown>).__DEV__).toBe(true);
+  });
+
+  it("installs requestAnimationFrame / cancelAnimationFrame", () => {
+    expect(typeof requestAnimationFrame).toBe("function");
+    expect(typeof cancelAnimationFrame).toBe("function");
+  });
+
+  it("marks the React act + React Native test environment", () => {
+    const g = globalThis as Record<string, unknown>;
+    expect(g.IS_REACT_ACT_ENVIRONMENT).toBe(true);
+    expect(g.IS_REACT_NATIVE_TEST_ENVIRONMENT).toBe(true);
+  });
+
+  it("provides the batched-bridge config RN core reads at init", () => {
+    expect((globalThis as Record<string, unknown>).__fbBatchedBridgeConfig).toBeDefined();
+  });
+});

--- a/packages/vitest-native/tests-native/platform-resolution.test.ts
+++ b/packages/vitest-native/tests-native/platform-resolution.test.ts
@@ -1,0 +1,19 @@
+// iOS platform-extension resolution (the default platform). Android resolution is
+// covered by android.test.ts, but neither side tested *priority* — that the engine
+// picks `.ios` over `.native` over the base file, matching Metro. These imports are
+// resolved by Vite using the platform-ordered `resolve.extensions` the plugin sets.
+import { describe, expect, it } from "vitest";
+import { marker } from "./fixtures/plat/marker";
+import { nativeOnly } from "./fixtures/plat/nativeonly";
+
+describe("native engine: iOS platform-extension resolution", () => {
+  it("prefers the .ios variant over .native and the base file", () => {
+    // fixtures/plat/marker.{ios,android,native,}.ts all exist.
+    expect(marker).toBe("ios");
+  });
+
+  it("falls back to .native when no platform-specific variant exists", () => {
+    // fixtures/plat/nativeonly has only .native.ts and .ts.
+    expect(nativeOnly).toBe("native");
+  });
+});

--- a/packages/vitest-native/tests-native/safe-area-control.test.tsx
+++ b/packages/vitest-native/tests-native/safe-area-control.test.tsx
@@ -1,0 +1,29 @@
+// The setInsets() helper drives the safe-area preset's mock insets under the native
+// engine. third-party-stack.test.tsx renders default insets; this verifies the
+// control helper actually flows through to useSafeAreaInsets() at render time.
+import { render, screen } from "@testing-library/react-native";
+import { Text } from "react-native";
+import { SafeAreaProvider, useSafeAreaInsets } from "react-native-safe-area-context";
+import { afterEach, describe, expect, it } from "vitest";
+import { resetAllMocks, setInsets } from "vitest-native/helpers";
+
+function Insets() {
+  const insets = useSafeAreaInsets();
+  return <Text>{`top:${insets.top} bottom:${insets.bottom}`}</Text>;
+}
+
+afterEach(() => {
+  resetAllMocks();
+});
+
+describe("native engine: setInsets drives the safe-area preset", () => {
+  it("returns the configured insets from useSafeAreaInsets()", () => {
+    setInsets({ top: 99, bottom: 7 });
+    render(
+      <SafeAreaProvider>
+        <Insets />
+      </SafeAreaProvider>,
+    );
+    expect(screen.getByText("top:99 bottom:7")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Closes the remaining native-engine **integration** gaps. The unit layer in `tests/` already covers transform / `resolvePlatformFile` / boundary / preset factories, and `tests-native/` covers component + preset integration — these add the behaviors that were exercised only indirectly (or not at all):

- **`resetAllMocks()` restoration** — `contract.test.ts` called it in `afterEach` but never asserted it works. Now verifies it restores driven `Dimensions`, color scheme, and removes injected native modules (the test-isolation guarantee).
- **Platform-extension priority** — `.ios` > `.native` > base on iOS, and `.android` > `.native` > base on Android. Android resolution was tested but not *priority*; iOS resolution wasn't tested live at all. One shared fixture set drives both.
- **`setInsets()`** — flows through the safe-area preset to `useSafeAreaInsets()` at render.
- **Runtime globals** — `__DEV__`, `requestAnimationFrame`/`cancelAnimationFrame`, the React-act / RN test-environment flags, and the batched-bridge config the engine installs for real RN to boot.
- **Accessibility queries + `toHaveStyle`** — `getByRole`/`getByLabelText` and resolving a `StyleSheet.create` ref through `toHaveStyle`; core RNTL paths not previously exercised under native (text/display/disabled matchers were already covered).

## Result

Native suite: **98 → 110 tests** (18 → 23 files); Android +1. All green under the iOS, hot-runtime, and Android configs; lint + typecheck clean. Tests-only — no source or behavior changes.