### PR TITLE
docs: cover large-suite memory, error-boundary noise, and preset overrides

### DIFF
--- a/packages/vitest-native/README.md
+++ b/packages/vitest-native/README.md
@@ -573,6 +573,41 @@ preset.
 Real RN computes host props (e.g. `<Text>`'s `accessible`, `allowFontScaling`) that mocks omit, so
 the tree is richer. Re-record once with `npx vitest -u` after migrating.
 
+**`Worker terminated due to reaching memory limit` / `JS heap out of memory` (large native suites)**
+Every test file that renders real React Native loads a full renderer, so a large suite can grow a
+worker's heap past Node's default ceiling. Cap it with Vitest's per-worker limit — Vitest recycles a
+worker once its heap exceeds the limit, so growth never reaches the hard OOM:
+
+```ts
+// vitest.config.ts
+export default defineConfig({
+  test: { poolOptions: { threads: { memoryLimit: "512MB" } } },
+});
+```
+
+The experimental `reactNative({ hotRuntime: true })` also helps: it keeps React Native resident
+across files (loaded once per worker instead of per file) and recycles workers on a memory/file
+budget.
+
+**`Vitest caught N unhandled errors` in error-boundary tests**
+A test that intentionally throws inside a component (to exercise an error boundary) makes React log
+a "recovered from an error during concurrent rendering" message and Vitest count it — even though
+the boundary worked and the test passes. It's cosmetic and the assertions are unaffected. Silence it
+in a setup file if you like (e.g. filter the message in an `onConsoleLog`/`console.error` wrapper).
+
+**Overriding a preset's mock (e.g. navigation route params)**
+Auto-detected presets shadow a library with a built-in mock. To change what that mock returns for a
+test or project, `vi.mock` the module in a setup file and spread the preset's mock — presets expose
+the module to Vitest's graph, so `vi.mock` applies and `importOriginal()` returns the preset mock:
+
+```ts
+// vitest.setup.ts
+vi.mock("@react-navigation/native", async (importOriginal) => ({
+  ...(await importOriginal()),
+  useRoute: () => ({ key: "r", name: "Screen", params: { id: "1" } }),
+}));
+```
+
 ---
 
 ## RNTL Matchers

--- a/packages/vitest-native/docs/migrating-from-jest.md
+++ b/packages/vitest-native/docs/migrating-from-jest.md
@@ -114,7 +114,9 @@ no-op under the shim (use `test.testTimeout` in config or per-test `{ timeout }`
 2. Delete manual third-party native-lib mocks and `@react-native/jest-preset` (2c, 2e).
 3. Convert any **top-level** `jest.mock(...)` to `vi.mock(...)`; leave runtime `jest.*` as-is (2a).
 4. Run `vitest run -u` once to re-record snapshots (2d), then `vitest run` to confirm green.
-5. Triage remaining failures — usually a missing query update or a suite-specific mock.
+5. Triage remaining failures — usually a missing query update or a suite-specific mock. For runtime
+   issues (large-suite memory limits, error-boundary console noise, overriding a preset's mock), see
+   the [Troubleshooting](../README.md#troubleshooting) section.
 
 ## 4. What "done" looks like
 


### PR DESCRIPTION
## Summary

Fills the runtime-issue gaps in the docs that migrators commonly hit — all behavior already true on `main`:

- **Troubleshooting → large-suite memory.** Every test file that renders real React Native loads a full renderer, so a big suite can grow a worker's heap past Node's ceiling. Documents `poolOptions.threads.memoryLimit` (Vitest recycles a worker once its heap exceeds the limit, before the hard OOM) and notes the experimental `hotRuntime` as a complementary lever.
- **Troubleshooting → error-boundary noise.** Tests that intentionally throw to exercise an error boundary make React log a concurrent-recovery message that Vitest counts as an unhandled error, even though the test passes. Clarifies it's cosmetic and assertions are unaffected.
- **Troubleshooting → overriding a preset's mock.** How to change what an auto-detected preset returns (`vi.mock` + spread `importOriginal()`), since presets expose the shadowed module to Vitest's graph.
- **Migration guide** triage step now links to Troubleshooting for these runtime issues.

Docs only — no code or behavior changes.