### PR TITLE
fix(native): dedupe React across the externalized RN graph

### DIFF
--- a/.changeset/react-singleton-dedupe.md
+++ b/.changeset/react-singleton-dedupe.md
@@ -1,0 +1,7 @@
+---
+"vitest-native": patch
+---
+
+Deduplicate React across the externalized React Native graph under the native engine.
+
+React Native is externalized and loaded through Node, outside Vite's module graph, so Vite's `resolve.dedupe` does not reach it. When a project resolves more than one physical copy of `react` — common with pnpm/Bun strict stores, monorepos, or version skew — React Native could bind a different React instance than the test renderer, making every render fail with "Invalid hook call". Resolution of `react`, `react-is`, and `scheduler` requested from the externalized graph is now pinned to the project's canonical copy, matching the single-instance guarantee `resolve.dedupe` provides for the Vite graph. A `pm-matrix` harness reproduces the scenario across npm, pnpm, and Bun.

--- a/.github/workflows/pm-matrix.yml
+++ b/.github/workflows/pm-matrix.yml
@@ -1,0 +1,51 @@
+name: Native engine — package-manager matrix
+
+# The native engine resolves React Native at the Node layer (Module._resolveFilename,
+# Module._extensions, and an ESM loader hook), outside Vite's resolver, because RN is
+# externalized. That makes it directly exposed to the on-disk shape each package
+# manager produces — and the layouts differ sharply (npm hoists; pnpm and Bun use
+# strict, symlinked/isolated stores). This job installs a minimal real RN + RNTL
+# suite under npm, pnpm, and Bun and runs it in two scenarios — a clean single-React
+# install and a planted split-React install — so a regression in the Node-layer
+# React-singleton dedupe (src/native/hooks.mjs + loader.mjs) is caught here. The
+# package's own native suite cannot exercise this, since its `react` is never
+# duplicated.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pm-matrix:
+    name: npm × pnpm × Bun — clean + split React
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.14
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22.13.0'
+
+      - name: Install pnpm
+        # Install directly via npm rather than corepack: corepack reads this repo's
+        # `packageManager: bun@…` field and refuses to prepare a different manager.
+        # The harness installs in a temp dir outside the repo, so the pnpm binary is
+        # used cleanly there.
+        run: npm install -g pnpm@10
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Package-manager resolution matrix
+        working-directory: packages/vitest-native
+        run: bun run test:pm-matrix

--- a/packages/vitest-native/package.json
+++ b/packages/vitest-native/package.json
@@ -184,6 +184,7 @@
     "test:native:hot": "vitest run --config tests-native/vitest.hot.config.mts",
     "test:native:hot:isolation": "vitest run --config tests-native/vitest.hot-isolation.config.mts",
     "test:native:hot:soak": "node scripts/test-hot-soak.mjs",
+    "test:pm-matrix": "bash pm-matrix/run.sh",
     "test:consumers": "node scripts/test-consumers.mjs",
     "lint": "oxlint --deny-warnings src/ tests/ tests-native/ crosscheck/ consumer-tests/ scripts/",
     "format": "oxfmt --write src/ tests/ consumer-tests/ scripts/",

--- a/packages/vitest-native/pm-matrix/README.md
+++ b/packages/vitest-native/pm-matrix/README.md
@@ -1,0 +1,45 @@
+# Package-manager resolution matrix
+
+The native engine resolves React Native at the **Node layer** (`Module._resolveFilename`,
+`Module._extensions`, and an ESM loader hook), *outside* Vite's resolver — because RN is
+externalized. That makes it directly exposed to the on-disk shape each package manager
+produces, which differ sharply:
+
+| Manager | Layout | Resolution |
+| --- | --- | --- |
+| npm / yarn-classic | hoisted, flat | permissive (phantom deps resolve) |
+| pnpm | symlinked `.pnpm` store | strict; realpath matters |
+| bun | isolated `.bun` store | strict, like pnpm |
+| yarn PnP | no `node_modules` | `.pnp.cjs` resolver — **not yet supported** |
+
+## What this harness proves
+
+`run.sh` installs a minimal real RN + RNTL suite under **npm, pnpm, and bun**, and runs it in
+two scenarios:
+
+- **clean** — a normal single-React install. Verifies the engine resolves and renders
+  identically across all three managers.
+- **split** — a second physical `react` is planted inside `react-native`'s own
+  `node_modules`, so the externalized RN graph resolves a *different* React instance than the
+  test/renderer. This is the everyday monorepo / version-skew / strict-store condition.
+
+React keeps its hooks dispatcher as module-level state, so two physical copies = two
+dispatchers = `Invalid hook call`. Vitest's `resolve.dedupe` enforces a single copy in the
+Vite graph, but it does **not** reach the externalized Node graph. vitest-native re-establishes
+the single instance at the Node boundary (the `REACT_SINGLETON` dedupe in
+`src/native/hooks.mjs` and `src/native/loader.mjs`), so the **split** scenario passes too.
+
+## Running
+
+```bash
+bash pm-matrix/run.sh
+```
+
+Requires `npm`, `pnpm`, and `bun` on `PATH` (missing managers are skipped). Installs run in a
+temp dir outside the repo. Expected result:
+
+```
+npm  | clean(react=1): PASS | split(react=2): PASS
+pnpm | clean(react=1): PASS | split(react=2): PASS
+bun  | clean(react=1): PASS | split(react=2): PASS
+```

