### PR TITLE
feat(native): bound hot-runtime memory with a default per-worker ceiling

### DIFF
--- a/.changeset/bounded-hot-memory-default.md
+++ b/.changeset/bounded-hot-memory-default.md
@@ -1,0 +1,7 @@
+---
+"vitest-native": patch
+---
+
+Bound hot-runtime memory by default. When `hotRuntime` is enabled on the native engine and neither `memoryLimit` nor `recycleAfterFiles` is configured, a default per-worker memory ceiling of `clamp(totalmem * 0.25, 768MB, 1.5GB)` is now applied. Hot workers keep React Native resident and accumulate roughly 4 MB per file, so without a bound a long suite could grow toward OOM; the default lets multi-worker runs recycle a worker once it crosses the ceiling, keeping total memory bounded out of the box.
+
+An explicit `memoryLimit` or `recycleAfterFiles` is respected unchanged. Single-worker hot still cannot recycle (Vitest batches all files into one scheduler task), so the bound is inert there and the existing one-time "recycling INACTIVE" warning advises running with `maxWorkers >= 2`.

--- a/packages/vitest-native/src/native/pool.ts
+++ b/packages/vitest-native/src/native/pool.ts
@@ -19,6 +19,7 @@
 // custom pools can't receive task.memoryLimit — so the threshold is our own
 // option. Upstream RFC item.)
 import path from "node:path";
+import os from "node:os";
 import { ThreadsPoolWorker } from "vitest/node";
 import type { PoolOptions, PoolRunnerInitializer, PoolTask, WorkerRequest } from "vitest/node";
 
@@ -135,6 +136,35 @@ class NativePoolWorker extends ThreadsPoolWorker {
     const env = task.context.environment;
     return env.name === this.environment.name && deepEqual(env.options, this.environment.options);
   }
+}
+
+// Per-worker memory bound applied by default when hot is enabled but the user
+// configured no explicit recycling. Hot workers hold React Native resident and
+// accumulate ~4 MB/file (RNTL's resident render trees can't be reclaimed across
+// files), so unbounded single-worker hot heads toward OOM at large file counts.
+// A per-worker `memoryLimit` lets multi-worker runs recycle a worker once its
+// heap crosses the ceiling, keeping total hot memory bounded regardless of suite
+// size. The bounds:
+//  - FLOOR (768 MB): a per-worker limit below RN's resident working set
+//    (~417 MB/worker measured @8w, plus headroom) would recycle every few files
+//    and thrash. 768 MB sits safely above it.
+//  - CEILING (1.5 GB): above this there's no practical point bounding on typical
+//    dev/CI machines.
+//  - FRACTION (0.25): scale the budget with machine size between those bounds.
+// Single-worker hot can't recycle at all (Vitest batches all files into one task),
+// so the bound is inert there — the pool's batch warning nudges users to >=2 workers.
+const HOT_MEMORY_MIN_BYTES = 768 * 1024 * 1024;
+const HOT_MEMORY_MAX_BYTES = 1536 * 1024 * 1024;
+const HOT_MEMORY_FRACTION = 0.25;
+
+/**
+ * Default per-worker hot `memoryLimit` (bytes): `clamp(totalmem * 0.25, 768MB, 1.5GB)`.
+ * Applied only when hot is enabled and neither `memoryLimit` nor
+ * `recycleAfterFiles` was set explicitly. `totalmem` is injectable for tests.
+ */
+export function defaultHotMemoryLimit(totalmem: number = os.totalmem()): number {
+  const budget = Math.floor(totalmem * HOT_MEMORY_FRACTION);
+  return Math.min(HOT_MEMORY_MAX_BYTES, Math.max(HOT_MEMORY_MIN_BYTES, budget));
 }
 
 /** Pool initializer for `test.pool` — keeps RN-hot workers alive across files. */

--- a/packages/vitest-native/src/plugin.ts
+++ b/packages/vitest-native/src/plugin.ts
@@ -1,4 +1,5 @@
 import type { Plugin, UserConfig } from "vite";
