### PR TITLE
fix(deps): bump bench vitest to 4.1.9 (security advisory)

### DIFF
--- a/bench/package.json
+++ b/bench/package.json
@@ -15,7 +15,7 @@
     "@babel/runtime": "7.29.7",
     "@react-native/babel-preset": "0.85.3",
     "@testing-library/react-native": "12.9.0",
-    "@vitest/coverage-v8": "4.0.18",
+    "@vitest/coverage-v8": "4.1.9",
     "babel-jest": "29.7.0",
     "jest": "29.7.0",
     "jest-environment-node": "29.7.0",
@@ -23,7 +23,7 @@
     "react-native": "0.84.1",
     "react-test-renderer": "19.2.4",
     "vite": "6.4.3",
-    "vitest": "4.0.18",
+    "vitest": "4.1.9",
     "vitest-native": "file:../packages/vitest-native"
   }
 }


### PR DESCRIPTION
Dependabot alert #1 (critical): Vitest UI server in >=4.0.0 <4.1.0 allows arbitrary file read and execution when listening. The bench workspace pinned vitest 4.0.18; this bumps vitest and @vitest/coverage-v8 to 4.1.9. Dev-scope only, but clears the repository's open critical alert.