### PR TITLE
docs: correct misleading source comments (accuracy sweep)

### DIFF
--- a/packages/vitest-native/src/native/transform.mjs
+++ b/packages/vitest-native/src/native/transform.mjs
@@ -1,7 +1,9 @@
 // Flow-strips a React Native source file via the project's @react-native/babel-preset
-// (the only transformer that lowers RN's `component` syntax). Disk-cached by
-// path + mtime + size + preset version. Used by BOTH the loader hook (import) and
-// the require hook — they run in separate threads, so this module is stateless.
+// (the only transformer that lowers RN's `component` syntax). Used by BOTH the loader
+// hook (import) and the require hook, which run in separate threads: each gets its own
+// instance of this module, so the in-memory `mem` cache below is per-thread (no shared
+// mutable state to race on). The disk cache — keyed by path + mtime + size + preset
+// version — is the layer shared across them.
 import { createRequire } from "node:module";
 import path from "node:path";
 import fs from "node:fs";


### PR DESCRIPTION
## Summary

A trust/accuracy sweep over all of `src/` (100+ files: native engine plumbing, plugin, jest-compat, all `mocks/` and `presets/`) looking for comments that contradict the code — false "no-op/dead" claims, behavior claims the code disproves, stale references, and incorrect platform-behavior assertions.

**The codebase came out clean** — comments matched code across the board (the getter-export loader facade, the hot-runtime attribution model, the pool reuse contract, the cjs-bridge teardown, jest-compat interop, and every mock/preset all verified accurate). This PR fixes the one genuine drift found:

- **`native/transform.mjs`** described itself as "stateless," but it holds an in-memory `mem` cache, lazy Babel handles, and a shared disk cache. The accurate model — each of the loader/require hooks runs in its own thread with a per-thread in-memory cache, sharing only the disk cache — is now stated.

(A second, higher-severity finding from the sweep — the mock-engine Flow-strip hook's inaccurate "currently a no-op" comment — is already corrected in #39.)

Comment-only; no behavior change.