### PR TITLE
feat(dx): actionable errors and engine transparency at migration failure points

### DIFF
--- a/.changeset/actionable-errors.md
+++ b/.changeset/actionable-errors.md
@@ -1,0 +1,11 @@
+---
+"vitest-native": minor
+---
+
+Actionable errors and engine transparency for migration failure points.
+
+- **Untransformed-package explainer**: when an externalized `node_modules` file throws a SyntaxError that fingerprints as untranspiled JSX/Flow/TypeScript (`Unexpected token '<'` and friends), the error now names the owning package and states the fix — `reactNative({ transform: ['<pkg>'] })` — with a link to the migration guide, instead of a bare Node compile stack. This is the single most common migration blocker observed in real-app bake-offs.
+- **Decorated Babel failures**: a Babel crash inside the native transform now reports the file, platform, and owning package at the single transform choke point (ESM loader, CJS require hook, and `requireActual` all inherit it), chaining the original error as `cause`.
+- **Engine banner**: one log line per process states which engine actually ran (`engine: native — real react-native@X` / `engine: mock — …`), so a silent `auto` fallback can never masquerade as real-RN testing.
+- **Config-time fail-fast**: explicit `engine: 'native'` without `@react-native/babel-preset` / `@babel/core` now fails at config time with install instructions, instead of starting the run and dying inside the loader. The `auto`→mock fallback notice is now emitted via `console.warn`, and the Flow-strip parse-failure warning is always visible (no longer diagnostics-gated).
+- **jest-compat signposts**: `jest.isolateModules`, `jest.createMockFromModule`, `jest.genMockFromModule`, and `jest.deepUnmock` now throw errors that name the API and its closest Vitest migration instead of bare `is not a function` TypeErrors; `jest.retryTimes` warns once and continues instead of crashing the suite.

--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,9 @@
     "packages/vitest-native": {
       "name": "vitest-native",
       "version": "0.8.0",
+      "bin": {
+        "vitest-native": "./dist/cli.mjs",
+      },
       "dependencies": {
         "flow-remove-types": "^2.321.0",
         "magic-string": "^0.30.21",
@@ -71,6 +74,7 @@
         "test-renderer": "^1.2.0",
         "tsdown": "0.21.10",
         "typescript": "6.0.3",
+        "untranspiled-jsx-lib": "file:./tests-native/fixtures/untranspiled-jsx-lib",
         "vite": "^8.0.5",
         "vitest": "^4.1.8",
       },
@@ -1824,6 +1828,8 @@
     "vitest-native/ext-platform-lib": ["ext-platform-lib@file:packages/vitest-native/tests-native/fixtures/ext-platform-lib", {}],
 
     "vitest-native/ext-rn-named-lib": ["ext-rn-named-lib@file:packages/vitest-native/tests-native/fixtures/ext-rn-named-lib", {}],
+
+    "vitest-native/untranspiled-jsx-lib": ["untranspiled-jsx-lib@file:packages/vitest-native/tests-native/fixtures/untranspiled-jsx-lib", {}],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 

--- a/packages/vitest-native/package.json
+++ b/packages/vitest-native/package.json
@@ -176,6 +176,7 @@
     "test-renderer": "^1.2.0",
     "tsdown": "0.21.10",
     "typescript": "6.0.3",
+    "untranspiled-jsx-lib": "file:./tests-native/fixtures/untranspiled-jsx-lib",
     "vite": "^8.0.5",
     "vitest": "^4.1.8"
   },

--- a/packages/vitest-native/src/jest-compat/setup.mjs
+++ b/packages/vitest-native/src/jest-compat/setup.mjs
@@ -65,6 +65,47 @@ vi.advanceTimersByTime = (...args) =>
 vi.advanceTimersByTimeAsync = async (...args) =>
   vi.isFakeTimers() ? advanceTimersByTimeAsync(...args) : undefined;
 
