### PR TITLE
ci: cancel superseded runs, cache bun downloads and transform output, bound matrix cells

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,13 @@ on:
 permissions:
   contents: read
 
+# A force-push to a PR branch previously left the superseded run executing to
+# completion alongside the new one. Cancel superseded runs on PR refs; keep
+# main pushes uncancelled so every landed commit gets a full verdict.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   check:
     name: Full gate (${{ matrix.os }}, Node ${{ matrix.node-version }})
@@ -48,8 +55,29 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      # Package-download cache: bun still verifies against the frozen lockfile,
+      # it just skips re-downloading unchanged tarballs.
+      - name: Cache bun downloads
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      # vitest-native's own on-disk caches (the Babel transform of the RN graph +
+      # the V8 compile cache) live under node_modules/.cache/vitest-native and are
+      # content/version-keyed internally, so restoring a stale snapshot is safe —
+      # outdated entries simply miss. Restored after install (bun may reshape
+      # node_modules), saved automatically post-job.
+      - name: Cache vitest-native transform output
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: packages/vitest-native/node_modules/.cache/vitest-native
+          key: vn-transform-${{ runner.os }}-node${{ matrix.node-version }}-${{ hashFiles('bun.lock') }}
+          restore-keys: vn-transform-${{ runner.os }}-node${{ matrix.node-version }}-
 
       - name: Verify dependencies are pinned
         run: bun run lint:deps

--- a/.github/workflows/native-rn-matrix.yml
+++ b/.github/workflows/native-rn-matrix.yml
@@ -36,10 +36,19 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs on PR refs (a force-push previously left 10+ stale
+# cells running to completion); keep main/scheduled runs uncancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   matrix:
     name: native+hot — vitest ${{ matrix.vitest }} × RN ${{ matrix.rn }}
     runs-on: ubuntu-latest
+    # Without a bound, a hung cell (e.g. a stuck hot-soak worker) burns the
+    # 360-minute default. A healthy cell finishes well under 15 minutes.
+    timeout-minutes: 30
     strategy:
       # Report every cell independently rather than stopping at the first failure.
       fail-fast: false
@@ -58,6 +67,15 @@ jobs:
         with:
           node-version: '22.13.0'
 
+      # Package-download cache: bun still verifies against the frozen lockfile,
+      # it just skips re-downloading unchanged tarballs.
+      - name: Cache bun downloads
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
@@ -66,6 +84,18 @@ jobs:
       - name: Pin react-native + babel-preset to ${{ matrix.rn }}
         run: |
           bun add -d "react-native@${{ matrix.rn }}" "@react-native/babel-preset@${{ matrix.rn }}" --cwd packages/vitest-native
+
+      # vitest-native's on-disk caches (Babel transform of the RN graph + V8
+      # compile cache), keyed per matrix cell — each cell transforms a different
+      # RN version. Entries are content/version-keyed internally, so a stale
+      # restore is a miss, never a wrong hit. Restored after the version pins
+      # (bun add reshapes node_modules), saved automatically post-job.
+      - name: Cache vitest-native transform output
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: packages/vitest-native/node_modules/.cache/vitest-native
+          key: vn-transform-${{ runner.os }}-rn${{ matrix.rn }}-vitest-${{ matrix.vitest }}-${{ hashFiles('bun.lock') }}
+          restore-keys: vn-transform-${{ runner.os }}-rn${{ matrix.rn }}-vitest-${{ matrix.vitest }}-
 
       - name: Pin Vitest to the newest supported 4.x release
         if: matrix.vitest == 'latest-supported'


### PR DESCRIPTION
## Problem

Four CI-hygiene gaps:

1. **No concurrency control.** A force-push to a PR branch left the superseded run — 5 full-gate legs plus 12 matrix cells — executing to completion alongside the new run.
2. **No dependency caching.** Every job cold-downloaded all packages on every run.
3. **The native engine's transform work was rebuilt from scratch every job.** Each matrix cell Babel-transforms React Native's ~250-file boot graph; nothing persisted it.
4. **Matrix cells had no timeout** — a hung cell (e.g. a stuck hot-soak worker) burned the 360-minute default.

## Change

- `concurrency` groups on `ci.yml` and `native-rn-matrix.yml` with `cancel-in-progress` on non-main refs; pushes to main stay uncancelled so every landed commit gets a full verdict.
- `actions/cache` (SHA-pinned, v4.3.0) for bun's package-download store, keyed on the lockfile. Installs still verify with `--frozen-lockfile`; only the tarball downloads are skipped.
- `actions/cache` for `packages/vitest-native/node_modules/.cache/vitest-native` (the Babel transform + V8 compile caches), keyed per OS/Node leg in the full gate and per RN × Vitest cell in the matrix. The cache's entries are content- and version-keyed internally, so a stale restore can only miss, never serve a wrong hit. **This step becomes effective once the transform-cache relocation (`perf/transform-cache`) lands** — before that the path doesn't exist and the step is a harmless no-op, so the two PRs can land in either order.
- `timeout-minutes: 30` on the matrix job (healthy cells finish well under 15).

All new expressions use trusted contexts only (`github.ref`, `runner.os`, `matrix.*`, `hashFiles`); no event-payload data reaches `run:` commands.