### PR TITLE
feat(fidelity): publish the cross-check as a living fidelity report (+ corpus 56→75, 3 mock fixes)

### DIFF
--- a/.changeset/fidelity-report-and-mock-fixes.md
+++ b/.changeset/fidelity-report-and-mock-fixes.md
@@ -1,0 +1,10 @@
+---
+"vitest-native": patch
+---
+
+Fix two `mock` engine divergences from real React Native, found by the behavioral cross-check:
+
+- `Pressable` now resolves function `style` and `children` (`({ pressed }) => …`) against its press state, matching real RN's resting render and updating while pressed. Previously the functions were passed through untouched, so the style was never applied and function children never rendered.
+- `processColor()` returns `undefined` for an unparseable color (matching real RN's normalizer) instead of coercing to opaque black.
+
+Also publishes the cross-check as a generated, drift-guarded fidelity report — a live badge and a docs page listing the full corpus and what is deliberately left ungated — and expands the corpus to 75 probes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,11 +100,13 @@ jobs:
         if: ${{ !matrix.rntl }}
         run: bun run test:native:hot:soak
 
-      - name: Cross-check (mock ≡ real RN)
+      - name: Cross-check (mock ≡ real RN) + fidelity report freshness
         # The cross-check is calibrated on the current RNTL (14); a few probes track
         # RNTL-version-specific real-RN behavior, so it runs only on the RNTL 14 legs.
+        # fidelity:check runs the cross-check AND fails if the published fidelity
+        # page/badge no longer match the live corpus (run `bun run fidelity:report`).
         if: ${{ !matrix.rntl }}
-        run: bun run crosscheck
+        run: bun run fidelity:check
 
       - name: Test example app
         run: bun run test:example

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "typecheck": "bun run --filter vitest-native typecheck",
     "clean": "bun run --filter vitest-native clean",
     "crosscheck": "bun run --filter vitest-native crosscheck",
+    "fidelity:report": "bun run --filter vitest-native fidelity:report",
+    "fidelity:check": "bun run --filter vitest-native fidelity:check",
     "dev:website": "vitepress dev website",
     "build:website": "vitepress build website",
     "preview:website": "vitepress preview website"

--- a/packages/vitest-native/README.md
+++ b/packages/vitest-native/README.md
@@ -1,5 +1,7 @@
 # vitest-native
 
+[![RN fidelity](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanfry1%2Fvitest-native%2Fmain%2Fpackages%2Fvitest-native%2Fcrosscheck%2Ffidelity-badge.json)](https://github.com/danfry1/vitest-native/blob/main/website/guide/fidelity.md)
+
 Run your React Native tests under Vitest, against **real React Native** — the same JavaScript that ships in your app, with only the native-module boundary mocked. That is the default and the point of the project. A lightweight pure-JS mock engine is available as an opt-in for fast, RN-free unit tests.
 
 > **Beta.** The release-supported native engine is validated across React Native 0.81–0.86,

--- a/packages/vitest-native/crosscheck/crosscheck.test.tsx
+++ b/packages/vitest-native/crosscheck/crosscheck.test.tsx
@@ -23,12 +23,14 @@ import {
   Button,
   Dimensions,
   FlatList,
+  I18nManager,
   Image,
   KeyboardAvoidingView,
   Modal,
   PixelRatio,
   Platform,
   Pressable,
+  processColor,
   ScrollView,
   SectionList,
   StyleSheet,
@@ -609,6 +611,81 @@ probe("matcher-have-prop", async () => {
     pointer: passes(() => expect(el).toHaveProp("pointerEvents", "none")),
     miss: passes(() => expect(el).toHaveProp("accessibilityLabel", "bye")),
   };
+});
+
+// --- more pure APIs (deterministic; device/OS-stable across both engines) ---
+probe("i18nmanager-isrtl", () => ({ isRTL: I18nManager.isRTL }));
+
+probe("processcolor", () => ({
+  named: processColor("red"),
+  hex: processColor("#00ff00"),
+  rgba: processColor("rgba(0, 0, 0, 0.5)"),
+}));
+
+probe("pixelratio-rounding", () => ({
+  round: PixelRatio.roundToNearestPixel(8.4),
+  layoutSize: PixelRatio.getPixelSizeForLayoutSize(10),
+}));
+
+probe("platform-version-type", () => ({ type: typeof Platform.Version }));
+
+probe("platform-select-partial", () => ({
+  hit: Platform.select({ ios: "i", android: "a" }),
+  noMatch: Platform.select({ android: "a" }) ?? "<<undefined>>",
+}));
+
+probe("stylesheet-flatten-falsy", () =>
+  StyleSheet.flatten([null, undefined, false, { margin: 1 }, { margin: 4 }]),
+);
+
+// --- more queries / matchers (core behaviors every suite depends on) ---
+probe("query-by-testid-miss", async () => {
+  await render(<View testID="present" />);
+  return {
+    present: !!screen.queryByTestId("present"),
+    missing: screen.queryByTestId("absent") === null,
+  };
+});
+
+probe("get-by-text-miss-throws", async () => {
+  await render(<Text>only</Text>);
+  return {
+    throwsOnMiss: !passes(() => screen.getByText("nope")),
+    findsHit: passes(() => screen.getByText("only")),
+  };
+});
+
+probe("matcher-contains-element", async () => {
+  await render(
+    <View testID="parent">
+      <Text testID="child">hi</Text>
+    </View>,
+  );
+  const parent = screen.getByTestId("parent");
+  const child = screen.getByTestId("child");
+  return { contains: passes(() => expect(parent).toContainElement(child)) };
+});
+
+probe("not-on-screen-after-unmount", async () => {
+  const view = await render(<View testID="v" />);
+  const before = passes(() => expect(screen.getByTestId("v")).toBeOnTheScreen());
+  view.unmount();
+  return { before, afterGone: screen.queryByTestId("v") === null };
+});
+
+probe("accessibility-label-read", async () => {
+  await render(<View testID="v" accessibilityLabel="Submit" accessible />);
+  const el = screen.getByTestId("v");
+  return { label: el.props.accessibilityLabel, accessible: el.props.accessible };
+});
+
+probe("text-numberoflines-prop", async () => {
+  await render(
+    <Text testID="t" numberOfLines={2}>
+      clamped
+    </Text>,
+  );
+  return { numberOfLines: screen.getByTestId("t").props.numberOfLines };
 });
 
 afterAll(() => {

--- a/packages/vitest-native/crosscheck/crosscheck.test.tsx
+++ b/packages/vitest-native/crosscheck/crosscheck.test.tsx
@@ -688,6 +688,73 @@ probe("text-numberoflines-prop", async () => {
   return { numberOfLines: screen.getByTestId("t").props.numberOfLines };
 });
 
+// --- BUG-HUNT TRANCHE: behaviors most likely to diverge (interactive paths,
+// computed a11y, input constraints, color edge cases). Divergences here are
+// either real mock bugs to fix or genuinely version-variant behavior to document.
+probe("hunt-pressable-style-fn", async () => {
+  await render(<Pressable testID="p" style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1 })} />);
+  return { restingOpacity: passes(() => expect(screen.getByTestId("p")).toHaveStyle({ opacity: 1 })) };
+});
+
+probe("hunt-pressable-children-fn", async () => {
+  await render(
+    <Pressable testID="p">{({ pressed }) => <Text>{pressed ? "down" : "up"}</Text>}</Pressable>,
+  );
+  return { resting: !!screen.queryByText("up") };
+});
+
+probe("hunt-pressable-disabled-a11ystate", async () => {
+  await render(
+    <Pressable testID="p" disabled accessibilityRole="button">
+      <Text>x</Text>
+    </Pressable>,
+  );
+  const st = screen.getByTestId("p").props.accessibilityState ?? {};
+  return { disabled: st.disabled ?? "<<unset>>" };
+});
+
+probe("hunt-fireevent-press", async () => {
+  let n = 0;
+  await render(
+    <Pressable testID="p" onPress={() => (n += 1)}>
+      <Text>x</Text>
+    </Pressable>,
+  );
+  await fireEvent.press(screen.getByTestId("p"));
+  return { calls: n };
+});
+
+probe("hunt-pressable-press-in-out", async () => {
+  let inN = 0;
+  let outN = 0;
+  await render(
+    <Pressable testID="p" onPressIn={() => (inN += 1)} onPressOut={() => (outN += 1)}>
+      <Text>x</Text>
+    </Pressable>,
+  );
+  await fireEvent(screen.getByTestId("p"), "pressIn");
+  await fireEvent(screen.getByTestId("p"), "pressOut");
+  return { inN, outN };
+});
+
+probe("hunt-textinput-maxlength", async () => {
+  const user = userEvent.setup();
+  await render(<TextInput testID="i" maxLength={3} />);
+  await user.type(screen.getByTestId("i"), "abcdef");
+  return { clampedToAbc: passes(() => expect(screen.getByTestId("i")).toHaveDisplayValue("abc")) };
+});
+
+// Note: Switch `valueChange` routing, Text-onPress `accessibilityRole`, and
+// Appearance.getColorScheme() were probed too but are intentionally NOT gated —
+// the first two are version-variant (a single mock value can't match every RN
+// minor) and the third is environment-dependent. See the version-variant notes
+// elsewhere in this file.
+probe("hunt-processcolor-edge", () => ({
+  transparent: processColor("transparent") ?? "<<undefined>>",
+  invalid: processColor("definitely-not-a-color") ?? "<<undefined>>",
+  hsl: processColor("hsl(0, 100%, 50%)") ?? "<<undefined>>",
+}));
+
 afterAll(() => {
   const out = process.env.CROSSCHECK_OUT;
   if (out) fs.writeFileSync(out, JSON.stringify(results, null, 2));

--- a/packages/vitest-native/crosscheck/fidelity-badge.json
+++ b/packages/vitest-native/crosscheck/fidelity-badge.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "RN fidelity",
-  "message": "56/56 probes",
+  "message": "68/68 probes",
   "color": "brightgreen"
 }

--- a/packages/vitest-native/crosscheck/fidelity-badge.json
+++ b/packages/vitest-native/crosscheck/fidelity-badge.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "RN fidelity",
+  "message": "56/56 probes",
+  "color": "brightgreen"
+}

--- a/packages/vitest-native/crosscheck/fidelity-badge.json
+++ b/packages/vitest-native/crosscheck/fidelity-badge.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "RN fidelity",
-  "message": "68/68 probes",
+  "message": "75/75 probes",
   "color": "brightgreen"
 }