+import type { PoolRunnerInitializer } from "vitest/node";
 import type { VitestNativeOptions, ResolvedOptions, Preset } from "./types.js";
 import { getPlatformExtensions } from "./resolve.js";
 import { fileURLToPath } from "node:url";
@@ -419,17 +420,28 @@ export function reactNative(options?: VitestNativeOptions): Plugin {
         }
         // Lazy import: pulls in vitest/node, which only exists when running
         // under Vitest (not plain Vite) — and only the hot runtime needs it.
-        const hot = hotRuntime
-          ? {
-              pool: (await import("./native/pool.js")).nativePool({
-                workerEntry: nativeWorkerPath,
-                recycleAfterFiles: hotRecycle.recycleAfterFiles,
-                memoryLimit: hotRecycle.memoryLimit,
-                diagnostics,
-              }),
-              runnerPath: nativeRunnerPath,
-            }
-          : undefined;
+        let hot: { pool: PoolRunnerInitializer; runnerPath: string } | undefined;
+        if (hotRuntime) {
+          const { nativePool, defaultHotMemoryLimit } = await import("./native/pool.js");
+          // When hot is enabled but the user set no explicit recycling, apply a
+          // default per-worker memory bound so enabling hot can't grow memory
+          // unbounded. Don't override an explicit choice: if the user set
+          // recycleAfterFiles, respect that as their bound and add no default
+          // memoryLimit. (Single-worker hot can't recycle regardless — the pool
+          // warns about that — but multi-worker runs are now bounded out of the box.)
+          const memoryLimit =
+            hotRecycle.memoryLimit ??
+            (hotRecycle.recycleAfterFiles == null ? defaultHotMemoryLimit() : undefined);
+          hot = {
+            pool: nativePool({
+              workerEntry: nativeWorkerPath,
+              recycleAfterFiles: hotRecycle.recycleAfterFiles,
+              memoryLimit,
+              diagnostics,
+            }),
+            runnerPath: nativeRunnerPath,
+          };
+        }
         return asCompatibleViteConfig(
           nativeEngineConfig(nativeSetupPath, env, extensions, transformPkgs, hot, jsxTransform),
         );

--- a/packages/vitest-native/src/types.ts
+++ b/packages/vitest-native/src/types.ts
@@ -314,7 +314,12 @@ export interface VitestNativeOptions {
    *   is enforced between Vitest scheduler tasks; a single task containing
    *   multiple files cannot be interrupted.
    * - `memoryLimit`: retire a worker when its reported JS heap (bytes) meets
-   *   or exceeds this value, also between scheduler tasks.
+   *   or exceeds this value, also between scheduler tasks. When hot is enabled
+   *   and you set neither `memoryLimit` nor `recycleAfterFiles`, a default
+   *   per-worker bound of `clamp(totalmem * 0.25, 768MB, 1.5GB)` is applied so
+   *   memory stays bounded out of the box (multi-worker runs recycle a worker
+   *   once it crosses the ceiling). Single-worker hot can't recycle, so the
+   *   bound is inert there — run with `maxWorkers >= 2` for bounded hot memory.
    * - `preserveGlobals`: exact globalThis property names intentionally owned
    *   by resident external libraries. App/test globals are otherwise removed
    *   between files. Storybook's preview registry is preserved automatically.

--- a/packages/vitest-native/tests/native-unit.test.ts
+++ b/packages/vitest-native/tests/native-unit.test.ts
@@ -290,6 +290,10 @@ describe("plugin engine routing", () => {
     });
     expect(worker.name).toBe("vitest-native");
     expect((worker as any).entrypoint).toMatch(/native[\\/]worker\.mjs$/);
+    // Plain `hotRuntime: true` (no explicit recycling) applies the default
+    // per-worker memory bound, which turns on heap reporting. Guards the
+    // plugin.ts default-application wiring, not just defaultHotMemoryLimit().
+    expect(worker.reportMemory).toBe(true);
   });
 
   it("hotRuntime object form wires recycling policy into the pool worker", async () => {

--- a/packages/vitest-native/tests/native-unit.test.ts
+++ b/packages/vitest-native/tests/native-unit.test.ts
@@ -399,3 +399,34 @@ describe("native globals: globalThis.expo shim", () => {
     expect(expo.getViewConfig()).toBeNull();
   });
 });
