### PR TITLE
fix(jest-compat): make requireActual('react-native') writable

### DIFF
--- a/.changeset/writable-requireactual-rn.md
+++ b/.changeset/writable-requireactual-rn.md
@@ -1,0 +1,5 @@
+---
+"vitest-native": patch
+---
+
+Make `jest.requireActual('react-native')` return a writable facade. Jest suites commonly clone-and-override React Native — `const RN = jest.requireActual('react-native'); RN.Platform = {...}; return RN`. Under the native engine RN's index is a facade of lazy getters with no setters, so assigning to it threw `Cannot set property … which has only a getter` and failed to load the whole test file. `requireActual('react-native')` now returns a write-through proxy: reads fall through to the real (lazy) facade, and assignments are captured so the override wins on later reads — matching Jest's mutable module. Only `react-native` is wrapped; its submodules and other packages are ordinary mutable CommonJS.

--- a/packages/vitest-native/src/jest-compat/setup.mjs
+++ b/packages/vitest-native/src/jest-compat/setup.mjs
@@ -21,7 +21,30 @@ import { jestMockInterop } from "./interop.mjs";
 const projectRoot = process.env.VITEST_NATIVE_PROJECT_ROOT || process.cwd();
 const require = createRequire(path.join(projectRoot, "package.json"));
 
-if (typeof vi.requireActual !== "function") vi.requireActual = (m) => require(m);
+// Real Jest suites commonly clone-and-override React Native:
+//   const RN = jest.requireActual('react-native'); RN.Platform = {...}; return RN
+// Under the native engine RN's index is a CJS facade of lazy getters with no
+// setters (see loader.mjs), so assigning to it throws "Cannot set property … which
+// has only a getter" and takes the whole test file down at load. Jest's module is
+// mutable, so match that: wrap the RN facade in a write-through proxy — reads fall
+// through (keeping the getters lazy), writes are captured in an overlay so the
+// override wins on later reads. Only `react-native` needs this; its submodules and
+// other packages are ordinary mutable CJS.
+function writableModuleFacade(mod) {
+  if (mod == null || typeof mod !== "object") return mod;
+  const overrides = new Map();
+  return new Proxy(mod, {
+    get: (target, prop) => (overrides.has(prop) ? overrides.get(prop) : Reflect.get(target, prop)),
+    set: (_target, prop, value) => {
+      overrides.set(prop, value);
+      return true;
+    },
+    has: (target, prop) => overrides.has(prop) || Reflect.has(target, prop),
+  });
+}
+
+if (typeof vi.requireActual !== "function")
+  vi.requireActual = (m) => (m === "react-native" ? writableModuleFacade(require(m)) : require(m));
 if (typeof vi.requireMock !== "function") vi.requireMock = (m) => require(m);
 // `jest.setTimeout(ms)` has no global `vi` equivalent — no-op so suites that call
 // it at top level don't crash.

--- a/packages/vitest-native/tests-native/requireactual-ts.test.tsx
+++ b/packages/vitest-native/tests-native/requireactual-ts.test.tsx
@@ -12,4 +12,19 @@ describe("native engine: jest.requireActual of app TS/TSX", () => {
     expect(typeof mod.default).toBe("function");
     expect(mod.default()).toBe("real-widget");
   });
+
+  // Real Jest suites clone-and-override RN: `const RN = jest.requireActual(
+  // 'react-native'); RN.Platform = {...}; return RN`. RN's index is a facade of
+  // lazy getters with no setters, so the assignment must not throw, the override
+  // must win on later reads, and un-overridden exports must still resolve.
+  it("returns a writable react-native facade (clone-and-override pattern)", () => {
+    const RN = jest.requireActual("react-native");
+    expect(() => {
+      RN.Platform = { OS: "ios", select: (o: any) => o.ios };
+    }).not.toThrow();
+    expect(RN.Platform.OS).toBe("ios");
+    expect(RN.Platform.select({ ios: 1, android: 2 })).toBe(1);
+    // Un-overridden exports still resolve through the real (lazy) facade.
+    expect(typeof RN.StyleSheet.create).toBe("function");
+  });
 });


### PR DESCRIPTION
## What

Jest suites commonly clone-and-override React Native:

```js
jest.mock('react-native', () => {
  const RN = jest.requireActual('react-native');
  RN.Platform = { OS: 'ios', select: (o) => o.ios };
  return RN;
});
```

Under the native engine RN's index is a facade of lazy getters with no setters (see `loader.mjs`), so `RN.Platform = …` threw `Cannot set property Platform which has only a getter` and failed to load the whole test file.

`jest.requireActual('react-native')` now returns a write-through proxy: reads fall through to the real (lazy) facade — preserving laziness and un-overridden exports — while assignments are captured in an overlay so the override wins on later reads, matching Jest's mutable module. Only `react-native` is wrapped; its submodules and other packages are ordinary mutable CommonJS and are returned unchanged.

## Why

Surfaced by a Jest→vitest-native migration friction audit. The `requireActual('react-native'); RN.X = …` idiom is common in real RN Jest suites, and today it crashes at load under the native engine.

## Scope / honest note

This removes the getter crash for the **valid** form of the pattern (override an export with a compatible value). It is a correctness fix, not a bake-off number-mover on its own: the one suite exercising the pattern in the paper bake-off (RadioButton) also relies on Jest **not** hoisting a `jest.mock` nested in `beforeAll` (so its override is inert under Jest). vitest-native hoists it correctly and the test's own override is malformed (`Platform` set to a function), so that file remains blocked by a separate mock-hoisting-semantics difference tracked independently.

## Validation

- New fixture in `tests-native/requireactual-ts.test.tsx`: asserts the assignment doesn't throw, the override wins on read, and un-overridden exports (`StyleSheet.create`) still resolve through the real facade.
- Full gate green locally: native suite 128, mock suite 1277, typecheck/lint/format clean.