### PR TITLE
docs: add contributors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,12 @@ bun run --filter vitest-native build
 bun run --filter vitest-native test
 ```
 
+## Contributors
+
+Thanks to everyone who has contributed 💙
+
+[![Contributors](https://contrib.rocks/image?repo=danfry1/vitest-native)](https://github.com/danfry1/vitest-native/graphs/contributors)
+
 ## License
 
 MIT


### PR DESCRIPTION
Adds an auto-updating Contributors section above the License, recognizing everyone who has contributed. The avatar strip renders from the GitHub contributors API (via contrib.rocks) and links to the contributors graph, so it stays current with no manual maintenance.

Complements the per-change credits already in the changelog (e.g. #50).