### PR TITLE
docs(migration): document known limits + transform-allowlist from real runs

### DIFF
--- a/.changeset/migration-known-limits.md
+++ b/.changeset/migration-known-limits.md
@@ -1,0 +1,5 @@
+---
+"vitest-native": patch
+---
+
+Expand the "Migrating from Jest" guide with the empirically-derived limits of a real migration: a "Known limits" section covering assertions coupled to Jest's RN mock internals that don't port under a real-RN engine (`jest.spyOn(View.prototype, …)`, mocks of RN internal submodules, raw `source`-shape assertions, `jest.mock` nested in callbacks), an Expo-core caveat, and concrete guidance for the `transformIgnorePatterns` → `transform` allowlist (including the JSX-in-`.js` third-party-lib parse error and its fix).

--- a/packages/vitest-native/docs/migrating-from-jest.md
+++ b/packages/vitest-native/docs/migrating-from-jest.md
@@ -101,6 +101,13 @@ Those are Jest/Metro config. vitest-native handles RN + third-party transformati
 For *run-real pure-JS* third-party libs under the native engine, use the plugin's `transform: [...]`
 allowlist instead of `transformIgnorePatterns`.
 
+One case needs a manual `transform` entry: a library shipping **untranspiled JSX in `.js` files**
+(its `package.json` `"react-native"`/`"module"` field points at `src/`). Under the native engine
+it's external to the Vite graph, so you'll see `Failed to parse source for import analysis … If you
+are using JSX, make sure to name the file with the .jsx or .tsx extension. File: node_modules/<lib>/…`.
+The error names the file — add that package: `reactNative({ engine: 'native', transform: ['<lib>'] })`.
+Same entry is needed when a `vi.mock('<lib>')` must intercept an otherwise-externalized library.
+
 ### 2f. Jest config options
 `jest.config.js` keys (`setupFilesAfterEnv`, `moduleNameMapper`, `testEnvironment`, etc.) move to the
 Vitest config: `setupFiles`, `resolve.alias`, `test.environment: 'node'`. `jest.setTimeout(ms)` is a