--- a/packages/vitest-native/pm-matrix/README.md
+++ b/packages/vitest-native/pm-matrix/README.md
@@ -32,14 +32,21 @@ the single instance at the Node boundary (the `REACT_SINGLETON` dedupe in
 ## Running
 
 ```bash
-bash pm-matrix/run.sh
+bun run test:pm-matrix   # or: bash pm-matrix/run.sh
 ```
 
 Requires `npm`, `pnpm`, and `bun` on `PATH` (missing managers are skipped). Installs run in a
-temp dir outside the repo. Expected result:
+temp dir outside the repo (printed at the end; not auto-removed, so logs can be inspected). The
+script exits non-zero if any scenario fails — including a `PLANT FAILED` guard that fires if the
+split-React planting did not actually add a second copy, so a "split" run can't pass vacuously.
+Expected result:
 
 ```
 npm  | clean(react=1): PASS | split(react=2): PASS
 pnpm | clean(react=1): PASS | split(react=2): PASS
 bun  | clean(react=1): PASS | split(react=2): PASS
 ```
+
+This runs in CI on every PR via `.github/workflows/pm-matrix.yml`, the regression guard for the
+React-singleton dedupe — the package's own native suite can't exercise it, since its `react` is
+never duplicated.

--- a/packages/vitest-native/pm-matrix/run.sh
+++ b/packages/vitest-native/pm-matrix/run.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Cross-package-manager resolution matrix for the native engine.
+#
+# Builds + packs vitest-native, then installs a minimal real React Native test
+# project under npm, pnpm, and bun, and runs the SAME suite under each — in two
+# scenarios:
+#   clean — a normal single-React install (the happy path)
+#   split — a second physical `react` planted inside react-native's own
+#           node_modules, so the externalized RN graph resolves a DIFFERENT React
+#           than the test/renderer (the everyday monorepo / version-skew / strict-
+#           store condition). Without the Node-layer React-singleton dedupe (see
+#           src/native/hooks.mjs + loader.mjs) this crashes with "Invalid hook call".
+#
+# Installs run in a temp dir OUTSIDE the repo so each PM's store stays isolated and
+# corepack doesn't trip on the repo's `packageManager` field. Requires npm, pnpm,
+# and bun on PATH; any missing manager is skipped.
+set -u
+
+PKG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="$(mktemp -d)"
+TARBALL_DIR="$WORK/_tarball"
+SUMMARY="$WORK/SUMMARY.txt"
+mkdir -p "$TARBALL_DIR"
+: > "$SUMMARY"
+
+echo "Building + packing vitest-native…"
+( cd "$PKG_DIR" && bun run build ) >/dev/null 2>&1 || { echo "build failed"; exit 1; }
+TARBALL="$(cd "$PKG_DIR" && npm pack --pack-destination "$TARBALL_DIR" 2>/dev/null | tail -1)"
+TARBALL="$TARBALL_DIR/$TARBALL"
+[ -f "$TARBALL" ] || { echo "pack failed"; exit 1; }
+
+plant_split () {
+  local rn_dir
+  rn_dir=$(node -e 'console.log(require("module").createRequire(process.cwd()+"/package.json").resolve("react-native"))' 2>/dev/null | xargs dirname 2>/dev/null)
+  [ -z "$rn_dir" ] && return 1
+  mkdir -p "$rn_dir/node_modules/react"
+  cp -R node_modules/react/. "$rn_dir/node_modules/react/" 2>/dev/null
+}
+
+run_pm () {
+  local pm="$1" install_cmd="$2"
+  command -v "$pm" >/dev/null 2>&1 || { echo "$pm | SKIPPED (not installed)" | tee -a "$SUMMARY"; return; }
+  local dir="$WORK/$pm"
+  rm -rf "$dir"; mkdir -p "$dir"
+  cp "$PKG_DIR/pm-matrix/template/"*.tsx "$PKG_DIR/pm-matrix/template/"*.mts "$dir/"
+  sed "s#__TARBALL__#$TARBALL#" "$PKG_DIR/pm-matrix/template/package.json" > "$dir/package.json"
+  cd "$dir" || return
+
+  echo "[$pm] installing…"
+  if ! eval "$install_cmd" >"$dir/install.log" 2>&1; then
+    echo "$pm | INSTALL FAILED" | tee -a "$SUMMARY"; tail -15 "$dir/install.log"; return
+  fi
+
+  ./node_modules/.bin/vitest run >"$dir/test-clean.log" 2>&1; local a=$?
+  local rc_clean; rc_clean=$(find node_modules -path '*/react/package.json' | wc -l | tr -d ' ')
+
+  plant_split
+  local rc_split; rc_split=$(find node_modules -path '*/react/package.json' | wc -l | tr -d ' ')
+  ./node_modules/.bin/vitest run >"$dir/test-split.log" 2>&1; local b=$?
+
+  local sa sb; [ $a -eq 0 ] && sa=PASS || sa=FAIL; [ $b -eq 0 ] && sb=PASS || sb=FAIL
+  echo "$pm | clean(react=$rc_clean): $sa | split(react=$rc_split): $sb" | tee -a "$SUMMARY"
+}
+
+run_pm npm  "npm install --no-audit --no-fund"
+run_pm pnpm "pnpm install"
+run_pm bun  "bun install"
+
+echo
+echo "================ PM RESOLUTION MATRIX ================"
+cat "$SUMMARY"
+echo "(logs under $WORK)"
+# Non-zero exit if any scenario failed.
+grep -q "FAIL" "$SUMMARY" && exit 1 || exit 0

--- a/packages/vitest-native/pm-matrix/run.sh
+++ b/packages/vitest-native/pm-matrix/run.sh
@@ -57,6 +57,13 @@ run_pm () {
 
   plant_split
   local rc_split; rc_split=$(find node_modules -path '*/react/package.json' | wc -l | tr -d ' ')
+  # Guard against a vacuous "split" run: if planting did not actually add a second
+  # physical react, the scenario is just a second clean install and a PASS proves
+  # nothing. Fail loudly instead.
+  if [ "$rc_split" -le "$rc_clean" ]; then
+    echo "$pm | clean(react=$rc_clean): — | split: PLANT FAILED (react still $rc_split, expected >$rc_clean)" | tee -a "$SUMMARY"
+    return
+  fi
   ./node_modules/.bin/vitest run >"$dir/test-split.log" 2>&1; local b=$?
 
   local sa sb; [ $a -eq 0 ] && sa=PASS || sa=FAIL; [ $b -eq 0 ] && sb=PASS || sb=FAIL

--- a/packages/vitest-native/pm-matrix/template/Counter.test.tsx
+++ b/packages/vitest-native/pm-matrix/template/Counter.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { useState } from "react";
+import { render, screen, fireEvent } from "@testing-library/react-native";
+import { View, Text, Pressable } from "react-native";
+
+function Counter() {
+  const [n, setN] = useState(0);
+  return (
+    <View>
+      <Text>count: {n}</Text>
+      <Pressable onPress={() => setN((x) => x + 1)}>
+        <Text>inc</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+describe("native engine across package managers", () => {
+  // Hooks (useState) are the canary: a dual-React install resolves two copies and
+  // the hooks dispatcher is null → "Cannot read properties of null (reading 'use…')".
+  it("renders hook state", () => {
+    render(<Counter />);
+    expect(screen.getByText("count: 0")).toBeTruthy();
+  });
+  it("updates state via fireEvent (real Pressable + React reconciliation)", () => {
+    render(<Counter />);
+    fireEvent.press(screen.getByText("inc"));
+    expect(screen.getByText("count: 1")).toBeTruthy();
+  });
+});

--- a/packages/vitest-native/pm-matrix/template/package.json
+++ b/packages/vitest-native/pm-matrix/template/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "pm-matrix-repro",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@babel/core": "^7.25.0",
+    "@react-native/babel-preset": "0.85.3",
+    "@testing-library/react-native": "13.3.0",
+    "react": "19.2.3",
+    "react-native": "0.85.3",
+    "react-test-renderer": "19.2.3",
+    "vitest": "4.1.8",
+    "vitest-native": "file:__TARBALL__"
+  }
+}

--- a/packages/vitest-native/pm-matrix/template/vitest.config.mts
+++ b/packages/vitest-native/pm-matrix/template/vitest.config.mts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+import { reactNative } from "vitest-native";
+
+export default defineConfig({
+  plugins: [reactNative({ engine: "native" })],
+  test: { globals: true, environment: "node", include: ["*.test.tsx"] },
+});

--- a/packages/vitest-native/src/native/hooks.mjs
+++ b/packages/vitest-native/src/native/hooks.mjs
@@ -14,6 +14,14 @@ const RN_PATH = /[\\/](react-native|@react-native)[\\/]/;
 // Metro, which resolves platform variants project-wide. See loader.mjs for the
 // ESM-path counterpart and the @react-navigation silent-failure this prevents.
 const NODE_MODULES = /[\\/]node_modules[\\/]/;
+// The React singleton family. React stores its hooks dispatcher (and other
+// internals) as module-level state, so two physical copies = two dispatchers =
+// "Invalid hook call". Vitest's `resolve.dedupe` enforces a single copy in the
+// Vite graph, but externalized RN loads through Node — outside that dedupe — so a
+// duplicated react on disk (monorepo, version skew, pnpm/bun strict stores) makes
+// RN bind a DIFFERENT react than the test/renderer and every render crashes. We
+// re-establish the single instance here, at the Node boundary.
+const REACT_SINGLETON = /^(react|react-is|scheduler)(\/|$)/;
 
 // Guarded via globalThis, not module scope: under the hot runtime this module
 // can be evaluated twice in one worker (once by the worker entry through Node's
@@ -66,8 +74,31 @@ export function installRequireHooks(
     return origLoad.call(this, request, parent, ...rest);
   };
 
+  // Canonical resolver rooted at the project, so React-family requests from
+  // anywhere in the externalized Node graph collapse onto the project's single
+  // copy (the same one the test/renderer graph uses). Resolutions are cached.
+  const rootRequire = Module.createRequire(path.join(projectRoot, "package.json"));
+  const reactSingletonCache = new Map();
+  function resolveReactSingleton(request) {
+    if (reactSingletonCache.has(request)) return reactSingletonCache.get(request);
+    let resolved = null;
+    try {
+      resolved = rootRequire.resolve(request);
+    } catch {}
+    reactSingletonCache.set(request, resolved);
+    return resolved;
+  }
+
   const origResolve = Module._resolveFilename;
   Module._resolveFilename = function (request, parent, ...rest) {
+    // React-singleton dedupe: a `react`/`react-is`/`scheduler` require reaching
+    // Node's loader comes from the externalized graph (the Vite graph never hits
+    // Module._resolveFilename). Pin it to the project's canonical copy so RN and
+    // the test share one React instance regardless of on-disk duplication.
+    if (REACT_SINGLETON.test(request)) {
+      const canonical = resolveReactSingleton(request);
+      if (canonical) return canonical;
+    }
     if (
       parent &&
       parent.filename &&

--- a/packages/vitest-native/src/native/loader.mjs
+++ b/packages/vitest-native/src/native/loader.mjs
@@ -1,6 +1,7 @@
 // Node ESM loader hook (registered via module.register). Intercepts import() of RN —
 // which Module._extensions cannot — Flow-stripping and serving boundary mock source.
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { createRequire } from "node:module";
 import path from "node:path";
 import fs from "node:fs";
 import { transformRN, isFlow } from "./transform.mjs";
@@ -17,6 +18,10 @@ const RN_PATH = /[\\/](react-native|@react-native)[\\/]/;
 const NODE_MODULES = /[\\/]node_modules[\\/]/;
 // React Native's main entry (`react-native/index.js`).
 const RN_INDEX = /[\\/]react-native[\\/]index\.js$/;
+// The React singleton family — see hooks.mjs. Externalized ESM libs that
+// `import React from 'react'` must bind the project's single copy too, or RN and
+// the test graph split React and every render throws "Invalid hook call".
+const REACT_SINGLETON = /^(react|react-is|scheduler)(\/|$)/;
 const TRANSFORMABLE = /\.(jsx?|tsx?|mjs|cjs)$/;
 // Extensions/index candidates for bundler-style extensionless resolution.
 const RESOLVE_EXTS = [".js", ".cjs", ".mjs", ".json", ".jsx", ".ts", ".tsx"];
@@ -50,6 +55,20 @@ let presetExports = {};
 // Asset file extensions (without leading dot, lower-cased) the loader should stub.
 let assetExtSet = new Set();
 
+// Lazily-built canonical resolver + cache for the React singleton family.
+let _rootRequire = null;
+const reactSingletonCache = new Map();
+function resolveReactSingleton(specifier) {
+  if (reactSingletonCache.has(specifier)) return reactSingletonCache.get(specifier);
+  if (!_rootRequire) _rootRequire = createRequire(path.join(PROJECT_ROOT, "package.json"));
+  let resolved = null;
+  try {
+    resolved = _rootRequire.resolve(specifier);
+  } catch {}
+  reactSingletonCache.set(specifier, resolved);
+  return resolved;
+}
+
 export async function initialize(data) {
   if (data && data.projectRoot) PROJECT_ROOT = data.projectRoot;
   if (data && data.platform === "android") PLATFORM = "android";
@@ -61,6 +80,14 @@ export async function initialize(data) {
 }
 
 export async function resolve(specifier, context, nextResolve) {
+  // React-singleton dedupe (ESM): pin any react/react-is/scheduler import from the
+  // externalized graph to the project's canonical copy, so RN and the test share
+  // one React instance regardless of on-disk duplication (see hooks.mjs).
+  if (REACT_SINGLETON.test(specifier)) {
+    const canonical = resolveReactSingleton(specifier);
+    if (canonical) return { url: pathToFileURL(canonical).href, shortCircuit: true };
+  }
+
   // Preset redirect (ESM): a bare import of a preset package — whether from the
   // test graph or, crucially, nested inside an externalized third-party lib — is
   // redirected to a synthetic module that re-exports the runtime preset mock. This

--- a/packages/vitest-native/src/native/loader.mjs
+++ b/packages/vitest-native/src/native/loader.mjs
@@ -55,7 +55,10 @@ let presetExports = {};
 // Asset file extensions (without leading dot, lower-cased) the loader should stub.
 let assetExtSet = new Set();
 
-// Lazily-built canonical resolver + cache for the React singleton family.
+// Lazily-built canonical resolver + cache for the React singleton family. Lazy
+// (unlike hooks.mjs, which gets projectRoot as a call argument) because the
+// loader learns PROJECT_ROOT only in initialize(), which runs before the first
+// resolve() but after this module is evaluated.
 let _rootRequire = null;
 const reactSingletonCache = new Map();
 function resolveReactSingleton(specifier) {


### PR DESCRIPTION
## Problem

The native engine externalizes React Native and loads it through Node, outside Vite's module graph. Vite's `resolve.dedupe` (which the native engine sets for `react`, `react-test-renderer`, `react-is`) therefore does **not** reach React Native's own `require('react')`.

When a project resolves more than one physical copy of `react` on disk — common with pnpm and Bun strict stores, monorepos, or version skew between `react` and the renderer — React Native binds a *different* React instance than the test renderer. React stores its hooks dispatcher as module-level state, so two instances means two dispatchers, and every render fails with:

```
Invalid hook call. Hooks can only be called inside of the body of a function component.
```

This is latent for single-copy installs (npm hoisting tends to converge on one copy) but reproducible as soon as React duplicates.

## Fix

Pin the React singleton family (`react`, `react-is`, `scheduler`) to the project's canonical copy whenever it is requested from the externalized graph, in both resolution hooks:

- `src/native/hooks.mjs` — `Module._resolveFilename` (CJS require path)
- `src/native/loader.mjs` — the ESM `resolve` hook (externalized ESM libs)

Requests are resolved once from the project root and cached. The Vite/test graph never hits these Node hooks, so application and test code are unaffected — this only re-establishes for the externalized graph the same single-instance guarantee `resolve.dedupe` already provides for the Vite graph.

## Reproduction & verification

A new `packages/vitest-native/pm-matrix/` harness installs a minimal React Native + RNTL suite under **npm, pnpm, and Bun**, in two scenarios:

- **clean** — a normal single-React install
- **split** — a second physical `react` planted inside `react-native`'s own `node_modules`

| Manager | clean | split (before) | split (after) |
| --- | --- | --- | --- |
| npm | pass | **Invalid hook call** | pass |
| pnpm | pass | **Invalid hook call** | pass |
| Bun | pass | **Invalid hook call** | pass |

`bash pm-matrix/run.sh` reproduces all six cells. The native and hot test suites remain 120/120 green.