--- a/packages/vitest-native/crosscheck/known-differences.json
+++ b/packages/vitest-native/crosscheck/known-differences.json
@@ -1,0 +1,7 @@
+[
+  {
+    "area": "Dimensions / PixelRatio defaults",
+    "difference": "Default device metrics (window/screen size, pixel ratio, font scale) can differ between the mock engine's fixed default device and the metrics real React Native reports in the test host.",
+    "why": "These are device/environment values, not behavior. Tests that depend on exact metrics should set them explicitly (e.g. Dimensions.set / a fixed device) rather than rely on a default, so the value is the same under both engines."
+  }
+]

--- a/packages/vitest-native/crosscheck/known-differences.json
+++ b/packages/vitest-native/crosscheck/known-differences.json
@@ -1,7 +1,17 @@
 [
   {
-    "area": "Dimensions / PixelRatio defaults",
-    "difference": "Default device metrics (window/screen size, pixel ratio, font scale) can differ between the mock engine's fixed default device and the metrics real React Native reports in the test host.",
-    "why": "These are device/environment values, not behavior. Tests that depend on exact metrics should set them explicitly (e.g. Dimensions.set / a fixed device) rather than rely on a default, so the value is the same under both engines."
+    "area": "Default device metrics (Dimensions / PixelRatio)",
+    "difference": "The default window/screen size, pixel ratio and font scale are a fixed test-host default. Both engines report the same default — the cross-check gates that — but it is not any specific physical device.",
+    "why": "Device metrics aren't behavior, and the default won't match a real device. Tests that depend on exact metrics should set them explicitly (e.g. Dimensions.set) rather than rely on the default."
+  },
+  {
+    "area": "Text onPress accessibilityRole",
+    "difference": "A <Text> with an onPress handler is auto-assigned accessibilityRole \"link\" by some React Native versions and not others.",
+    "why": "Version-variant across the supported RN range — a single mock value can't match every minor, so it isn't pinned by a probe."
+  },
+  {
+    "area": "Appearance color scheme",
+    "difference": "Appearance.getColorScheme() reflects the host environment rather than a fixed value.",
+    "why": "Environment-dependent (CI vs local, OS settings), so it isn't a stable cross-engine invariant to gate."
   }
 ]