@@ -108,17 +115,45 @@ no-op under the shim (use `test.testTimeout` in config or per-test `{ timeout }`
 
 ---
 
-## 3. Suggested migration recipe
+## 3. Known limits — assertions coupled to Jest's mocks
+
+A minority of tests assert on **Jest's React Native mock internals** rather than rendered behavior.
+The native engine runs *real* RN, so these can't be reproduced without re-mocking RN internally
+(which defeats the point). Recognize them so you rewrite or skip rather than chase them. In our runs
+they clustered in **component libraries** (which test RN internals directly); ordinary app suites hit
+few or none.
+
+- **`jest.spyOn(View.prototype, 'measure'/'measureInWindow')`** — Jest mocks `View` as a class with
+  prototype methods; real RN's `View` is a `forwardRef` with no such prototype, so the spy target is
+  `undefined`. Drive layout via `onLayout`/`fireEvent` instead, or accept as known-incompatible.
+- **`jest.mock('react-native/Libraries/…')` of internal submodules** (e.g. `Appearance`,
+  `AccessibilityInfo`) then spying them — externalized/resident RN isn't intercepted by a submodule
+  mock. Prefer the public API from `react-native`.
+- **`image.props.source.uri` / raw `source`-shape assertions** — real RN normalizes `source`, so the
+  raw shape differs. Native = real RN = ground truth; assert on behavior instead.
+- **`jest.mock('react-native', …)` nested inside `beforeAll`/`describe` callbacks** — Jest doesn't
+  hoist those (they're inert); vitest-native applies mocks more consistently, which can expose a mock
+  that was silently a no-op. Move it to top level with a valid override, or drop it.
+
+The `jest.requireActual('react-native')` clone-and-override pattern is supported (RN's module is
+writable under the compat layer). **Expo caveat:** suites importing **Expo core** pull in Expo's
+dev-server/init plumbing (message socket, dev tools) that expects a Metro connection and may not
+collect without extra setup; suites using Expo *modules* via the `expo` preset are unaffected.
+
+---
+
+## 4. Suggested migration recipe
 
 1. Add the jest-compat config (section 1). Upgrade RNTL to a supported 12–14 release (2b).
 2. Delete manual third-party native-lib mocks and `@react-native/jest-preset` (2c, 2e).
 3. Convert any **top-level** `jest.mock(...)` to `vi.mock(...)`; leave runtime `jest.*` as-is (2a).
 4. Run `vitest run -u` once to re-record snapshots (2d), then `vitest run` to confirm green.
-5. Triage remaining failures — usually a missing query update or a suite-specific mock. For runtime
-   issues (large-suite memory limits, error-boundary console noise, overriding a preset's mock), see
-   the [Troubleshooting](../README.md#troubleshooting) section.
+5. Triage remaining failures — a missing query update, a suite-specific mock, or a known
+   Jest-mock-coupled assertion (section 3). For runtime issues (large-suite memory limits,
+   error-boundary console noise, overriding a preset's mock), see the
+   [Troubleshooting](../README.md#troubleshooting) section.
 
-## 4. What "done" looks like
+## 5. What "done" looks like
 
 A migrated suite runs under Vitest with: the jest-compat aliases + setup, RNTL 12–14, no manual
 third-party native mocks, top-level mocks converted, and snapshots re-recorded. You get Vitest's

--- a/website/migration/from-jest.md
+++ b/website/migration/from-jest.md
@@ -84,18 +84,52 @@ Prefer explicit queries (`getByText`, `getByTestId`, `getByRole`) over large sna
 
 Drop `@react-native/jest-preset` and `transform` / `transformIgnorePatterns` — those are Jest/Metro config. vitest-native handles RN + third-party transformation itself (`engine: 'native'` transforms real RN in Node's loader hooks; the mock engine virtualizes RN). For *run-real pure-JS* third-party libs under the native engine, use the plugin's [`transform`](/guide/plugin-options#transform) allowlist instead of `transformIgnorePatterns`.
 
+The one case that needs a manual `transform` entry: a library that ships **untranspiled JSX in `.js` files** (its `package.json` `"react-native"`/`"module"` field points at `src/`, relying on Metro to transform it). Under the native engine such a lib is external to the Vite graph, and you'll see:
+
+```
+Failed to parse source for import analysis because the content contains invalid JS
+syntax. If you are using JSX, make sure to name the file with the .jsx or .tsx extension.
+  File: node_modules/<lib>/src/Something.js
+```
+
+The error names the offending file — add that package to `transform` so vitest-native transforms it:
+
+```ts
+reactNative({ engine: 'native', transform: ['<lib>'] })
+```
+
+This is the direct replacement for having listed the lib in `transformIgnorePatterns` under Jest. It's also required when a `vi.mock('<lib>')` must intercept an otherwise-externalized library — `vi.mock` only applies to modules pulled into the Vite graph.
+
 ### Move jest config options to Vitest
 
 `jest.config.js` keys (`setupFilesAfterEnv`, `moduleNameMapper`, `testEnvironment`, etc.) move to the Vitest config: `setupFiles`, `resolve.alias`, `test.environment: 'node'`. `jest.setTimeout(ms)` is a no-op under the shim (use `test.testTimeout` in config or per-test `{ timeout }`).
 
-## 3. Suggested migration recipe
+## 3. Known limits — assertions coupled to Jest's mocks
+
+A minority of tests assert on **Jest's React Native mock internals** rather than on rendered behavior. The native engine runs *real* React Native, so these can't be reproduced without re-mocking RN internally (which would defeat the point). They're worth recognizing up front so you can rewrite or skip them rather than chase them. In our own runs these were concentrated in **component libraries** (which test RN internals directly); ordinary app suites hit few or none.
+
+| Jest-coupled pattern | Why it doesn't port | What to do |
+|---|---|---|
+| `jest.spyOn(View.prototype, 'measure')` / `'measureInWindow'` | Jest mocks `View` as a class with methods on its prototype; real RN's `View` is a `forwardRef` with no such prototype, so the spy target is `undefined`. | Rewrite to drive layout via `onLayout` / `fireEvent`, or accept as a known-incompatible assertion. |
+| `jest.mock('react-native/Libraries/Utilities/Appearance')` (and other deep RN-internal submodules), then `jest.spyOn` them | Under the native engine RN is externalized/resident, so a mock of an internal submodule never intercepts the module the app already imported. | Prefer the public API (e.g. `Appearance` from `react-native`); vitest-native provides controllable boundaries for common ones. |
+| `image.props.source.uri` / raw `source`-shape assertions | Real RN normalizes the `source` prop (an object like `{ uri }`), so tests reading the raw mock shape see a different value. Native = real RN = ground truth. | Assert on behavior (what renders) rather than the internal prop shape. |
+| `jest.mock('react-native', …)` **nested inside** `beforeAll`/`describe` callbacks | Jest does **not** hoist a `jest.mock` inside a callback, so under Jest it's effectively inert; vitest-native applies mocks more consistently, which can expose a mock that was silently doing nothing. | Move the mock to top level and make its override valid, or drop it if it was a no-op. |
+
+The `jest.requireActual('react-native')` clone-and-override pattern (`const RN = jest.requireActual('react-native'); RN.Platform = {…}; return RN`) **is** supported — RN's module is writable under the compat layer.
+
+::: warning Expo-core-coupled suites
+A test that imports **Expo core** pulls in Expo's dev-server/init plumbing (async-require message socket, dev tools), which expects a running Metro connection. Deeply Expo-coupled files may not collect under the native engine without additional setup — this is the documented not-turnkey case. Suites that use Expo *modules* (via the auto-detected `expo` preset) are unaffected; it's Expo *core* import chains that hit this.
+:::
+
+## 4. Suggested migration recipe
 
 1. Add the jest-compat config (section 1). Upgrade RNTL to a supported 12–14 release.
 2. Delete manual third-party native-lib mocks and `@react-native/jest-preset`.
 3. Convert any **top-level** `jest.mock(...)` to `vi.mock(...)`; leave runtime `jest.*` as-is (or rely on `jestMockTransform()`).
-4. Run `vitest run -u` once to re-record snapshots, then `vitest run` to confirm green.
-5. Triage remaining failures — usually a missing query update or a suite-specific mock.
+4. Add any JSX-in-`.js` third-party libs to `transform` as their parse errors surface (section 2).
+5. Run `vitest run -u` once to re-record snapshots, then `vitest run` to confirm green.
+6. Triage remaining failures — a missing query update, a suite-specific mock, or a known Jest-mock-coupled assertion (section 3).
 
-## 4. What "done" looks like
+## 5. What "done" looks like
 
 A migrated suite runs under Vitest with: the jest-compat aliases + setup, RNTL 12–14, no manual third-party native mocks, top-level mocks converted, and snapshots re-recorded. You get Vitest's speed/watch/UI while keeping `engine: 'native'` real-RN fidelity (or `engine: 'mock'` for the fast path). The compat layer is intentionally small — it removes the mechanical Jest coupling so the only work left is the genuinely suite-specific bits.


### PR DESCRIPTION
## What

Expands the [Migrating from Jest](https://danfry1.github.io/vitest-native/migration/from-jest) guide with the empirically-derived reality of a real migration, from friction audits across the obytes, react-native-paper, and rneui suites:

- **New "Known limits" section** — assertions coupled to Jest's RN *mock internals* that can't reproduce under a real-RN engine, each with a recommended action:
  - `jest.spyOn(View.prototype, 'measure'/'measureInWindow')` (real RN's `View` is a `forwardRef`, no prototype method)
  - `jest.mock('react-native/Libraries/…')` of internal submodules + spying them (externalized RN isn't intercepted)
  - raw `source`-shape assertions (real RN normalizes `source`)
  - `jest.mock('react-native', …)` nested in `beforeAll`/`describe` callbacks (Jest doesn't hoist those; vitest-native applies mocks more consistently)
- **Expo-core caveat** — suites importing Expo *core* pull in dev-server/init plumbing that expects a Metro connection and may not collect; suites using Expo *modules* via the `expo` preset are unaffected.
- **Concrete `transform` allowlist guidance** — the JSX-in-`.js` third-party-lib parse error (a lib pointing its `react-native`/`module` field at untranspiled `src/`) and the fix (add the package to `transform`), as the direct replacement for `transformIgnorePatterns`; also noting `vi.mock` needs the lib in the Vite graph.

Applied to both the website guide and the packaged `docs/` copy so they stay consistent.

## Why

The guide already covered the mechanical steps but set the expectation that remaining failures are "usually a missing query update." The audits showed a distinct, nameable class of Jest-mock-coupled assertions that *won't* port — documenting them sets honest expectations and tells migrators what to rewrite vs. chase.

## Validation

- `vitepress build website` renders cleanly with these changes.
- Docs-only; no code paths touched.

## Note (separate issue, not in this PR)

While validating, found that `website/guide/fidelity.md` (a **generated** file from the fidelity-report pipeline) contains a bare `<Text>` in a table cell that VitePress parses as an unclosed tag, which **breaks `vitepress build` on main** (and thus the Pages deploy). The fix belongs in the report generator (escape/backtick-wrap angle-bracket tokens); filing separately.