### PR TITLE
fix(native): provide SourceCode.scriptURL so getDevServer resolves

### DIFF
--- a/.changeset/native-sourcecode-scripturl.md
+++ b/.changeset/native-sourcecode-scripturl.md
@@ -1,0 +1,5 @@
+---
+"vitest-native": patch
+---
+
+Provide `SourceCode.getConstants().scriptURL` at the native boundary. RN's `getDevServer` (`Libraries/Core/Devtools/getDevServer.js`) reads `scriptURL` and calls `.match()` on it; under the native engine the value was `undefined`, so `getDevServer` threw and took down any test whose module graph reached it. The boundary now returns a `file://` (bundled) URL for the `SourceCode` native module. It is deliberately not an `http(s)` URL: `getDevServer` only treats `http(s)` script URLs as a live dev server, so a `file://` value keeps `bundleLoadedFromServer` false — tests run as if loaded from a bundle rather than a Metro dev server, which prevents RN internals and third-party SDKs from believing they're connected to a packager and attempting real network I/O against `localhost:8081`. This mirrors the intent of RN's own Jest mock (which keeps that flag off).

--- a/packages/vitest-native/src/native/boundary.mjs
+++ b/packages/vitest-native/src/native/boundary.mjs
@@ -47,6 +47,23 @@ function deviceConstants(platform, reactNativeVersion) {
       doLeftAndRightSwapInRTL: true,
       localeIdentifier: "en_US",
     },
+    // RN's getDevServer (Libraries/Core/Devtools/getDevServer.js) reads
+    // SourceCode.getConstants().scriptURL and calls .match() on it — undefined
+    // there throws and takes the whole file down. Expo's async-require
+    // (messageSocket) pulls this in on any Expo-core-importing test. Provide a
+    // defined string so the lookup resolves instead of crashing.
+    //
+    // Deliberately a file:// (bundled/release) URL, NOT http(s): getDevServer only
+    // treats http(s) scriptURLs as a live server, so a file:// value keeps
+    // `bundleLoadedFromServer` false — tests run as if loaded from a bundle, not a
+    // Metro dev server. That stops RN internals (AssetSourceResolver,
+    // symbolicateStackTrace, DevTools) and third-party SDKs from believing they're
+    // connected to a packager and attempting real network I/O against localhost:8081.
+    // Mirrors RN's own jest mock, which keeps this flag off (scriptURL: null there,
+    // but null would re-introduce the .match crash, so we use a bundled URL).
+    SourceCode: {
+      scriptURL: "file:///index.bundle",
+    },
   };
 }
 

--- a/packages/vitest-native/tests-native/dev-server.test.ts
+++ b/packages/vitest-native/tests-native/dev-server.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Proof: RN's `getDevServer` resolves under the native engine because the boundary
+ * provides `SourceCode.getConstants().scriptURL`. Without it, getDevServer calls
+ * `.match()` on `undefined` and throws — which under the native engine takes down
+ * any test whose module graph reaches it (Expo's async-require `messageSocket`
+ * pulls it in on Expo-core-importing suites). Surfaced by the obytes bake-off,
+ * where the whole login-form file failed to collect for this reason.
+ */
+import { describe, it, expect } from "vitest";
+// eslint-disable-next-line
+import getDevServer from "react-native/Libraries/Core/Devtools/getDevServer";
+
+describe("native engine: getDevServer / SourceCode.scriptURL", () => {
+  it("resolves instead of crashing on undefined scriptURL", () => {
+    // A non-string scriptURL would throw inside getDevServer (`.match`) before
+    // returning; reaching here at all proves the boundary provides a string.
+    const server = getDevServer();
+    expect(typeof server.url).toBe("string");
+  });
+
+  it("reports the bundle as NOT loaded from a dev server (no network I/O)", () => {
+    // The scriptURL is a file:// (bundled) URL, so getDevServer must not treat the
+    // test as connected to Metro — otherwise RN internals / third-party SDKs would
+    // attempt real fetches/WebSockets against localhost:8081.
+    expect(getDevServer().bundleLoadedFromServer).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

RN's `getDevServer` (`Libraries/Core/Devtools/getDevServer.js`) reads `SourceCode.getConstants().scriptURL` and calls `.match()` on it. Under the native engine `scriptURL` was `undefined`, so `getDevServer` threw `Cannot read properties of undefined (reading 'match')` and took down any test whose module graph reached it.

The boundary's device constants now return a **`file://` (bundled) URL** for the `SourceCode` native module.

### Why `file://` and not `http://`

`getDevServer` derives `bundleLoadedFromServer` from whether `scriptURL` matches `^https?://`. A `file://` value keeps that flag **false**, so tests behave as if the bundle was loaded from disk (a release/embedded build) rather than a live Metro dev server. That matters because a truthy `bundleLoadedFromServer` makes RN internals (`AssetSourceResolver` building live asset fetch URLs, `symbolicateStackTrace` fetching, `setUpReactDevTools` opening a WebSocket) and third-party SDKs that read `SourceCode` directly believe they're connected to a packager and attempt **real network I/O against `localhost:8081`** — which hangs or `ECONNREFUSED`s in CI. RN's own Jest mock deliberately keeps this flag off; this mirrors that intent while still returning a defined string so `.match()` doesn't crash.

## Why

Surfaced by a Jest→vitest-native migration friction audit. `getDevServer` is foundational RN dev plumbing reached by symbolication, DevTools, Expo's async-require, and crash-reporting SDKs; an `undefined` `scriptURL` crashes any file that touches those paths.

## Scope / honest note

This is a foundational correctness fix (prevents the `undefined.match` crash and keeps `bundleLoadedFromServer` false), **not** a bake-off pass-count mover on its own. In the obytes bake-off it does not unblock the `login-form` file: with `bundleLoadedFromServer` correctly false, Expo's `messageSocket` (under `__DEV__`) throws `Cannot create devtools websocket connections in embedded environments` — a separate, deeper Expo-init wall tracked independently. (The earlier `http://` value masked this only by letting Expo open a real dev-server WebSocket, which is precisely the network-I/O this PR avoids.)

## Validation

- New fixture `tests-native/dev-server.test.ts`: asserts `getDevServer()` resolves without crashing **and** reports `bundleLoadedFromServer === false` (no network I/O).
- Full gate green locally: native suite 129, mock suite 1277, typecheck/lint/format clean.
- Independent adversarial review flagged the original `http://` value's network-I/O risk; this PR is the corrected `file://` version.