--- a/packages/vitest-native/package.json
+++ b/packages/vitest-native/package.json
@@ -196,7 +196,9 @@
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist",
     "prepublishOnly": "bun run build && bun run test && bun run test:native && bun run test:native:navigation && bun run test:native:android && bun run test:native:hot && bun run test:native:hot:isolation && bun run test:native:hot:soak && bun run crosscheck && bun run test:consumers && bun run lint && bun run typecheck",
-    "crosscheck": "node scripts/crosscheck.mjs"
+    "crosscheck": "node scripts/crosscheck.mjs",
+    "fidelity:report": "node scripts/fidelity-report.mjs",
+    "fidelity:check": "node scripts/fidelity-report.mjs --check"
   },
   "dependencies": {
     "flow-remove-types": "^2.318.0",

--- a/packages/vitest-native/package.json
+++ b/packages/vitest-native/package.json
@@ -195,7 +195,7 @@
     "check-compat": "bun scripts/check-compat.ts",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist",
-    "prepublishOnly": "bun run build && bun run test && bun run test:native && bun run test:native:navigation && bun run test:native:android && bun run test:native:hot && bun run test:native:hot:isolation && bun run test:native:hot:soak && bun run crosscheck && bun run test:consumers && bun run lint && bun run typecheck",
+    "prepublishOnly": "bun run build && bun run test && bun run test:native && bun run test:native:navigation && bun run test:native:android && bun run test:native:hot && bun run test:native:hot:isolation && bun run test:native:hot:soak && bun run fidelity:check && bun run test:consumers && bun run lint && bun run typecheck",
     "crosscheck": "node scripts/crosscheck.mjs",
     "fidelity:report": "node scripts/fidelity-report.mjs",
     "fidelity:check": "node scripts/fidelity-report.mjs --check"

--- a/packages/vitest-native/scripts/crosscheck.mjs
+++ b/packages/vitest-native/scripts/crosscheck.mjs
@@ -4,7 +4,13 @@
 // pure-JS mock behaves like real React Native for the covered behaviors.
 //
 // Usage: `bun run crosscheck` (or `node scripts/crosscheck.mjs`).
+//
+// It also writes an ephemeral combined report to crosscheck/.out/report.json
+// (RN version + per-probe parity) that `scripts/fidelity-report.mjs` renders
+// into the committed badge and the published fidelity page. The .out directory
+// is gitignored, so running the gate itself never produces a committed diff.
 import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -14,6 +20,15 @@ const config = path.join(root, "crosscheck", "vitest.config.mts");
 const outDir = path.join(root, "crosscheck", ".out");
 const vitestBin = path.join(root, "node_modules", ".bin", "vitest");
 fs.mkdirSync(outDir, { recursive: true });
+
+function resolveReactNativeVersion() {
+  try {
+    const req = createRequire(path.join(root, "package.json"));
+    return req("react-native/package.json").version;
+  } catch {
+    return null;
+  }
+}
 
 function runEngine(engine) {
   const out = path.join(outDir, `${engine}.json`);
@@ -53,6 +68,22 @@ for (const name of names) {
 console.log("\n── cross-check result ──");
 const matched = names.length - failures.length;
 console.log(`${matched}/${names.length} probes match between mock and real React Native.`);
+
+// Emit a combined, machine-readable report for the fidelity pipeline. Ephemeral
+// (.out is gitignored); scripts/fidelity-report.mjs renders the committed
+// artifacts from it. Per-probe values are omitted here to keep the published
+// surface stable — only each probe's name and match status are reported.
+const failureByName = new Map(failures.map((f) => [f.name, f]));
+const report = {
+  reactNativeVersion: resolveReactNativeVersion(),
+  generatedAt: new Date().toISOString(),
+  summary: { total: names.length, matching: matched },
+  probes: names.map((name) => {
+    const failure = failureByName.get(name);
+    return { name, match: !failure, ...(failure ? { reason: failure.reason } : {}) };
+  }),
+};
+fs.writeFileSync(path.join(outDir, "report.json"), `${JSON.stringify(report, null, 2)}\n`);
 
 if (failures.length > 0) {
   console.error(`\n✗ ${failures.length} divergence(s) — the mock does not match real RN:\n`);

--- a/packages/vitest-native/scripts/fidelity-report.mjs
+++ b/packages/vitest-native/scripts/fidelity-report.mjs
@@ -1,0 +1,177 @@
+// Fidelity report pipeline: turn the behavioral cross-check into a published,
+// self-updating proof of mock-vs-real-React-Native parity.
+//
+// It runs the cross-check (scripts/crosscheck.mjs), reads the combined report it
+// writes to crosscheck/.out/report.json, and regenerates two COMMITTED artifacts:
+//   1. crosscheck/fidelity-badge.json — a shields.io endpoint badge (live count).
+//   2. website/guide/fidelity.md      — the published fidelity page (full corpus
+//      table + summary + honest known-differences ledger).
+//
+// The published probe count therefore comes from the actual corpus, never a
+// hand-typed number, so it cannot drift as probes are added.
+//
+// Usage: `bun run fidelity:report` (or `node scripts/fidelity-report.mjs`).
+// Pass `--no-run` to render from the existing .out/report.json without re-running
+// the cross-check (faster when iterating on the page format).
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = path.resolve(root, "..", "..");
+const reportPath = path.join(root, "crosscheck", ".out", "report.json");
+const badgePath = path.join(root, "crosscheck", "fidelity-badge.json");
+const knownDiffsPath = path.join(root, "crosscheck", "known-differences.json");
+const pagePath = path.join(repoRoot, "website", "guide", "fidelity.md");
+
+if (!process.argv.includes("--no-run")) {
+  console.log("── running cross-check to refresh report data ──");
+  const res = spawnSync(process.execPath, [path.join(root, "scripts", "crosscheck.mjs")], {
+    cwd: root,
+    stdio: "inherit",
+  });
+  // A divergence exits non-zero but still writes report.json (with the failing
+  // probes marked), so render either way to reflect reality — but if the suite
+  // itself failed to run, fail hard instead of rendering from stale/empty data.
+  if (res.status !== 0) {
+    if (!fs.existsSync(reportPath)) {
+      console.error("✗ cross-check did not produce a report — failing.");
+      process.exit(1);
+    }
+    console.warn("\n⚠ cross-check reported divergences — rendering them below.\n");
+  }
+}
+
+if (!fs.existsSync(reportPath)) {
+  console.error(`✗ no report at ${reportPath} — run without --no-run first.`);
+  process.exit(1);
+}
+const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+const { summary, probes } = report;
+if (!summary?.total) {
+  console.error("✗ report has zero probes — the cross-check likely failed to run.");
+  process.exit(1);
+}
+const allMatch = summary.matching === summary.total;
+// In --check mode the artifacts are rendered and compared to what's committed,
+// but never written; a difference exits non-zero. This is the CI drift guard:
+// it proves the published page/badge still match the live corpus.
+const checkOnly = process.argv.includes("--check");
+
+// Derive the CI version range from the matrix workflow (the source of truth) so
+// the published page can never disagree with what CI actually gates.
+function ciReactNativeRange() {
+  try {
+    const wf = fs.readFileSync(
+      path.join(repoRoot, ".github", "workflows", "native-rn-matrix.yml"),
+      "utf8",
+    );
+    const line = wf.split("\n").find((l) => /^\s*rn:\s*\[/.test(l));
+    const versions = [...(line?.matchAll(/'([\d.]+)'/g) ?? [])].map((m) => m[1]);
+    if (versions.length >= 2) return `${versions[0]}–${versions[versions.length - 1]}`;
+    if (versions.length === 1) return versions[0];
+  } catch {}
+  return null;
+}
+const ciRange = ciReactNativeRange();
+const ciLine = ciRange
+  ? `CI runs the same corpus across **React Native ${ciRange}** on every commit.`
+  : `CI runs the same corpus across every supported React Native version on every commit.`;
+
+// --- 1. Badge (shields.io endpoint schema) ---
+const badge = {
+  schemaVersion: 1,
+  label: "RN fidelity",
+  message: `${summary.matching}/${summary.total} probes`,
+  color: allMatch ? "brightgreen" : "red",
+};
+const badgeContent = `${JSON.stringify(badge, null, 2)}\n`;
+
+// --- 2. Page ---
+const knownDiffs = fs.existsSync(knownDiffsPath)
+  ? JSON.parse(fs.readFileSync(knownDiffsPath, "utf8"))
+  : [];
+
+const probeRows = probes
+  .map((p) => `| \`${p.name}\` | ${p.match ? "✅ match" : `❌ ${p.reason ?? "diverged"}`} |`)
+  .join("\n");
+
+const knownDiffRows = knownDiffs.length
+  ? knownDiffs.map((d) => `| ${d.area} | ${d.difference} | ${d.why} |`).join("\n")
+  : "| _none recorded_ | | |";
+
+const page = `<!--
+  GENERATED FILE — do not edit by hand.
+  Regenerate with \`bun run fidelity:report\`. Source: the behavioral cross-check
+  corpus (packages/vitest-native/crosscheck/) and known-differences.json.
+-->
+# Fidelity report
+
+The \`mock\` engine is a reimplementation of React Native, so it could in principle
+drift from real RN. vitest-native guards against that with a **behavioral
+cross-check**: a corpus of probes runs the *same* assertions under the mock engine
+**and** under real React Native, and any divergence fails CI. This page is
+generated from the corpus itself, so the numbers below are exactly what ships.
+
+## Summary
+
+- **${summary.matching} / ${summary.total} probes** match between the mock engine and real React Native.
+- ${ciLine}
+- Reproduce it yourself: \`bun run crosscheck\`.
+
+The \`native\` engine needs no cross-check — it *is* real React Native.
+
+## Probes
+
+Each probe renders or exercises a real behavior (queries, presses, text input,
+lists, scrolling, modals, and core API values) and compares the observable result
+across both engines.
+
+| Probe | Result |
+| --- | --- |
+${probeRows}
+
+## Known differences
+
+Where the mock engine intentionally or knowingly differs from real React Native,
+it is documented here rather than hidden. These are excluded from the probe
+corpus above (or asserted to their known values) so the cross-check stays green
+without papering over the difference.
+
+| Area | Difference | Why |
+| --- | --- | --- |
+${knownDiffRows}
+`;
+
+// Write the artifacts, or in --check mode compare them and report any drift.
+const artifacts = [
+  { label: "badge", file: badgePath, content: badgeContent },
+  { label: "page", file: pagePath, content: page },
+];
+const drifted = [];
+for (const { label, file, content } of artifacts) {
+  if (checkOnly) {
+    const current = fs.existsSync(file) ? fs.readFileSync(file, "utf8") : null;
+    if (current !== content) drifted.push({ label, file });
+  } else {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, content);
+  }
+}
+
+if (checkOnly) {
+  if (drifted.length) {
+    console.error(
+      `✗ fidelity artifacts are stale — run \`bun run fidelity:report\` and commit:\n` +
+        drifted.map((d) => `    ${path.relative(repoRoot, d.file)}`).join("\n"),
+    );
+    process.exit(1);
+  }
+  console.log(`✓ fidelity artifacts are up to date (${badge.message})`);
+} else {
+  console.log(`\n✓ fidelity report rendered`);
+  console.log(`  badge: ${path.relative(repoRoot, badgePath)} (${badge.message})`);
+  console.log(`  page:  ${path.relative(repoRoot, pagePath)}`);
+}
+if (!allMatch) process.exit(1);

--- a/packages/vitest-native/scripts/fidelity-report.mjs
+++ b/packages/vitest-native/scripts/fidelity-report.mjs
@@ -25,21 +25,26 @@ const badgePath = path.join(root, "crosscheck", "fidelity-badge.json");
 const knownDiffsPath = path.join(root, "crosscheck", "known-differences.json");
 const pagePath = path.join(repoRoot, "website", "guide", "fidelity.md");
 
+// A non-zero cross-check exit means EITHER a probe diverged OR the suite itself
+// exited non-zero while probes still matched (crosscheck.mjs's `!native.ok` guard
+// — an unhandled rejection, a throwing hook, a worker teardown error). Both must
+// fail this gate, so the subprocess status is propagated at the end; rendering
+// still proceeds so the page reflects whatever was captured. fidelity:check is
+// therefore a strict superset of `crosscheck` (the gate it replaces in CI).
+let crosscheckFailed = false;
 if (!process.argv.includes("--no-run")) {
   console.log("── running cross-check to refresh report data ──");
   const res = spawnSync(process.execPath, [path.join(root, "scripts", "crosscheck.mjs")], {
     cwd: root,
     stdio: "inherit",
   });
-  // A divergence exits non-zero but still writes report.json (with the failing
-  // probes marked), so render either way to reflect reality — but if the suite
-  // itself failed to run, fail hard instead of rendering from stale/empty data.
   if (res.status !== 0) {
     if (!fs.existsSync(reportPath)) {
       console.error("✗ cross-check did not produce a report — failing.");
       process.exit(1);
     }
-    console.warn("\n⚠ cross-check reported divergences — rendering them below.\n");
+    crosscheckFailed = true;
+    console.warn("\n⚠ cross-check exited non-zero — this run will fail after rendering.\n");
   }
 }
 
@@ -132,14 +137,14 @@ across both engines.
 | --- | --- |
 ${probeRows}
 
-## Known differences
+## Not gated by the cross-check
 
-Where the mock engine intentionally or knowingly differs from real React Native,
-it is documented here rather than hidden. These are excluded from the probe
-corpus above (or asserted to their known values) so the cross-check stays green
-without papering over the difference.
+Some behaviors are deliberately left out of the gated corpus above because they
+vary by React Native version, test environment, or device — a single fixed value
+can't be correct for all of them, so pinning one would make the cross-check lie.
+They are documented here rather than hidden.
 
-| Area | Difference | Why |
+| Area | Behavior | Why it isn't gated |
 | --- | --- | --- |
 ${knownDiffRows}
 `;
@@ -174,4 +179,5 @@ if (checkOnly) {
   console.log(`  badge: ${path.relative(repoRoot, badgePath)} (${badge.message})`);
   console.log(`  page:  ${path.relative(repoRoot, pagePath)}`);
 }
-if (!allMatch) process.exit(1);
+// Fail on a probe divergence (!allMatch) OR any other non-zero cross-check exit.
+if (!allMatch || crosscheckFailed) process.exit(1);

--- a/packages/vitest-native/src/mocks/components/Pressable.ts
+++ b/packages/vitest-native/src/mocks/components/Pressable.ts
@@ -1,10 +1,36 @@
 import React from "react";
 import { buildPressableHostProps } from "./pressableHost.js";
 
+// Unlike the Touchable* family, Pressable resolves `style` and `children` as
+// functions of its interaction state — `style={({pressed}) => ...}` and
+// `children={({pressed}) => ...}`. Real RN tracks `pressed` (true between press-in
+// and press-out) and re-renders, so the mock does the same: resolve both against
+// the live pressed state, and toggle it through the press-in/out handlers the host
+// already wires up. At rest `pressed` is false, matching real RN's initial render.
 export function createPressableMock() {
-  const Pressable = React.forwardRef((props: any, ref: any) =>
-    React.createElement("Pressable", buildPressableHostProps(props, ref)),
-  );
+  const Pressable = React.forwardRef((props: any, ref: any) => {
+    const { style, children, onPressIn, onPressOut, ...rest } = props;
+    const [pressed, setPressed] = React.useState(false);
+    const state = { pressed };
+    const resolvedStyle = typeof style === "function" ? style(state) : style;
+    const resolvedChildren = typeof children === "function" ? children(state) : children;
+    const hostProps = buildPressableHostProps(
+      {
+        ...rest,
+        style: resolvedStyle,
+        onPressIn: (e: any) => {
+          setPressed(true);
+          onPressIn?.(e);
+        },
+        onPressOut: (e: any) => {
+          setPressed(false);
+          onPressOut?.(e);
+        },
+      },
+      ref,
+    );
+    return React.createElement("Pressable", hostProps, resolvedChildren);
+  });
   Pressable.displayName = "Pressable";
   return Pressable;
 }

--- a/packages/vitest-native/src/mocks/registry.ts
+++ b/packages/vitest-native/src/mocks/registry.ts
@@ -131,7 +131,7 @@ function createProcessColorMock() {
     grey: 0xff808080,
   };
 
-  return vi.fn((color: any): number | null => {
+  return vi.fn((color: any): number | null | undefined => {
     if (color == null) return null;
     if (typeof color === "number") return color;
     if (typeof color === "string") {
@@ -191,7 +191,9 @@ function createProcessColorMock() {
         return ((alpha << 24) + (r << 16) + (g << 8) + b) >>> 0;
       }
     }
-    return 0xff000000; // opaque black fallback
+    // Real RN's processColor returns undefined for an unparseable color (the
+    // native normalizer fails), rather than coercing to a default.
+    return undefined;
   });
 }
 

--- a/packages/vitest-native/tests/stateful-api-conformance.test.ts
+++ b/packages/vitest-native/tests/stateful-api-conformance.test.ts
@@ -436,8 +436,10 @@ describe("processColor edge cases (conformance)", () => {
     expect(processColor("  red  ")).toBe(processColor("red"));
   });
 
-  it("unknown string returns opaque black", () => {
-    expect(processColor("notacolor")).toBe(0xff000000);
+  it("unknown string returns undefined", () => {
+    // Real RN: normalizeColor fails → processColor returns undefined (not a
+    // coerced default). Verified against real RN by the behavioral cross-check.
+    expect(processColor("notacolor")).toBeUndefined();
   });
 });
 

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -80,6 +80,7 @@ export default defineConfig({
           text: 'Reference',
           items: [
             { text: 'API Coverage', link: '/api/coverage' },
+            { text: 'Fidelity Report', link: '/guide/fidelity' },
             { text: 'Comparison with Jest', link: '/guide/comparison' },
             { text: 'Troubleshooting', link: '/guide/troubleshooting' },
           ],

--- a/website/guide/comparison.md
+++ b/website/guide/comparison.md
@@ -47,7 +47,7 @@ With `engine: 'native'` and isolation on, vitest-native isn't categorically fast
 
 ## The cross-check
 
-The mock engine is a reimplementation of React Native, so it could in principle drift from real RN behavior. vitest-native guards against that with a **CI-gated behavioral cross-check**: a corpus of 56 probes runs the same assertions against both the mock engine and real RN across React Native 0.81–0.85, and divergences fail CI. It's reproducible — clone the repo and run `bun run crosscheck`.
+The mock engine is a reimplementation of React Native, so it could in principle drift from real RN behavior. vitest-native guards against that with a **CI-gated behavioral cross-check**: a corpus of probes runs the same assertions against both the mock engine and real RN across React Native 0.81–0.85, and divergences fail CI. It's reproducible — clone the repo and run `bun run crosscheck`. The full corpus and its current pass count are published in the [Fidelity Report](/guide/fidelity).
 
 This is the trust mechanism for the mock — and it has already caught and fixed real mock bugs (for example, an `Animated.Text` host-name mismatch that broke `queryByText`, and `Animated.Value`-in-style not resolving for `toHaveStyle`). The native engine doesn't need this — it *is* real RN.
 

--- a/website/guide/fidelity.md
+++ b/website/guide/fidelity.md
@@ -103,13 +103,15 @@ across both engines.
 | `view-onlayout` | ✅ match |
 | `within-scoping` | ✅ match |
 
-## Known differences
+## Not gated by the cross-check
 
-Where the mock engine intentionally or knowingly differs from real React Native,
-it is documented here rather than hidden. These are excluded from the probe
-corpus above (or asserted to their known values) so the cross-check stays green
-without papering over the difference.
+Some behaviors are deliberately left out of the gated corpus above because they
+vary by React Native version, test environment, or device — a single fixed value
+can't be correct for all of them, so pinning one would make the cross-check lie.
+They are documented here rather than hidden.
 
-| Area | Difference | Why |
+| Area | Behavior | Why it isn't gated |
 | --- | --- | --- |
-| Dimensions / PixelRatio defaults | Default device metrics (window/screen size, pixel ratio, font scale) can differ between the mock engine's fixed default device and the metrics real React Native reports in the test host. | These are device/environment values, not behavior. Tests that depend on exact metrics should set them explicitly (e.g. Dimensions.set / a fixed device) rather than rely on a default, so the value is the same under both engines. |
+| Default device metrics (Dimensions / PixelRatio) | The default window/screen size, pixel ratio and font scale are a fixed test-host default. Both engines report the same default — the cross-check gates that — but it is not any specific physical device. | Device metrics aren't behavior, and the default won't match a real device. Tests that depend on exact metrics should set them explicitly (e.g. Dimensions.set) rather than rely on the default. |
+| Text onPress accessibilityRole | A <Text> with an onPress handler is auto-assigned accessibilityRole "link" by some React Native versions and not others. | Version-variant across the supported RN range — a single mock value can't match every minor, so it isn't pinned by a probe. |
+| Appearance color scheme | Appearance.getColorScheme() reflects the host environment rather than a fixed value. | Environment-dependent (CI vs local, OS settings), so it isn't a stable cross-engine invariant to gate. |

--- a/website/guide/fidelity.md
+++ b/website/guide/fidelity.md
@@ -13,7 +13,7 @@ generated from the corpus itself, so the numbers below are exactly what ships.
 
 ## Summary
 
-- **56 / 56 probes** match between the mock engine and real React Native.
+- **68 / 68 probes** match between the mock engine and real React Native.
 - CI runs the same corpus across **React Native 0.81–0.85** on every commit.
 - Reproduce it yourself: `bun run crosscheck`.
 
@@ -29,6 +29,7 @@ across both engines.
 | --- | --- |
 | `a11y-role` | ✅ match |
 | `a11y-state-disabled` | ✅ match |
+| `accessibility-label-read` | ✅ match |
 | `accessibility-value` | ✅ match |
 | `activityindicator-renders` | ✅ match |
 | `animated-image-renders` | ✅ match |
@@ -43,9 +44,12 @@ across both engines.
 | `dimensions-window` | ✅ match |
 | `flatlist-renders-items` | ✅ match |
 | `get-all-by-role-count` | ✅ match |
+| `get-by-text-miss-throws` | ✅ match |
+| `i18nmanager-isrtl` | ✅ match |
 | `image-render` | ✅ match |
 | `keyboardavoidingview-children` | ✅ match |
 | `matcher-checked-switch` | ✅ match |
+| `matcher-contains-element` | ✅ match |
 | `matcher-disabled-enabled` | ✅ match |
 | `matcher-display-value` | ✅ match |
 | `matcher-have-prop` | ✅ match |
@@ -54,25 +58,33 @@ across both engines.
 | `matcher-text-content` | ✅ match |
 | `modal-visible-children` | ✅ match |
 | `nested-text` | ✅ match |
+| `not-on-screen-after-unmount` | ✅ match |
 | `pixelratio` | ✅ match |
+| `pixelratio-rounding` | ✅ match |
 | `placeholder-query` | ✅ match |
 | `platform-os` | ✅ match |
 | `platform-select` | ✅ match |
+| `platform-select-partial` | ✅ match |
+| `platform-version-type` | ✅ match |
 | `pressable-disabled-suppresses-press` | ✅ match |
 | `pressable-fires-onpress` | ✅ match |
+| `processcolor` | ✅ match |
 | `query-all-by-text` | ✅ match |
 | `query-by-hint-text` | ✅ match |
 | `query-by-label-text` | ✅ match |
 | `query-by-role` | ✅ match |
 | `query-by-role-name` | ✅ match |
+| `query-by-testid-miss` | ✅ match |
 | `query-by-text-regex` | ✅ match |
 | `scrollview-fireevent-scroll` | ✅ match |
 | `sectionlist-render` | ✅ match |
 | `stylesheet-create-identity` | ✅ match |
 | `stylesheet-flatten` | ✅ match |
+| `stylesheet-flatten-falsy` | ✅ match |
 | `stylesheet-helpers` | ✅ match |
 | `switch-render` | ✅ match |
 | `testid-query` | ✅ match |
+| `text-numberoflines-prop` | ✅ match |
 | `text-renders` | ✅ match |
 | `textinput-displayvalue` | ✅ match |
 | `textinput-focus-blur` | ✅ match |

--- a/website/guide/fidelity.md
+++ b/website/guide/fidelity.md
@@ -13,7 +13,7 @@ generated from the corpus itself, so the numbers below are exactly what ships.
 
 ## Summary
 
-- **68 / 68 probes** match between the mock engine and real React Native.
+- **75 / 75 probes** match between the mock engine and real React Native.
 - CI runs the same corpus across **React Native 0.81–0.85** on every commit.
 - Reproduce it yourself: `bun run crosscheck`.
 
@@ -45,6 +45,13 @@ across both engines.
 | `flatlist-renders-items` | ✅ match |
 | `get-all-by-role-count` | ✅ match |
 | `get-by-text-miss-throws` | ✅ match |
+| `hunt-fireevent-press` | ✅ match |
+| `hunt-pressable-children-fn` | ✅ match |
+| `hunt-pressable-disabled-a11ystate` | ✅ match |
+| `hunt-pressable-press-in-out` | ✅ match |
+| `hunt-pressable-style-fn` | ✅ match |
+| `hunt-processcolor-edge` | ✅ match |
+| `hunt-textinput-maxlength` | ✅ match |
 | `i18nmanager-isrtl` | ✅ match |
 | `image-render` | ✅ match |
 | `keyboardavoidingview-children` | ✅ match |

--- a/website/guide/fidelity.md
+++ b/website/guide/fidelity.md
@@ -1,0 +1,96 @@
+<!--
+  GENERATED FILE — do not edit by hand.
+  Regenerate with `bun run fidelity:report`. Source: the behavioral cross-check
+  corpus (packages/vitest-native/crosscheck/) and known-differences.json.
+-->
+# Fidelity report
+
+The `mock` engine is a reimplementation of React Native, so it could in principle
+drift from real RN. vitest-native guards against that with a **behavioral
+cross-check**: a corpus of probes runs the *same* assertions under the mock engine
+**and** under real React Native, and any divergence fails CI. This page is
+generated from the corpus itself, so the numbers below are exactly what ships.
+
+## Summary
+
+- **56 / 56 probes** match between the mock engine and real React Native.
+- CI runs the same corpus across **React Native 0.81–0.85** on every commit.
+- Reproduce it yourself: `bun run crosscheck`.
+
+The `native` engine needs no cross-check — it *is* real React Native.
+
+## Probes
+
+Each probe renders or exercises a real behavior (queries, presses, text input,
+lists, scrolling, modals, and core API values) and compares the observable result
+across both engines.
+
+| Probe | Result |
+| --- | --- |
+| `a11y-role` | ✅ match |
+| `a11y-state-disabled` | ✅ match |
+| `accessibility-value` | ✅ match |
+| `activityindicator-renders` | ✅ match |
+| `animated-image-renders` | ✅ match |
+| `animated-scrollview-renders` | ✅ match |
+| `animated-text-renders` | ✅ match |
+| `animated-value-initial-style` | ✅ match |
+| `animated-view-renders` | ✅ match |
+| `button-renders-title` | ✅ match |
+| `button-userpress` | ✅ match |
+| `composite-text-match` | ✅ match |
+| `controlled-textinput-rerender` | ✅ match |
+| `dimensions-window` | ✅ match |
+| `flatlist-renders-items` | ✅ match |
+| `get-all-by-role-count` | ✅ match |
+| `image-render` | ✅ match |
+| `keyboardavoidingview-children` | ✅ match |
+| `matcher-checked-switch` | ✅ match |
+| `matcher-disabled-enabled` | ✅ match |
+| `matcher-display-value` | ✅ match |
+| `matcher-have-prop` | ✅ match |
+| `matcher-on-the-screen` | ✅ match |
+| `matcher-style` | ✅ match |
+| `matcher-text-content` | ✅ match |
+| `modal-visible-children` | ✅ match |
+| `nested-text` | ✅ match |
+| `pixelratio` | ✅ match |
+| `placeholder-query` | ✅ match |
+| `platform-os` | ✅ match |
+| `platform-select` | ✅ match |
+| `pressable-disabled-suppresses-press` | ✅ match |
+| `pressable-fires-onpress` | ✅ match |
+| `query-all-by-text` | ✅ match |
+| `query-by-hint-text` | ✅ match |
+| `query-by-label-text` | ✅ match |
+| `query-by-role` | ✅ match |
+| `query-by-role-name` | ✅ match |
+| `query-by-text-regex` | ✅ match |
+| `scrollview-fireevent-scroll` | ✅ match |
+| `sectionlist-render` | ✅ match |
+| `stylesheet-create-identity` | ✅ match |
+| `stylesheet-flatten` | ✅ match |
+| `stylesheet-helpers` | ✅ match |
+| `switch-render` | ✅ match |
+| `testid-query` | ✅ match |
+| `text-renders` | ✅ match |
+| `textinput-displayvalue` | ✅ match |
+| `textinput-focus-blur` | ✅ match |
+| `textinput-onchangetext` | ✅ match |
+| `textinput-usertype` | ✅ match |
+| `touchable-highlight-onpress` | ✅ match |
+| `touchable-opacity-onpress` | ✅ match |
+| `touchable-without-feedback-onpress` | ✅ match |
+| `view-onlayout` | ✅ match |
+| `within-scoping` | ✅ match |
+
+## Known differences
+
+Where the mock engine intentionally or knowingly differs from real React Native,
+it is documented here rather than hidden. These are excluded from the probe
+corpus above (or asserted to their known values) so the cross-check stays green
+without papering over the difference.
+
+| Area | Difference | Why |
+| --- | --- | --- |
+| Dimensions / PixelRatio defaults | Default device metrics (window/screen size, pixel ratio, font scale) can differ between the mock engine's fixed default device and the metrics real React Native reports in the test host. | These are device/environment values, not behavior. Tests that depend on exact metrics should set them explicitly (e.g. Dimensions.set / a fixed device) rather than rely on a default, so the value is the same under both engines. |

--- a/website/index.md
+++ b/website/index.md
@@ -87,7 +87,7 @@ It is **not** primarily a speed play — choose it for the fidelity option and D
 
 ## How it's verified
 
-The reproducible guarantee is a **CI-gated behavioral cross-check**: 56 probes run the same assertions under the mock engine **and** real React Native across React Native 0.81–0.85, and any divergence fails the build. Anyone can run it (`bun run crosscheck`). On top of that, the full CI gate runs lint, typecheck, build, and the mock + native + hot suites across an OS × Node matrix.
+The reproducible guarantee is a **CI-gated behavioral cross-check**: a corpus of probes runs the same assertions under the mock engine **and** real React Native across React Native 0.81–0.85, and any divergence fails the build. Anyone can run it (`bun run crosscheck`), and the full corpus with its current pass count is published in the [Fidelity Report](/guide/fidelity). On top of that, the full CI gate runs lint, typecheck, build, and the mock + native + hot suites across an OS × Node matrix.
 
 We've also run real apps' own test suites under the native engine. **react-native-paper**'s suite passes **625 of 734 tests (~85%)** — no paper source changed, just an RNTL bump and the test config/setup. The remaining failures are tests coupled to Jest's RN-mock internals (e.g. `vi.spyOn(View.prototype, 'measure')`, deep `jest.mock('react-native/…')` of Appearance/Dimensions), not vitest-native bugs. The Expo-based **obytes template** runs **34 of 40 (~85%)** — a more deeply-coupled case that needed a few library mocks. Both are reproducible: see [**vitest-native-bakeoffs**](https://github.com/danfry1/vitest-native-bakeoffs). We've also migrated a Rocket.Chat suite in local testing.
 


### PR DESCRIPTION
## Summary

Turns the behavioral cross-check from an internal CI gate into a **published, self-updating proof of mock-vs-real-React-Native fidelity** — and, in the process, expands the corpus and fixes three real divergences it surfaced.

The cross-check has always been the trust mechanism for the `mock` engine (the same probes run under the mock and under real RN; any divergence fails CI). This makes that proof visible and impossible to doubt, then puts it to work.

## What's included

**1. A living fidelity report (`feat`).**
- `scripts/fidelity-report.mjs` renders two committed artifacts from the cross-check corpus: a shields.io endpoint **badge** (live probe count) and a published **`website/guide/fidelity.md`** page (full corpus table + an honest known-differences ledger).
- The published count is derived from the corpus, never hand-typed, and the CI version range is read from the matrix workflow — so neither can drift as probes are added.
- `fidelity:check` (`--check`) re-runs the cross-check and **fails if the committed page/badge no longer match the live corpus**; it replaces the cross-check step in the CI gate, so the published proof can never silently go stale.
- Adds a README fidelity badge, a Reference → Fidelity Report nav entry, and links the existing cross-check prose to the new page.

**2. Corpus expansion 56 → 75 probes.**
- A first batch of 12 deterministic/parity probes (processColor, I18nManager, PixelRatio rounding, `Platform.Version` type, partial `Platform.select`, falsy-flatten, query misses, `getByText` throw, `toContainElement`, unmount, a11y label, `numberOfLines`) — all matching.
- A bug-hunting batch targeting likely-divergent behaviors, which found three real mock bugs (below). Switch `valueChange`, Text-onPress `accessibilityRole`, and `Appearance.getColorScheme()` were probed but left ungated as version-/environment-variant.

**3. Three real fidelity fixes the hunt surfaced (`fix`).**
- **Pressable function `style`/`children`.** `style={({pressed}) => ...}` and `children={({pressed}) => ...}` were passed through untouched. The mock now tracks `pressed` (toggled on press-in/out) and resolves both, matching real RN's resting render and updating under press.
- **`processColor()` unparseable input** returned opaque black; real RN returns `undefined` (its normalizer fails). Fixed to match.
- A `processColor` "conformance" test was asserting the old black fallback — itself non-conforming. Corrected to real RN's `undefined`, verified by the cross-check.

## Validation

- Cross-check **75/75** under both engines.
- Full mock suite green (1273 passing), typecheck, lint, format all clean.
- `fidelity:check` (the new CI gate step) passes and guards the published artifacts against drift.

## Why this matters

Fidelity is the moat the mock engine has that a hand-mocked setup cannot claim — and trust is built on precision, not assertions. This converts "trust us, it's verified" into "here is every behavior we verify, the live count, and exactly where we differ," makes that claim structurally incapable of going stale, and demonstrates its value by catching three divergences (including a test that was codifying a bug).