+// Jest APIs with NO Vitest equivalent would otherwise surface as bare
+// "jest.isolateModules is not a function" TypeErrors deep in a migrated suite.
+// Give each one an error that names the API and states the closest migration,
+// so the failure is a signpost instead of a mystery.
+const MIGRATION_GUIDE =
+  "https://github.com/danfry1/vitest-native/blob/main/packages/vitest-native/docs/migrating-from-jest.md";
+function unsupported(name, guidance) {
+  if (typeof vi[name] === "function") return;
+  vi[name] = () => {
+    throw new Error(
+      `[vitest-native] jest.${name}() has no Vitest equivalent. ${guidance} See ${MIGRATION_GUIDE}`,
+    );
+  };
+}
+unsupported(
+  "isolateModules",
+  "Use vi.resetModules() plus a dynamic import() to get a fresh module copy.",
+);
+unsupported(
+  "createMockFromModule",
+  "Build the mock explicitly with vi.fn()/vi.mock(), or import the real module and override members.",
+);
+unsupported(
+  "genMockFromModule",
+  "Build the mock explicitly with vi.fn()/vi.mock(), or import the real module and override members.",
+);
+unsupported("deepUnmock", "Use vi.unmock()/vi.doUnmock() per module.");
+// jest.retryTimes configures retries at runtime; Vitest configures them statically.
+// Warn once and continue — crashing a suite over retry policy helps nobody.
+if (typeof vi.retryTimes !== "function") {
+  let warned = false;
+  vi.retryTimes = () => {
+    if (!warned) {
+      warned = true;
+      console.warn(
+        `[vitest-native] jest.retryTimes() is ignored under Vitest — set test.retry in your vitest config (or per-test: test('name', { retry: N }, fn)).`,
+      );
+    }
+  };
+}
+
 globalThis.jest = vi;
 
 // jest.mock factories are wrapped by jestMockTransform to route their return

--- a/packages/vitest-native/src/native/explain.mjs
+++ b/packages/vitest-native/src/native/explain.mjs
@@ -1,0 +1,69 @@
+// Turns the native engine's two worst failure moments — a Babel crash while
+// transforming a file, and Node choking on untranspiled JSX/Flow from an
+// externalized package — into errors that name the package and say what to do.
+// Pure functions; used by transform.mjs and hooks.mjs, unit-tested directly.
+
+/** The npm package name owning `file`, from its deepest node_modules segment, or null. */
+export function packageNameFromPath(file) {
+  const norm = String(file).replace(/\\/g, "/");
+  const idx = norm.lastIndexOf("/node_modules/");
+  if (idx === -1) return null;
+  const rest = norm.slice(idx + "/node_modules/".length);
+  const segs = rest.split("/");
+  if (!segs[0]) return null;
+  if (segs[0].startsWith("@")) return segs[1] ? `${segs[0]}/${segs[1]}` : segs[0];
+  return segs[0];
+}
+
+/**
+ * Decorate a Babel failure from transformRN with the file, platform, and owning
+ * package, preserving the original message (Babel's includes a code frame) and
+ * chaining the original error as `cause`.
+ */
+export function decorateTransformError(err, file, platform) {
+  const pkg = packageNameFromPath(file);
+  const subject = pkg ? `'${pkg}' (${file})` : `${file}`;
+  const hint = pkg
+    ? `The React Native Babel preset could not parse this file from ${pkg}. ` +
+      `If this happens on a package you added to transform: [...], the package may ` +
+      `ship syntax the preset can't handle — please report it at ` +
+      `https://github.com/danfry1/vitest-native/issues with the error below.`
+    : `The React Native Babel preset could not parse this file.`;
+  const wrapped = new Error(
+    `[vitest-native] Failed to transform ${subject} for platform '${platform}'.\n` +
+      `${hint}\n\n${err && err.message ? err.message : String(err)}`,
+    { cause: err },
+  );
+  wrapped.name = err && err.name ? err.name : "Error";
+  return wrapped;
+}
+
+// Node's SyntaxError messages when it compiles untranspiled JSX / Flow / TS.
+// "Unexpected token '<'" = JSX; "Unexpected identifier" / "Unexpected reserved
+// word" commonly = type annotations or `import type`.
+const UNTRANSPILED_SYNTAX =
+  /Unexpected token '?<'?|Unexpected identifier|Unexpected reserved word|Missing initializer in const|Unexpected token ':'/;
+
+/**
+ * When Node throws a SyntaxError compiling a node_modules file that vitest-native
+ * did NOT transform, explain the (very common) real cause: the package ships
+ * untranspiled JSX/Flow/TS and needs to be added to `transform: [...]`.
+ * Returns a decorated error, or null when the failure doesn't match the pattern.
+ */
+export function explainUntransformedSyntaxError(err, file) {
+  if (!err || err.name !== "SyntaxError") return null;
+  if (!UNTRANSPILED_SYNTAX.test(String(err.message))) return null;
+  const pkg = packageNameFromPath(file);
+  if (!pkg) return null;
+  const wrapped = new SyntaxError(
+    `[vitest-native] '${pkg}' shipped source Node can't run directly ` +
+      `(${err.message} in ${file}).\n` +
+      `This usually means the package publishes untranspiled JSX, Flow, or TypeScript. ` +
+      `Ask vitest-native to transform it:\n\n` +
+      `  reactNative({ transform: ['${pkg}'] })\n\n` +
+      `in your vitest config. See https://github.com/danfry1/vitest-native` +
+      `/blob/main/packages/vitest-native/docs/migrating-from-jest.md`,
+    { cause: err },
+  );
+  return wrapped;
+}

