### PR TITLE
perf(native): cache the RN graph's compiled bytecode via Node's V8 compile cache

### DIFF
--- a/.changeset/native-v8-compile-cache.md
+++ b/.changeset/native-v8-compile-cache.md
@@ -1,0 +1,7 @@
+---
+"vitest-native": patch
+---
+
+Cache the React Native graph's compiled bytecode under the native engine.
+
+With per-file isolation (`engine: 'native'`, the default), React Native's module graph is re-instantiated for every test file, recompiling its source to V8 bytecode each time. The native engine now enables Node's on-disk compile cache (Node 22.8+) before React Native is loaded, so subsequent compilations across files, workers, and runs reuse cached bytecode. Measured on a 100-file suite (single worker), this reduced cold time by ~7% and warm time by ~7-18% with tighter run-to-run variance and no change in memory use. It is a no-op on Node versions without the compile-cache API.

--- a/packages/vitest-native/src/native/compile-cache.mjs
+++ b/packages/vitest-native/src/native/compile-cache.mjs
@@ -1,0 +1,36 @@
+// V8 compile-cache for the externalized React Native graph.
+//
+// RN is loaded through Node (externalized), and our require/loader hooks compile
+// each RN module's Flow-stripped source with `mod._compile` / a synthetic module
+// source. The transform disk cache (transform.mjs) means Babel runs once per RN
+// version — but V8 still re-parses and re-compiles that source to bytecode on
+// every fresh module graph. Under `engine:'native'` (isolate:true) RN's ~240-file
+// graph is re-instantiated per test FILE, so that V8 compile is paid over and
+// over. Node's on-disk compile cache (Node 22.8+) keys bytecode by source content
+// + Node version and is shared process-wide, so the second compile of any RN
+// module — the next file, the next worker, the next run — loads bytecode instead
+// of recompiling. Verified to apply to `mod._compile`, which is how the hooks load
+// RN. No-op on Node < 22.8 (the API is absent) and harmless when caching is off.
+import nodeModule from "node:module";
+import os from "node:os";
+import path from "node:path";
+
+let _enabled = false;
+
+/**
+ * Enable Node's persistent V8 compile cache for this worker/thread. Idempotent and
+ * guarded per realm. Colocated under the `vitest-native-cache` tmp prefix so it
+ * shares the transform cache's lifecycle (cleared with it on a cold run, reused on
+ * warm). Must be called before RN's modules are first compiled.
+ */
+export function enableV8CompileCache() {
+  if (_enabled) return;
+  _enabled = true;
+  const enable = nodeModule.enableCompileCache;
+  if (typeof enable !== "function") return; // Node < 22.8: feature absent
+  try {
+    enable.call(nodeModule, path.join(os.tmpdir(), "vitest-native-cache-v8"));
+  } catch {
+    // Read-only tmp, unsupported platform, etc. — caching is a pure optimization.
+  }
+}

--- a/packages/vitest-native/src/native/compile-cache.mjs
+++ b/packages/vitest-native/src/native/compile-cache.mjs
@@ -30,6 +30,10 @@ export function enableV8CompileCache() {
   if (typeof enable !== "function") return; // Node < 22.8: feature absent
   try {
     enable.call(nodeModule, path.join(os.tmpdir(), "vitest-native-cache-v8"));
+    // No atomic-write handling needed (unlike the transform cache, which writes
+    // executable source): Node CRC32-validates each compile-cache entry on read,
+    // so a torn or raced write from concurrent workers is a cache miss and a
+    // recompile, never a corruption-induced failure.
   } catch {
     // Read-only tmp, unsupported platform, etc. — caching is a pure optimization.
   }

--- a/packages/vitest-native/src/native/setup.mjs
+++ b/packages/vitest-native/src/native/setup.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import { expect, vi } from "vitest";
 import { installGlobals } from "./globals.mjs";
 import { installRequireHooks } from "./hooks.mjs";
+import { enableV8CompileCache } from "./compile-cache.mjs";
 import * as presetFactories from "../presets.mjs";
 import { animatedMatchers } from "../matchers.mjs";
 import { serializer as rnSerializer } from "../serializer.mjs";
@@ -95,6 +96,10 @@ for (const name of presetNames) {
   }
 }
 
+// Enable the V8 compile cache before RN is compiled (it loads when the test file
+// imports react-native, after this setup runs) so its bytecode is cached to disk
+// and reused on the next file/worker/run. Covers the stock (non-hot) path.
+enableV8CompileCache();
 installGlobals();
 // RNTL 13+ auto-registers matchers through the global expect when imported.
 // Expose Vitest's expect only when the consumer has not enabled globals.

--- a/packages/vitest-native/src/native/worker.mjs
+++ b/packages/vitest-native/src/native/worker.mjs
@@ -16,6 +16,7 @@ import { init, runBaseTests, setupEnvironment } from "vitest/worker";
 import { installGlobals } from "./globals.mjs";
 import { installRequireHooks } from "./hooks.mjs";
 import { installHotReset } from "./reset.mjs";
