### PR TITLE
feat(native): add react-native-worklets preset (auto-detected)

### DIFF
--- a/.changeset/worklets-preset.md
+++ b/.changeset/worklets-preset.md
@@ -1,0 +1,5 @@
+---
+"vitest-native": minor
+---
+
+Add a built-in `react-native-worklets` preset (auto-detected). Worklets is Reanimated's low-level runtime and is also imported directly by apps (e.g. `import { scheduleOnUI } from 'react-native-worklets'`). It ships a Jest mock at `react-native-worklets/lib/module/mock` that is ESM ending in `module.exports = …`; under the native engine React Native and its ecosystem are externalized, so requiring that file through Node throws `module is not defined in ES module scope` and takes down the whole test file. The preset shadows the package with a self-contained mock modelled on worklets' own `mock.js` API (schedulers run their worklet synchronously, matching the Reanimated preset), so worklets-using suites load and render without a hand-written mock.

--- a/packages/vitest-native/src/preset-map.ts
+++ b/packages/vitest-native/src/preset-map.ts
@@ -9,6 +9,7 @@ export type PresetName = keyof typeof Presets;
  */
 export const AUTO_DETECT_PRESETS = {
   "react-native-reanimated": "reanimated",
+  "react-native-worklets": "worklets",
   "react-native-gesture-handler": "gestureHandler",
   "react-native-safe-area-context": "safeAreaContext",
   "@react-navigation/native": "navigation",

--- a/packages/vitest-native/src/presets/index.ts
+++ b/packages/vitest-native/src/presets/index.ts
@@ -13,3 +13,4 @@ export { vectorIcons } from "./vector-icons.js";
 export { flashList } from "./flash-list.js";
 export { bottomSheet } from "./bottom-sheet.js";
 export { keyboardController } from "./keyboard-controller.js";
+export { worklets } from "./worklets.js";

--- a/packages/vitest-native/src/presets/worklets.ts
+++ b/packages/vitest-native/src/presets/worklets.ts
@@ -1,0 +1,137 @@
+import type { Preset } from "../types.js";
+
+// react-native-worklets is reanimated's low-level runtime (and is imported
+// directly by apps, e.g. `import { scheduleOnUI } from 'react-native-worklets'`).
+// It ships a Jest mock at `react-native-worklets/lib/module/mock`, but that file
+// is ESM that ends with `module.exports = …`; under the native engine RN and its
+// ecosystem are externalized, so requiring it through Node throws "module is not
+// defined in ES module scope" and takes down the whole test file.
+//
+// This preset shadows the package with a self-contained mock modelled on
+// worklets' own `mock.js` WorkletAPI. Schedulers run their worklet synchronously
+// (matching the reanimated preset's `runOnJS`/`runOnUI => fn` convention) so
+// UI-thread work is observable in tests without fake-timer juggling.
+
+// Mirrors worklets' RuntimeKind enum (lib/module/runtimeKind.js). Tests run on
+// the React Native runtime.
+const RuntimeKind = { ReactNative: 1, UI: 2, Worker: 3 } as const;
+
+const NOOP = () => {};
+const ID = <T>(value: T): T => value;
+const invoke = (callback: () => any) => callback();
+
+export function worklets(): Preset {
+  return {
+    name: "worklets",
+    modules: {
+      "react-native-worklets": {
+        exports: [
+          "runOnJS",
+          "runOnUI",
+          "runOnUIAsync",
+          "runOnUISync",
+          "scheduleOnRN",
+          "scheduleOnUI",
+          "runOnRuntime",
+          "runOnRuntimeAsync",
+          "runOnRuntimeSync",
+          "scheduleOnRuntime",
+          "executeOnUIRuntimeSync",
+          "createWorkletRuntime",
+          "getRuntimeKind",
+          "isRNRuntime",
+          "isUIRuntime",
+          "isWorkerRuntime",
+          "isWorkletRuntime",
+          "RuntimeKind",
+          "makeShareable",
+          "makeShareableCloneRecursive",
+          "makeShareableCloneOnUIRecursive",
+          "isShareable",
+          "isShareableRef",
+          "createShareable",
+          "shareableMappingCache",
+          "createSerializable",
+          "isSerializableRef",
+          "registerCustomSerializable",
+          "serializableMappingCache",
+          "createSynchronizable",
+          "isSynchronizable",
+          "getStaticFeatureFlag",
+          "getDynamicFeatureFlag",
+          "setDynamicFeatureFlag",
+          "callMicrotasks",
+          "isWorkletFunction",
+          "WorkletsModule",
+          "UIRuntimeId",
+        ],
+        factory: () => {
+          // Schedulers execute the worklet immediately on the current thread —
+          // there is no separate UI runtime under test.
+          const runOnJS = (fn: Function) => fn;
+          const runOnUI = (fn: Function) => fn;
+          // Direct call form: `runOnUIAsync(worklet, ...args)` returns a Promise
+          // (unlike `runOnUI(worklet)(...args)`, which is curried).
+          const runOnUIAsync = (worklet: Function, ...args: any[]) =>
+            Promise.resolve(worklet(...args));
+
+          const api: Record<string, any> = {
+            __esModule: true,
+
+            // Scheduling
+            runOnJS,
+            runOnUI,
+            runOnUIAsync,
+            runOnUISync: invoke,
+            scheduleOnRN: (fn: Function, ...args: any[]) => fn(...args),
+            scheduleOnUI: (worklet: Function, ...args: any[]) => worklet(...args),
+            runOnRuntime: ID,
+            runOnRuntimeAsync: (_runtime: unknown, worklet: Function, ...args: any[]) =>
+              Promise.resolve(worklet(...args)),
+            runOnRuntimeSync: (_runtime: unknown, worklet: Function, ...args: any[]) =>
+              worklet(...args),
+            scheduleOnRuntime: invoke,
+            executeOnUIRuntimeSync: ID,
+            callMicrotasks: NOOP,
+
+            // Runtimes
+            createWorkletRuntime: () => ({}),
+            getRuntimeKind: () => RuntimeKind.ReactNative,
+            RuntimeKind,
+            isRNRuntime: () => true,
+            isUIRuntime: () => false,
+            isWorkerRuntime: () => false,
+            isWorkletRuntime: () => false,
+            UIRuntimeId: 1,
+
+            // Shareables / serializables — identity in tests
+            makeShareable: ID,
+            makeShareableCloneRecursive: ID,
+            makeShareableCloneOnUIRecursive: ID,
+            createShareable: ID,
+            isShareable: () => false,
+            isShareableRef: () => true,
+            shareableMappingCache: new Map(),
+            createSerializable: ID,
+            isSerializableRef: ID,
+            registerCustomSerializable: NOOP,
+            serializableMappingCache: new Map(),
+            createSynchronizable: ID,
+            isSynchronizable: () => false,
+
+            // Feature flags
+            getStaticFeatureFlag: () => false,
+            getDynamicFeatureFlag: () => false,
+            setDynamicFeatureFlag: NOOP,
+
+            // A worklet detection always reports false on the RN runtime.
+            isWorkletFunction: () => false,
+            WorkletsModule: {},
+          };
+          api.default = api;
+          return api;
+        },
+      },
+    },
+  };
+}

--- a/packages/vitest-native/tests-native/third-party-presets.test.tsx
+++ b/packages/vitest-native/tests-native/third-party-presets.test.tsx
@@ -24,6 +24,16 @@ import {
   KeyboardController,
   useKeyboardController,
 } from "react-native-keyboard-controller";
+import {
+  scheduleOnUI,
+  runOnJS,
+  runOnUI,
+  runOnUIAsync,
+  makeShareable,
+  getRuntimeKind,
+  RuntimeKind,
+  isWorkletFunction,
+} from "react-native-worklets";
 
 describe("@shopify/flash-list under native engine", () => {
   it("renders each data row through renderItem (no native recycler loaded)", async () => {
@@ -80,5 +90,30 @@ describe("react-native-keyboard-controller under native engine", () => {
     expect(KeyboardController.isVisible()).toBe(false);
     expect(typeof KeyboardController.preload).toBe("function");
     expect(typeof useKeyboardController).toBe("function");
+  });
+});
+
+describe("react-native-worklets under native engine", () => {
+  // Without the preset, importing worklets pulls in its ESM `mock.js` (which
+  // ends with `module.exports = …`) through Node's externalized require and
+  // throws "module is not defined in ES module scope", taking down the file.
+  // The preset shadows the package so direct consumers (e.g. paper's FAB, which
+  // does `import { scheduleOnUI } from 'react-native-worklets'`) load cleanly.
+  it("schedulers run their worklet synchronously on the test thread", () => {
+    const seen: number[] = [];
+    scheduleOnUI(() => seen.push(1));
+    runOnUI((n: number) => seen.push(n))(2);
+    runOnJS((n: number) => seen.push(n))(3);
+    expect(seen).toEqual([1, 2, 3]);
+  });
+
+  it("runOnUIAsync resolves with the worklet's result (direct call form)", async () => {
+    await expect(runOnUIAsync((n: number) => n + 1, 41)).resolves.toBe(42);
+  });
+
+  it("runtime + shareable helpers are shadowed, not undefined", () => {
+    expect(makeShareable({ a: 1 })).toEqual({ a: 1 });
+    expect(getRuntimeKind()).toBe(RuntimeKind.ReactNative);
+    expect(isWorkletFunction(() => {})).toBe(false);
   });
 });


### PR DESCRIPTION
## What

Adds a built-in, auto-detected `react-native-worklets` preset for the native engine.

`react-native-worklets` is Reanimated's low-level runtime and is also imported directly by apps (e.g. `import { scheduleOnUI } from 'react-native-worklets'`). It ships a Jest mock at `react-native-worklets/lib/module/mock` that is ESM ending in `module.exports = …`. Under the native engine React Native and its ecosystem are externalized, so requiring that file through Node throws `module is not defined in ES module scope`, which fails to load the whole test file.

The preset shadows the package with a self-contained mock modelled on worklets' own `mock.js` API surface. Schedulers (`runOnJS`/`runOnUI`/`scheduleOnUI`/`scheduleOnRN`) run their worklet synchronously on the test thread, matching the existing Reanimated preset's `runOnJS`/`runOnUI => fn` convention, so UI-thread work is observable without fake-timer juggling. `runOnUIAsync`/`runOnRuntimeAsync` resolve with the worklet's result. Runtime/shareable/serializable helpers and `RuntimeKind` are shadowed as no-op/identity so worklets-using suites load and render without a hand-written mock.

Registered in `AUTO_DETECT_PRESETS`, so any project depending on `react-native-worklets` gets it with zero config (and can drop a hand-written worklets mock from its setup).

## Why

Surfaced by a Jest→vitest-native migration friction audit across three real apps. A worklets-using suite currently fails to collect at all under the native engine unless the user hand-writes a mock; even then the common `require('react-native-worklets/lib/module/mock')` shim crashes. On the react-native-paper suite (RN 0.85.3, RNTL 13.3.3), the three FAB test files (`FAB`/`FABExtended`/`FABMenu`) fail to load for this exact reason.

## Validation

- react-native-paper bake-off: **625 → 662 passing (+37)** with the preset replacing a hand-written worklets mock; the three FAB files now collect and pass, with **zero new regressions** (the remaining failures are the same pre-existing classes — `spyOn(View.prototype)`, externalized-RN-internal mocks, and RNTL-version skew).
- New fixture `tests-native/third-party-presets.test.tsx`: proves auto-detection + shadowing end to end (schedulers run synchronously, `runOnUIAsync` resolves, runtime/shareable helpers defined).
- Full gate green locally: mock suite 1277, native suite 126, typecheck/lint/format clean.