+
+import { defaultHotMemoryLimit } from "../src/native/pool.js";
+
+describe("defaultHotMemoryLimit", () => {
+  const MB = 1024 * 1024;
+  const GB = 1024 * MB;
+
+  it("scales with total memory at 25% between the bounds", () => {
+    // 0.25 * 16 GB = 4 GB → clamped to the 1.5 GB ceiling; pick a total whose
+    // quarter lands inside the band: 0.25 * 4 GB = 1 GB.
+    expect(defaultHotMemoryLimit(4 * GB)).toBe(1 * GB);
+    expect(defaultHotMemoryLimit(5 * GB)).toBe(Math.floor(0.25 * 5 * GB));
+  });
+
+  it("clamps up to the 768 MB floor on small machines", () => {
+    // 0.25 * 2 GB = 512 MB, below the floor.
+    expect(defaultHotMemoryLimit(2 * GB)).toBe(768 * MB);
+    expect(defaultHotMemoryLimit(0)).toBe(768 * MB);
+  });
+
+  it("clamps down to the 1.5 GB ceiling on large machines", () => {
+    expect(defaultHotMemoryLimit(64 * GB)).toBe(1536 * MB);
+    expect(defaultHotMemoryLimit(8 * GB)).toBe(1536 * MB); // 0.25 * 8 GB = 2 GB
+  });
+
+  it("defaults totalmem from os when no argument is given", () => {
+    const limit = defaultHotMemoryLimit();
+    expect(limit).toBeGreaterThanOrEqual(768 * MB);
+    expect(limit).toBeLessThanOrEqual(1536 * MB);
+  });
+});


### PR DESCRIPTION
## Summary

Hot workers keep React Native resident and accumulate ~4 MB per test file (RNTL's resident render trees can't be reclaimed across files), so an enabled hot runtime with no configured recycling could grow toward OOM on large suites. This makes `hotRuntime` **safe to enable by default**: total memory stays bounded out of the box.

When `hotRuntime` is enabled on the native engine and the user set **neither** `memoryLimit` **nor** `recycleAfterFiles`, a default per-worker memory ceiling is applied:

```
clamp(totalmem * 0.25, 768MB, 1.5GB)
```

Multi-worker runs recycle a worker once its heap crosses the ceiling. An explicit `memoryLimit`/`recycleAfterFiles` is respected unchanged.

### Why these bounds
- **Floor (768 MB)** sits above React Native's measured resident working set (~417 MB/worker), so the bound never recycles every few files and thrashes.
- **Ceiling (1.5 GB)** — above this there's no practical point bounding on typical dev/CI machines.
- **Fraction (0.25)** scales the budget with machine size between the bounds.

### Single-worker is inert (by design)
Vitest batches all files into one scheduler task under `isolate:false` + `maxWorkers:1`, so a worker can never be retired between files. With the default limit now set, single-worker hot automatically surfaces the existing one-time "recycling INACTIVE" warning, which advises running with `maxWorkers >= 2`. The default does **not** rewrite the user's `maxWorkers`.

This is **Layer 1** of the [hot-default design](packages/vitest-native/docs/hot-default-design.md); the worker-count division/cap (the high-worker / low-memory corner) is intentionally deferred as a documented residual.

## Changes
- `src/native/pool.ts` — new exported `defaultHotMemoryLimit(totalmem = os.totalmem())` helper.
- `src/plugin.ts` — applies the default only when neither recycle option is set.
- `src/types.ts` — `hotRuntime` docstring documents the default bound.
- `tests/native-unit.test.ts` — 4 unit tests for the clamp behavior.

## Verification
- build + typecheck + lint + format clean
- native-unit 30/30; full mock suite 1277; hot soak (12 recycle boots + single-worker INACTIVE warning); `test:native:hot` 3/3; hot-isolation 124/124
- `bench/scale` 150 files hot@4w → 150/150, RSS ~993 MB (under the 1.5 GB bound, no thrash)
- single-worker hot@1w auto-fires the INACTIVE warning