### PR TITLE
fix: update regex patterns to include node_modules for react-native folder

### DIFF
--- a/.changeset/native-rn-path-node-modules-scope.md
+++ b/.changeset/native-rn-path-node-modules-scope.md
@@ -1,0 +1,13 @@
+---
+"vitest-native": patch
+---
+
+Scope React Native path detection to `node_modules`. The native engine identified
+React Native package files with the regex `/[\\/]react-native[\\/]/`, which also
+matched any project checked out under a directory named `react-native` (for example
+`/home/runner/work/react-native/react-native/` in CI for a repo named `react-native`).
+Every project file then matched, so `.tsx` test files were externalized and sent raw
+to Node (`Unknown file extension ".tsx"`) and `vi.mock()` calls stopped hoisting.
+The matchers in `apply.ts`, `loader.mjs`, and `hooks.mjs` now require a
+`node_modules/` segment, which still matches real RN and `@react-native/*` packages
+(including pnpm-nested layouts) without false-matching project paths.

--- a/packages/vitest-native/src/native/apply.ts
+++ b/packages/vitest-native/src/native/apply.ts
@@ -67,7 +67,11 @@ export function nativeEngineConfig(
         : { pool: "threads" as const }),
       server: {
         deps: {
-          external: [/[\\/]node_modules[\\/]react-native[\\/]/, /[\\/]node_modules[\\/]@react-native[\\/]/, ...extraExternal],
+          external: [
+            /[\\/]node_modules[\\/]react-native[\\/]/,
+            /[\\/]node_modules[\\/]@react-native[\\/]/,
+            ...extraExternal,
+          ],
         },
       },
     },

--- a/packages/vitest-native/src/native/apply.ts
+++ b/packages/vitest-native/src/native/apply.ts
@@ -67,7 +67,7 @@ export function nativeEngineConfig(
         : { pool: "threads" as const }),
       server: {
         deps: {
-          external: [/[\\/]react-native[\\/]/, /[\\/]@react-native[\\/]/, ...extraExternal],
+          external: [/[\\/]node_modules[\\/]react-native[\\/]/, /[\\/]node_modules[\\/]@react-native[\\/]/, ...extraExternal],
         },
       },
     },

--- a/packages/vitest-native/src/native/hooks.mjs
+++ b/packages/vitest-native/src/native/hooks.mjs
@@ -8,7 +8,7 @@ import { boundarySourceFor } from "./boundary.mjs";
 import { resolvePlatformFile } from "./resolve.mjs";
 import { buildPkgMatcher } from "./match.mjs";
 
-const RN_PATH = /[\\/](react-native|@react-native)[\\/]/;
+const RN_PATH = /[\\/]node_modules[\\/](react-native|@react-native)[\\/]/;
 // Any file under a node_modules directory. Platform-extension resolution
 // (`.native.js` etc.) applies to every node_modules package, not just RN — matching
 // Metro, which resolves platform variants project-wide. See loader.mjs for the

--- a/packages/vitest-native/src/native/loader.mjs
+++ b/packages/vitest-native/src/native/loader.mjs
@@ -8,7 +8,7 @@ import { boundarySourceFor } from "./boundary.mjs";
 import { resolvePlatformFile } from "./resolve.mjs";
 import { buildPkgMatcher } from "./match.mjs";
 
-const RN_PATH = /[\\/](react-native|@react-native)[\\/]/;
+const RN_PATH = /[\\/]node_modules[\\/](react-native|@react-native)[\\/]/;
 // Any file living under a node_modules directory. Platform-extension resolution
 // (`.native.js` etc.) applies to every node_modules package, not just RN, matching
 // Metro — which resolves platform variants project-wide. (Without this, e.g.

--- a/packages/vitest-native/tests/native-unit.test.ts
+++ b/packages/vitest-native/tests/native-unit.test.ts
@@ -238,6 +238,27 @@ describe("plugin engine routing", () => {
     expect(plugin.resolveId("react-native", undefined)).toBeUndefined();
   });
 
+  it("externalizes RN only under node_modules, not a project named react-native", async () => {
+    const plugin = reactNative({ engine: "native" }) as any;
+    const cfg = await plugin.config({ root: projectRoot }, SERVE_ENV);
+    const external: RegExp[] = cfg.test.server.deps.external;
+    const matches = (p: string) => external.some((re) => re instanceof RegExp && re.test(p));
+
+    // A repo literally named `react-native` (e.g. checked out at
+    // /home/runner/work/react-native/react-native/ in CI): test files must NOT be
+    // externalized, otherwise `.tsx` is sent raw to Node and vi.mock() stops hoisting.
+    expect(matches("/home/runner/work/react-native/react-native/__tests__/foo.test.tsx")).toBe(
+      false,
+    );
+    // Real RN (and @react-native/* scoped packages), including pnpm-nested layouts,
+    // must still be externalized.
+    expect(matches("/proj/node_modules/react-native/index.js")).toBe(true);
+    expect(matches("/proj/node_modules/@react-native/assets-registry/registry.js")).toBe(true);
+    expect(
+      matches("/proj/node_modules/.pnpm/react-native@0.81.0/node_modules/react-native/index.js"),
+    ).toBe(true);
+  });
+
   it("rejects mock-only top-level overrides when native is selected", async () => {
     const plugin = reactNative({
       engine: "native",


### PR DESCRIPTION
## Description

Hi, thank you for the great lib! I use it in my personal project. However I found an issue that was surprisingly happening in my CI pipeline. It looks like this:

```
 FAIL  __tests__/component-tests/patient-item.test.tsx [ __tests__/component-tests/patient-item.test.tsx ]
TypeError: Unknown file extension ".tsx" for /home/runner/work/react-native/react-native/__tests__/component-tests/patient-item.test.tsx
 ❯ load node_modules/vitest-native/dist/native/loader.mjs:193:12
 ```
 
 BUT on my local machine (MacOS), it works.

So I did the investigation, found and fixed the root cause. Here's what was happening:

- My repository was named `react-native`. On my local machine, the project folder is renamed to `xxx-mobile`.

- Root cause: vitest-native uses the regex `/[\\/]react-native[\\/]/` in several places to identify React Native package files. On CI, your repository is checked out into `/home/runner/work/react-native/react-native/`, so every file in the project matches this overly broad regex. This causes two problems:

1. `.tsx` files fail to load: Vitest's `server.deps.external` config externalizes all files under a `/react-native/` path, so .tsx test files are sent directly to Node.js without transformation. Node doesn't know how to load .tsx, hence Unknown file extension ".tsx".
2. Mock failures: Because the test files themselves are externalized, Vitest doesn't process them through its module graph, so `vi.mock()` calls aren't hoisted and external packages like `libphonenumber-js` load as real modules instead of mocks.

## Checklist

- [x] Tests pass (`bun run test`)
- [x] Lint passes (`bun run lint`)
- [x] Changeset added (if user-facing change): `bunx changeset`
- [x] Docs updated (if API changed)
