### PR TITLE
fix(fidelity): escape Markdown/Vue hazards in generated report cells

### DIFF
--- a/packages/vitest-native/scripts/fidelity-report.mjs
+++ b/packages/vitest-native/scripts/fidelity-report.mjs
@@ -98,12 +98,25 @@ const knownDiffs = fs.existsSync(knownDiffsPath)
   ? JSON.parse(fs.readFileSync(knownDiffsPath, "utf8"))
   : [];
 
+// The page is built by VitePress, which parses Markdown as Vue: a bare `<Tag>`
+// in free text is read as an (unclosed) HTML element and breaks the build, `|`
+// breaks table columns, and `{{ }}` is Vue interpolation. Probe names/reasons
+// and known-difference text come from the corpus, so escape those hazards in
+// any cell rendered as free text (not inside a code span).
+const cell = (s) =>
+  String(s ?? "")
+    .replace(/\|/g, "\\|")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\{\{/g, "&#123;&#123;")
+    .replace(/\}\}/g, "&#125;&#125;");
+
 const probeRows = probes
-  .map((p) => `| \`${p.name}\` | ${p.match ? "✅ match" : `❌ ${p.reason ?? "diverged"}`} |`)
+  .map((p) => `| \`${p.name}\` | ${p.match ? "✅ match" : `❌ ${cell(p.reason ?? "diverged")}`} |`)
   .join("\n");
 
 const knownDiffRows = knownDiffs.length
-  ? knownDiffs.map((d) => `| ${d.area} | ${d.difference} | ${d.why} |`).join("\n")
+  ? knownDiffs.map((d) => `| ${cell(d.area)} | ${cell(d.difference)} | ${cell(d.why)} |`).join("\n")
   : "| _none recorded_ | | |";
 
 const page = `<!--

--- a/website/guide/fidelity.md
+++ b/website/guide/fidelity.md
@@ -113,5 +113,5 @@ They are documented here rather than hidden.
 | Area | Behavior | Why it isn't gated |
 | --- | --- | --- |
 | Default device metrics (Dimensions / PixelRatio) | The default window/screen size, pixel ratio and font scale are a fixed test-host default. Both engines report the same default — the cross-check gates that — but it is not any specific physical device. | Device metrics aren't behavior, and the default won't match a real device. Tests that depend on exact metrics should set them explicitly (e.g. Dimensions.set) rather than rely on the default. |
-| Text onPress accessibilityRole | A <Text> with an onPress handler is auto-assigned accessibilityRole "link" by some React Native versions and not others. | Version-variant across the supported RN range — a single mock value can't match every minor, so it isn't pinned by a probe. |
+| Text onPress accessibilityRole | A &lt;Text&gt; with an onPress handler is auto-assigned accessibilityRole "link" by some React Native versions and not others. | Version-variant across the supported RN range — a single mock value can't match every minor, so it isn't pinned by a probe. |
 | Appearance color scheme | Appearance.getColorScheme() reflects the host environment rather than a fixed value. | Environment-dependent (CI vs local, OS settings), so it isn't a stable cross-engine invariant to gate. |


### PR DESCRIPTION
## What

The fidelity report page (`website/guide/fidelity.md`) is generated by `scripts/fidelity-report.mjs` and rendered by VitePress, which parses Markdown as Vue. A known-difference description contained a bare `<Text>`, which VitePress reads as an **unclosed HTML element** — so `vitepress build` fails with `Element is missing end tag` at that row.

This has broken `bun run build:website` (and therefore the Pages deploy) on `main` since the report began publishing that row.

## Fix

Escape free-text table cells in the generator before interpolating them into Markdown — angle brackets (`<`/`>` → entities), table-breaking pipes (`|` → `\|`), and Vue interpolation (`{{`/`}}`). This covers both the probe-reason cells and the known-difference rows, so any corpus-derived text is safe to render.

The one currently-affected cell (`<Text>` → `&lt;Text&gt;`) is updated in the committed page to match the fixed generator's deterministic output. That is the only token the new escaping changes, so the committed page equals a fresh regeneration and the `fidelity:check` drift guard stays green (numbers are untouched).

## Validation

- `vitepress build website` now completes cleanly (previously failed at `fidelity.md`).
- The escaping only rewrites hazard characters; probe numbers and all other content are unchanged.

## Context

Found while updating the migration guide (#66); filed separately as it's an unrelated pre-existing deploy break.