--- a/packages/vitest-native/src/native/hooks.mjs
+++ b/packages/vitest-native/src/native/hooks.mjs
@@ -7,6 +7,7 @@ import { transformRN, isFlow } from "./transform.mjs";
 import { boundarySourceFor } from "./boundary.mjs";
 import { resolvePlatformFile } from "./resolve.mjs";
 import { buildPkgMatcher, packageNameOf, subpathLeafOf, isUtilitySubpath } from "./match.mjs";
+import { explainUntransformedSyntaxError } from "./explain.mjs";
 
 const RN_PATH = /[\\/]node_modules[\\/](react-native|@react-native)[\\/]/;
 // Any file under a node_modules directory. Platform-extension resolution
@@ -153,6 +154,17 @@ export function installRequireHooks(
       // type`/JSX aren't caught by isFlow, and babel passes plain JS through.
       const src = fs.readFileSync(filename, "utf8");
       return mod._compile(transformRN(filename, src, projectRoot, platform), filename);
+    }
+    if (NODE_MODULES.test(norm)) {
+      // A node_modules package we did NOT transform: when Node's compile throws a
+      // SyntaxError that fingerprints as untranspiled JSX/Flow/TS, explain the
+      // real fix (add the package to `transform: [...]`) instead of leaving a
+      // bare "Unexpected token '<'" — the single most common migration blocker.
+      try {
+        return origJs(mod, filename);
+      } catch (err) {
+        throw explainUntransformedSyntaxError(err, filename) ?? err;
+      }
     }
     return origJs(mod, filename);
   };

--- a/packages/vitest-native/src/native/transform.mjs
+++ b/packages/vitest-native/src/native/transform.mjs
@@ -18,6 +18,7 @@ import path from "node:path";
 import fs from "node:fs";
 import os from "node:os";
 import crypto from "node:crypto";
+import { decorateTransformError } from "./explain.mjs";
 
 let _req;
 let _babel;
@@ -123,13 +124,21 @@ export function transformRN(file, src, projectRoot, platform = "ios") {
   } catch {}
 
   if (!_babel) _babel = _req("@babel/core");
-  const out = _babel.transformSync(src, {
-    filename: file,
-    presets: [[_preset, { disableStaticViewConfigsCodegen: true }]],
-    babelrc: false,
-    configFile: false,
-    caller: { name: "metro", bundler: "metro", platform, supportsStaticESM: false },
-  }).code;
+  let out;
+  try {
+    out = _babel.transformSync(src, {
+      filename: file,
+      presets: [[_preset, { disableStaticViewConfigsCodegen: true }]],
+      babelrc: false,
+      configFile: false,
+      caller: { name: "metro", bundler: "metro", platform, supportsStaticESM: false },
+    }).code;
+  } catch (err) {
+    // Decorate here, at the single choke point, so every caller — the ESM
+    // loader, the CJS require hook, requireActual's .ts handlers — surfaces
+    // the file, platform, and owning package instead of a bare Babel stack.
+    throw decorateTransformError(err, file, platform);
+  }
   // Atomic write: multiple worker threads may transform the same RN file
   // concurrently on a cold cache. Write to a unique temp file then rename
   // (atomic on POSIX same-dir) so a concurrent reader never sees a partial file.

