### PR TITLE
docs: fix broken contributors image (use GitHub-hosted avatars)

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ bun run --filter vitest-native test
 
 ## Contributors
 
-Thanks to everyone who has contributed 💙
+Thanks to everyone who has contributed.
 
 [<img src="https://github.com/danfry1.png?size=80" width="56" height="56" alt="@danfry1" />](https://github.com/danfry1)
 [<img src="https://github.com/jakeboone02.png?size=80" width="56" height="56" alt="@jakeboone02" />](https://github.com/jakeboone02)

--- a/README.md
+++ b/README.md
@@ -405,7 +405,11 @@ bun run --filter vitest-native test
 
 Thanks to everyone who has contributed 💙
 
-[![Contributors](https://contrib.rocks/image?repo=danfry1/vitest-native)](https://github.com/danfry1/vitest-native/graphs/contributors)
+[<img src="https://github.com/danfry1.png?size=80" width="56" height="56" alt="@danfry1" />](https://github.com/danfry1)
+[<img src="https://github.com/jakeboone02.png?size=80" width="56" height="56" alt="@jakeboone02" />](https://github.com/jakeboone02)
+[<img src="https://github.com/Doko-Demo-Doa.png?size=80" width="56" height="56" alt="@Doko-Demo-Doa" />](https://github.com/Doko-Demo-Doa)
+
+See the full list on the [contributors graph](https://github.com/danfry1/vitest-native/graphs/contributors).
 
 ## License
 


### PR DESCRIPTION
The `contrib.rocks` image added in #53 is timing out (verified HTTP 000 / full timeout — the service is unreachable), leaving a broken image on the README. Replace it with GitHub-hosted contributor avatars (`github.com/<user>.png`, reliably served and proxy-friendly) that link to each profile, plus a link to the contributors graph for the always-current full list.

Reliable visuals + a list that never goes stale, with no third-party image dependency.