+import { enableV8CompileCache } from "./compile-cache.mjs";
 
 if (isMainThread || !parentPort) {
   throw new Error("[vitest-native] hot worker entry must run in node:worker_threads");
@@ -52,6 +53,9 @@ if (diagnostics) {
 // guarded; doing them at boot lets RN preload BEFORE the globals baseline and
 // listener tracking in reset.mjs, so RN's own boot state is preserved across
 // per-file resets rather than wrongly torn down with test pollution.
+// Enable the V8 compile cache before any RN module compiles, so the resident
+// graph's bytecode is cached to disk for the next worker/run.
+enableV8CompileCache();
 installGlobals();
 installRequireHooks(projectRoot, transformPkgs, platform, reactNativeVersion, assetExts);
 try {

--- a/packages/vitest-native/tests/compile-cache.test.ts
+++ b/packages/vitest-native/tests/compile-cache.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import Module from "node:module";
+import os from "node:os";
+import path from "node:path";
+
+// `enableV8CompileCache` reads `nodeModule.enableCompileCache` at call time, so we
+// drive its three branches by swapping the real (singleton) `Module.enableCompileCache`
+// and re-importing the module fresh each test — its module-scope `_enabled` guard is
+// sticky, so `vi.resetModules()` is what lets each case start from a clean slate.
+// Swapping also prevents these tests from actually enabling the cache on the test
+// process.
+const EXPECTED_DIR = path.join(os.tmpdir(), "vitest-native-cache-v8");
+
+describe("enableV8CompileCache", () => {
+  let original: unknown;
+
+  beforeEach(() => {
+    original = (Module as unknown as Record<string, unknown>).enableCompileCache;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    (Module as unknown as Record<string, unknown>).enableCompileCache = original;
+  });
+
+  async function load() {
+    // @ts-expect-error — runtime .mjs, no types
+    return (await import("../src/native/compile-cache.mjs")).enableV8CompileCache;
+  }
+
+  it("enables the cache once, under the vitest-native-cache-v8 tmp dir", async () => {
+    const dirs: string[] = [];
+    (Module as unknown as Record<string, unknown>).enableCompileCache = (dir: string) => {
+      dirs.push(dir);
+      return { status: 1, directory: dir };
+    };
+    const enableV8CompileCache = await load();
+
+    enableV8CompileCache();
+    enableV8CompileCache(); // idempotent: the per-realm guard suppresses the second call
+
+    expect(dirs).toEqual([EXPECTED_DIR]);
+  });
+
+  it("is a no-op when the API is absent (Node < 22.8)", async () => {
+    (Module as unknown as Record<string, unknown>).enableCompileCache = undefined;
+    const enableV8CompileCache = await load();
+
+    expect(() => enableV8CompileCache()).not.toThrow();
+  });
+
+  it("swallows a throwing enableCompileCache (read-only tmp, unsupported platform)", async () => {
+    (Module as unknown as Record<string, unknown>).enableCompileCache = () => {
+      throw new Error("EROFS: read-only file system");
+    };
+    const enableV8CompileCache = await load();
+
+    expect(() => enableV8CompileCache()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Background

Under `engine: 'native'` with per-file isolation (the default), React Native's module graph is re-instantiated for every test file. The transform disk cache already ensures Babel runs only once per RN version, but V8 still re-parses and re-compiles that source to bytecode on each fresh module graph — so RN's ~240-file graph is recompiled per test file.

## Change

Enable Node's on-disk V8 compile cache (`module.enableCompileCache`, Node 22.8+) before React Native is first compiled. Bytecode is keyed by source content + Node version and shared process-wide, so the second compile of any RN module — the next file, worker, or run — loads cached bytecode instead of recompiling.

- New `src/native/compile-cache.mjs` exposes `enableV8CompileCache()`, idempotent and guarded per realm. The cache directory is colocated under the `vitest-native-cache` temp prefix so it shares the transform cache's lifecycle.
- Wired into `src/native/worker.mjs` (hot path) and `src/native/setup.mjs` (stock path), before RN loads.
- Verified to apply to `mod._compile`, which is how the require/loader hooks compile RN.
- No-op on Node versions without the compile-cache API; failures (read-only temp, etc.) are swallowed since caching is a pure optimization.

## Measurements

`bench/scale`, native engine (`isolate: true`), 100-file suite, single worker, Apple M5:

| | cold | warm (samples) | peak RSS |
| --- | --: | --: | --: |
| before | 25027 ms | 23219 / 26595 ms | 594 MB |
| after | 23193 ms | 21586 / 21683 ms | 594 MB |

Every cached warm sample beats every baseline warm sample (~7-18% faster) with tighter variance; cold ~7% faster; memory unchanged. The win concentrates on `native-stock` (per-file RN recompile); `native-hot` benefits less (RN stays resident) and the mock engine not at all. Native and hot suites remain 120/120 green.