--- a/packages/vitest-native/src/plugin.ts
+++ b/packages/vitest-native/src/plugin.ts
@@ -87,6 +87,29 @@ function resolvePackageVersion(packageName: string, projectRoot: string): string
   }
 }
 
+/**
+ * One line, once per process, stating which engine this run actually uses.
+ * Tests pass either way; a team that believes it's exercising real React Native
+ * while running the mock (or vice versa) must be able to see it in every log.
+ * Guarded via globalThis (like the require-hook install) so workspace setups
+ * that call config() per project print it once.
+ */
+function printEngineBanner(engine: "mock" | "native", platform: string, projectRoot: string): void {
+  const g = globalThis as { __vitest_native_banner_printed?: boolean };
+  if (g.__vitest_native_banner_printed) return;
+  g.__vitest_native_banner_printed = true;
+  if (engine === "native") {
+    const rn = resolvePackageVersion("react-native", projectRoot);
+    console.log(
+      `[vitest-native] engine: native — real react-native${rn ? `@${rn}` : ""} (platform ${platform})`,
+    );
+  } else {
+    console.log(
+      `[vitest-native] engine: mock — React Native reimplementation, cross-checked against real RN (platform ${platform})`,
+    );
+  }
+}
+
 function getJsxTransformConfig(projectRoot: string): JsxTransformConfig {
   const viteVersion = resolvePackageVersion("vite", projectRoot);
   const viteMajor = Number(viteVersion?.split(".")[0]);
@@ -425,7 +448,23 @@ export function reactNative(options?: VitestNativeOptions): Plugin {
       // only when it must fall back to mock. See detect.ts / AUTO_PREFERS_NATIVE.
       const decision = detectEngine(requestedEngine, resolvedRoot);
       engine = decision.engine;
-      if (decision.notice) console.log(decision.notice);
+      // Explicit engine:'native' without its transform deps must fail HERE, at
+      // config time — deferring lets the run start and die mid-suite inside the
+      // loader with a stack that doesn't mention configuration at all.
+      if (engine === "native" && !decision.nativeAvailable) {
+        throw new Error(
+          `[vitest-native] engine:'native' requires '@react-native/babel-preset' and ` +
+            `'@babel/core' to resolve from ${resolvedRoot}. Install them as ` +
+            `devDependencies (React Native projects ship them by default):\n\n` +
+            `  npm install -D @react-native/babel-preset @babel/core\n\n` +
+            `Or set engine:'mock' to run without a React Native install.`,
+        );
+      }
+      // The fallback notice is a warning — a team that believes it is testing real
+      // React Native while running the mock is the exact failure mode the engine
+      // split exists to prevent.
+      if (decision.notice) console.warn(decision.notice);
+      printEngineBanner(engine, platform, resolvedRoot);
       const env: Record<string, string> = {
         VITEST_NATIVE_PLATFORM: platform,
         VITEST_NATIVE_DIAGNOSTICS: String(diagnostics),
@@ -792,11 +831,12 @@ export function reactNative(options?: VitestNativeOptions): Plugin {
           map: stripped.generateMap(),
         };
       } catch (e) {
-        if (diagnostics) {
-          console.warn(
-            `[vitest-native] Flow strip skipped for ${id} (parse failed: ${(e as Error)?.message}); serving the file untouched.`,
-          );
-        }
+        // Always visible (not diagnostics-gated): if this was a genuine Flow file,
+        // the run is about to fail on Vite's own parse with no breadcrumb back to
+        // this decision. One line here turns a mystery into a lead.
+        console.warn(
+          `[vitest-native] Flow strip skipped for ${id} (parse failed: ${(e as Error)?.message}); serving the file untouched.`,
+        );
         return undefined;
       }
     },

--- a/packages/vitest-native/src/plugin.ts
+++ b/packages/vitest-native/src/plugin.ts
@@ -93,6 +93,9 @@ function resolvePackageVersion(packageName: string, projectRoot: string): string
  * while running the mock (or vice versa) must be able to see it in every log.
  * Guarded via globalThis (like the require-hook install) so workspace setups
  * that call config() per project print it once.
+ *
+ * Written to stderr: this is the plugin's only unconditional output, and stdout
+ * must stay parseable for pipelines like `vitest --reporter=json > results.json`.
  */
 function printEngineBanner(engine: "mock" | "native", platform: string, projectRoot: string): void {
   const g = globalThis as { __vitest_native_banner_printed?: boolean };
@@ -100,11 +103,11 @@ function printEngineBanner(engine: "mock" | "native", platform: string, projectR
   g.__vitest_native_banner_printed = true;
   if (engine === "native") {
     const rn = resolvePackageVersion("react-native", projectRoot);
-    console.log(
+    console.error(
       `[vitest-native] engine: native — real react-native${rn ? `@${rn}` : ""} (platform ${platform})`,
     );
   } else {
-    console.log(
+    console.error(
       `[vitest-native] engine: mock — React Native reimplementation, cross-checked against real RN (platform ${platform})`,
     );
   }

--- a/packages/vitest-native/tests-native/explain-untransformed.test.ts
+++ b/packages/vitest-native/tests-native/explain-untransformed.test.ts
@@ -1,0 +1,28 @@
+// End-to-end wiring check for the untransformed-package explainer: requiring a
+// node_modules package that ships untranspiled JSX (the single most common
+// migration blocker) must surface the explained error — naming the package and
+// the `transform: ['<pkg>']` fix — not Node's bare "Unexpected token '<'".
+// The pure explainer functions are unit-tested in tests/explain.test.ts; this
+// exercises the live require-hook path in native/hooks.mjs.
+import { describe, it, expect } from "vitest";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+describe("untransformed node_modules JSX", () => {
+  it("explains the transform:[...] fix instead of a bare SyntaxError", () => {
+    let caught: unknown;
+    try {
+      require("untranspiled-jsx-lib");
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(SyntaxError);
+    const err = caught as SyntaxError & { cause?: unknown };
+    expect(err.message).toContain("'untranspiled-jsx-lib' shipped source Node can't run directly");
+    expect(err.message).toContain("transform: ['untranspiled-jsx-lib']");
+    expect(err.message).toContain("migrating-from-jest.md");
+    // The original Node error stays attached for debugging.
+    expect(err.cause).toBeInstanceOf(SyntaxError);
+  });
+});

--- a/packages/vitest-native/tests-native/fixtures/untranspiled-jsx-lib/index.js
+++ b/packages/vitest-native/tests-native/fixtures/untranspiled-jsx-lib/index.js
@@ -1,0 +1,7 @@
+// Simulates a library that publishes untranspiled JSX — common in the RN
+// ecosystem, where packages assume Metro will compile them. Node cannot parse
+// this file; requiring it without adding the package to `transform: [...]`
+// must produce the explained error (see explain-untransformed.test.ts).
+module.exports = function Badge() {
+  return <text>badge</text>;
+};

--- a/packages/vitest-native/tests-native/fixtures/untranspiled-jsx-lib/package.json
+++ b/packages/vitest-native/tests-native/fixtures/untranspiled-jsx-lib/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "untranspiled-jsx-lib",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.js"
+}

--- a/packages/vitest-native/tests/explain.test.ts
+++ b/packages/vitest-native/tests/explain.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+// @ts-expect-error — runtime .mjs
+import {
+  packageNameFromPath,
+  decorateTransformError,
+  explainUntransformedSyntaxError,
+} from "../src/native/explain.mjs";
+
+describe("packageNameFromPath", () => {
+  it("extracts plain and scoped package names from node_modules paths", () => {
+    expect(packageNameFromPath("/p/node_modules/react-native-svg/src/index.js")).toBe(
+      "react-native-svg",
+    );
+    expect(packageNameFromPath("/p/node_modules/@op/lib/dist/a.js")).toBe("@op/lib");
+  });
+
+  it("uses the DEEPEST node_modules segment (nested installs)", () => {
+    expect(packageNameFromPath("/p/node_modules/a/node_modules/@s/b/x.js")).toBe("@s/b");
+  });
+
+  it("handles Windows separators and returns null outside node_modules", () => {
+    expect(packageNameFromPath("C:\\p\\node_modules\\lib\\index.js")).toBe("lib");
+    expect(packageNameFromPath("/p/src/app.js")).toBeNull();
+  });
+});
+
+describe("decorateTransformError", () => {
+  it("names the package, file, and platform, and chains the cause", () => {
+    const orig = new SyntaxError("Unexpected token (3:14)");
+    const err = decorateTransformError(orig, "/p/node_modules/some-lib/a.js", "android");
+    expect(err.message).toContain("'some-lib'");
+    expect(err.message).toContain("/p/node_modules/some-lib/a.js");
+    expect(err.message).toContain("platform 'android'");
+    expect(err.message).toContain("Unexpected token (3:14)");
+    expect(err.cause).toBe(orig);
+    expect(err.name).toBe("SyntaxError");
+  });
+
+  it("still explains files outside node_modules without a package hint", () => {
+    const err = decorateTransformError(new Error("boom"), "/p/src/x.js", "ios");
+    expect(err.message).toContain("/p/src/x.js");
+    expect(err.message).not.toContain("transform: [");
+  });
+});
+
+describe("explainUntransformedSyntaxError", () => {
+  const jsxErr = () => {
+    const e = new SyntaxError("Unexpected token '<'");
+    return e;
+  };
+
+  it("suggests transform: ['pkg'] for a JSX SyntaxError in node_modules", () => {
+    const out = explainUntransformedSyntaxError(jsxErr(), "/p/node_modules/uniwind/dist/x.js");
+    expect(out).not.toBeNull();
+    expect(out.message).toContain("transform: ['uniwind']");
+    expect(out.message).toContain("untranspiled JSX, Flow, or TypeScript");
+    expect(out.name).toBe("SyntaxError");
+  });
+
+  it("returns null for non-syntax errors, app files, and unrelated syntax errors", () => {
+    expect(explainUntransformedSyntaxError(new Error("ENOENT"), "/p/node_modules/a/x.js")).toBe(
+      null,
+    );
+    expect(explainUntransformedSyntaxError(jsxErr(), "/p/src/app.js")).toBeNull();
+    const unrelated = new SyntaxError("Cannot use import statement outside a module");
+    expect(explainUntransformedSyntaxError(unrelated, "/p/node_modules/a/x.js")).toBeNull();
+  });
+});

--- a/packages/vitest-native/tests/jest-compat.test.ts
+++ b/packages/vitest-native/tests/jest-compat.test.ts
@@ -156,3 +156,33 @@ describe("jest-compat: setup", () => {
     expect(typeof React.createElement).toBe("function");
   });
 });
+
+describe("jest-compat: unsupported Jest APIs are signposts, not TypeErrors", () => {
+  it("isolateModules / createMockFromModule / genMockFromModule / deepUnmock throw actionable errors", async () => {
+    await import("../src/jest-compat/setup.mjs");
+    const jestGlobal = (globalThis as { jest?: Record<string, (...a: unknown[]) => unknown> })
+      .jest!;
+    for (const name of [
+      "isolateModules",
+      "createMockFromModule",
+      "genMockFromModule",
+      "deepUnmock",
+    ]) {
+      expect(() => jestGlobal[name]("x")).toThrow(/no Vitest equivalent.*migrating-from-jest/s);
+    }
+  });
+
+  it("retryTimes warns once and continues (does not crash the suite)", async () => {
+    await import("../src/jest-compat/setup.mjs");
+    const jestGlobal = (globalThis as { jest?: { retryTimes: (n: number) => void } }).jest!;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(() => jestGlobal.retryTimes(3)).not.toThrow();
+      jestGlobal.retryTimes(3);
+      const warnings = warn.mock.calls.filter((c) => String(c[0]).includes("retryTimes"));
+      expect(warnings).toHaveLength(1);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/packages/vitest-native/tests/native-unit.test.ts
+++ b/packages/vitest-native/tests/native-unit.test.ts
@@ -490,29 +490,33 @@ describe("engine-selection notices", () => {
       .__vitest_native_banner_printed;
   beforeEach(resetBanner);
 
-  it("auto prints exactly the one-line engine banner when it selects native", async () => {
+  it("auto prints exactly the one-line engine banner on stderr when it selects native", async () => {
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
     const plugin = reactNative({}) as any;
     await plugin.config({ root: projectRoot }, SERVE_ENV);
-    const notices = log.mock.calls.filter((c) => String(c[0]).includes("[vitest-native]"));
-    expect(notices).toHaveLength(1);
-    expect(String(notices[0][0])).toContain("engine: native — real react-native");
+    // stdout must stay clean — it belongs to reporters (e.g. --reporter=json).
+    expect(log.mock.calls.filter((c) => String(c[0]).includes("[vitest-native]"))).toHaveLength(0);
+    const banners = err.mock.calls.filter((c) => String(c[0]).includes("[vitest-native]"));
+    expect(banners).toHaveLength(1);
+    expect(String(banners[0][0])).toContain("engine: native — real react-native");
     log.mockRestore();
+    err.mockRestore();
   });
 
   it("the engine banner prints once per process, not once per project", async () => {
-    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
     const plugin = reactNative({}) as any;
     await plugin.config({ root: projectRoot }, SERVE_ENV);
     await plugin.config({ root: projectRoot }, SERVE_ENV);
-    const banners = log.mock.calls.filter((c) => String(c[0]).includes("engine:"));
+    const banners = err.mock.calls.filter((c) => String(c[0]).includes("engine:"));
     expect(banners).toHaveLength(1);
-    log.mockRestore();
+    err.mockRestore();
   });
 
   it("auto WARNS about the mock fallback when native deps are absent, and banners mock", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "vn-nudge-"));
     try {
       fs.writeFileSync(
@@ -525,11 +529,11 @@ describe("engine-selection notices", () => {
         String(c[0]).includes("@react-native/babel-preset not found"),
       );
       expect(notices).toHaveLength(1);
-      const banners = log.mock.calls.filter((c) => String(c[0]).includes("engine: mock"));
+      const banners = err.mock.calls.filter((c) => String(c[0]).includes("engine: mock"));
       expect(banners).toHaveLength(1);
     } finally {
       warn.mockRestore();
-      log.mockRestore();
+      err.mockRestore();
       fs.rmSync(tmp, { recursive: true, force: true });
     }
   });

--- a/packages/vitest-native/tests/native-unit.test.ts
+++ b/packages/vitest-native/tests/native-unit.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import path from "node:path";
 import fs from "node:fs";
 import os from "node:os";
@@ -485,16 +485,33 @@ describe("plugin engine routing", () => {
 });
 
 describe("engine-selection notices", () => {
-  it("auto stays silent when it selects native (the happy path)", async () => {
+  const resetBanner = () =>
+    delete (globalThis as { __vitest_native_banner_printed?: boolean })
+      .__vitest_native_banner_printed;
+  beforeEach(resetBanner);
+
+  it("auto prints exactly the one-line engine banner when it selects native", async () => {
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
     const plugin = reactNative({}) as any;
     await plugin.config({ root: projectRoot }, SERVE_ENV);
     const notices = log.mock.calls.filter((c) => String(c[0]).includes("[vitest-native]"));
-    expect(notices).toHaveLength(0);
+    expect(notices).toHaveLength(1);
+    expect(String(notices[0][0])).toContain("engine: native — real react-native");
     log.mockRestore();
   });
 
-  it("auto explains the mock fallback once when native deps are absent", async () => {
+  it("the engine banner prints once per process, not once per project", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const plugin = reactNative({}) as any;
+    await plugin.config({ root: projectRoot }, SERVE_ENV);
+    await plugin.config({ root: projectRoot }, SERVE_ENV);
+    const banners = log.mock.calls.filter((c) => String(c[0]).includes("engine:"));
+    expect(banners).toHaveLength(1);
+    log.mockRestore();
+  });
+
+  it("auto WARNS about the mock fallback when native deps are absent, and banners mock", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "vn-nudge-"));
     try {
@@ -504,12 +521,31 @@ describe("engine-selection notices", () => {
       );
       const plugin = reactNative({}) as any;
       await plugin.config({ root: tmp }, SERVE_ENV);
-      const notices = log.mock.calls.filter((c) =>
+      const notices = warn.mock.calls.filter((c) =>
         String(c[0]).includes("@react-native/babel-preset not found"),
       );
       expect(notices).toHaveLength(1);
+      const banners = log.mock.calls.filter((c) => String(c[0]).includes("engine: mock"));
+      expect(banners).toHaveLength(1);
     } finally {
+      warn.mockRestore();
       log.mockRestore();
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("explicit engine:'native' without its transform deps fails at config time", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "vn-failfast-"));
+    try {
+      fs.writeFileSync(
+        path.join(tmp, "package.json"),
+        JSON.stringify({ name: "x", version: "0.0.0" }),
+      );
+      const plugin = reactNative({ engine: "native" }) as any;
+      await expect(plugin.config({ root: tmp }, SERVE_ENV)).rejects.toThrow(
+        /@react-native\/babel-preset.*npm install -D/s,
+      );
+    } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## What

Turns the failure moments a migrating team actually hits into errors that name their own fix, and makes the engine choice visible in every run.

- **Untransformed-package explainer** (`src/native/explain.mjs`, wired in the CJS require hook): when an externalized `node_modules` file throws a SyntaxError fingerprinting as untranspiled JSX/Flow/TS (`Unexpected token '<'` and friends), the error names the owning package and states the fix — `reactNative({ transform: ['<pkg>'] })` — with a link to the migration guide. Real-app bake-offs (paper, obytes, Rocket.Chat) show this bare SyntaxError is the single most common migration blocker.
- **Decorated Babel failures**: a Babel crash in `transformRN` now reports the file, platform, and owning package. Decoration happens at the one choke point, so the ESM loader, CJS require hook, and `requireActual`'s handlers all inherit it. The original error is chained as `cause`.
- **Engine banner**: one line per process — `[vitest-native] engine: native — real react-native@X (platform ios)` or the mock equivalent. With `engine: 'auto'`, a silent fallback to mock passes tests identically; the banner makes the actual engine auditable from any log.
- **Config-time fail-fast**: explicit `engine: 'native'` without `@react-native/babel-preset` / `@babel/core` now throws at config time with install instructions, instead of starting the run and dying mid-suite inside the loader. The `auto`→mock fallback notice is promoted to `console.warn`, and the Flow-strip parse-failure warning is always visible (previously diagnostics-gated).
- **jest-compat signposts**: `jest.isolateModules`, `jest.createMockFromModule`, `jest.genMockFromModule`, and `jest.deepUnmock` throw errors naming the API and its closest Vitest migration instead of bare `is not a function` TypeErrors. `jest.retryTimes` warns once and continues. Each shim is guarded by a `typeof vi[name]` check so a future Vitest API is never clobbered.

## Behavior notes

- Passing suites behave identically apart from the one banner line.
- The fail-fast on `engine: 'native'` is a new config-time error for setups that previously failed later at runtime — changeset is marked **minor** accordingly.
- The JSX-fingerprint match is heuristic (`Unexpected identifier` can also come from a genuinely broken package); the message hedges with "usually means" and the original error stays attached as `cause`.

## Testing

- New `tests/explain.test.ts` (7 tests): package-name extraction (scoped, nested, Windows paths), Babel decoration, SyntaxError explainer positive/negative cases.
- `tests/native-unit.test.ts`: banner on the auto→native happy path, once-per-process dedup across projects, warn-level fallback notice, config-time fail-fast.
- `tests/jest-compat.test.ts`: signpost errors for the four unmappable APIs, warn-once for `retryTimes`.
- Full local gate green: format, lint, typecheck, build, mock suite 1360/1360, native suite 141/141.