### PR TITLE
ci: group all github-actions dependabot bumps into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,10 @@ updates:
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7
+    # One PR for all action bumps. Split PRs break lockstep-versioned actions:
+    # github/codeql-action init/analyze/upload-sarif must move together, or the
+    # Analyze job fails with "Loaded a configuration file for version X, but
+    # running version Y" on every individual PR.
+    groups:
+      github-actions:
+        patterns: ["*"]


### PR DESCRIPTION
Dependabot currently opens one PR per action bump. For lockstep-versioned actions this guarantees red CI on each PR: `github/codeql-action` `init`/`analyze`/`upload-sarif` must move together, so every split PR fails `Analyze` with:

```
Loaded a configuration file for version '4.36.3', but running version '4.36.2'
```

(observed on #81 and #82 this week — the bumps themselves are fine; only the split is broken).

This groups all `github-actions` ecosystem updates into a single weekly PR, which keeps lockstep actions in sync and collapses the five-PR weekly noise (#81–#85) into one.