### PR TITLE
feat(native): stub Expo's dev-server messageSocket (unblocks Expo apps)

### DIFF
--- a/.changeset/expo-messagesocket-stub.md
+++ b/.changeset/expo-messagesocket-stub.md
@@ -1,0 +1,9 @@
+---
+"vitest-native": minor
+---
+
+Stub Expo's dev-server messageSocket under the native engine.
+
+`expo`'s `Expo.fx` requires `async-require/messageSocket` whenever `__DEV__ && globalThis.expo`, and that module throws at load time when the bundle wasn't served over HTTP ("Cannot create devtools websocket connections in embedded environments"). Under the native engine this took down any suite importing an `expo-*` package (e.g. `expo-image`) — the primary blocker for Expo apps. The module's only job is a devtools websocket to a live dev server, an environment that doesn't exist under Node, so it is now stubbed to a no-op via the boundary mechanism — matching Jest's dev-server-layer mocks. All published variants are covered (`build/` output and `src/` TS sources, plain and `.native`), and the `.ts`/`.tsx` require handlers now consult boundary stubs, which previously only `.js` did.
+
+Validated against the obytes Expo template bake-off: the login-form suite (previously import-time dead) now passes, 34/40 → 38/40 overall with the two remaining failures pre-existing and unrelated (bottom-sheet mock completeness).

--- a/packages/vitest-native/src/native/boundary.mjs
+++ b/packages/vitest-native/src/native/boundary.mjs
@@ -312,9 +312,30 @@ export const BOUNDARY_SOURCES = {
 
 const SUFFIXES = Object.keys(BOUNDARY_SOURCES);
 
+/**
+ * Expo modules whose only job is talking to a live dev server — an environment
+ * that doesn't exist under Node. `expo`'s Expo.fx requires messageSocket whenever
+ * `__DEV__ && globalThis.expo`, and the module throws at load time when the
+ * bundle wasn't served over HTTP ("Cannot create devtools websocket connections
+ * in embedded environments"), taking down any suite that imports an expo-*
+ * package. Stub it to a no-op, like Jest's dev-server layer mocks do. Matched
+ * for both the published build/ output and the src/ TS sources (some resolution
+ * paths reach src/), in plain and .native platform variants.
+ */
+const EXPO_DEV_STUBS = {
+  "src/async-require/messageSocket.native.ts": "module.exports = {};",
+  "src/async-require/messageSocket.ts": "module.exports = {};",
+  "build/async-require/messageSocket.native.js": "module.exports = {};",
+  "build/async-require/messageSocket.js": "module.exports = {};",
+};
+const EXPO_SUFFIXES = Object.keys(EXPO_DEV_STUBS);
+
 /** Normalised-path test: is this a native-boundary module? */
 export function isBoundary(normPath) {
-  return SUFFIXES.some((s) => normPath.endsWith("/react-native/" + s));
+  return (
+    SUFFIXES.some((s) => normPath.endsWith("/react-native/" + s)) ||
+    EXPO_SUFFIXES.some((s) => normPath.endsWith("/expo/" + s))
+  );
 }
 
 /** Returns the CJS source for a boundary module, or null if not a boundary. */
@@ -324,6 +345,9 @@ export function boundarySourceFor(normPath, platform = "ios", version = "0.0.0")
       const source = BOUNDARY_SOURCES[s];
       return typeof source === "function" ? source(platform, version) : source;
     }
+  }
+  for (const s of EXPO_SUFFIXES) {
+    if (normPath.endsWith("/expo/" + s)) return EXPO_DEV_STUBS[s];
   }
   return null;
 }

--- a/packages/vitest-native/src/native/hooks.mjs
+++ b/packages/vitest-native/src/native/hooks.mjs
@@ -166,6 +166,14 @@ export function installRequireHooks(
   for (const ext of [".ts", ".tsx"]) {
     if (Module._extensions[ext]) continue;
     Module._extensions[ext] = function (mod, filename) {
+      // Boundary stubs can live in TS sources too (expo publishes src/ alongside
+      // build/, and some resolution paths reach the .ts files directly).
+      const boundary = boundarySourceFor(
+        filename.replace(/\\/g, "/"),
+        platform,
+        reactNativeVersion,
+      );
+      if (boundary != null) return mod._compile(boundary, filename);
       const src = fs.readFileSync(filename, "utf8");
       return mod._compile(transformRN(filename, src, projectRoot, platform), filename);
     };

--- a/packages/vitest-native/tests/native-unit.test.ts
+++ b/packages/vitest-native/tests/native-unit.test.ts
@@ -88,6 +88,25 @@ describe("native boundary", () => {
     expect(isBoundary("/x/react-native/Libraries/StyleSheet/StyleSheet.js")).toBe(false);
   });
 
+  it("stubs expo's dev-server messageSocket (all published variants) to a no-op", () => {
+    // The real module throws at load time under Node ("Cannot create devtools
+    // websocket connections in embedded environments") whenever __DEV__ &&
+    // globalThis.expo — the wall that blocked every expo-* import in Expo apps.
+    for (const p of [
+      "/x/node_modules/expo/src/async-require/messageSocket.native.ts",
+      "/x/node_modules/expo/src/async-require/messageSocket.ts",
+      "/x/node_modules/expo/build/async-require/messageSocket.native.js",
+      "/x/node_modules/expo/build/async-require/messageSocket.js",
+    ]) {
+      expect(isBoundary(p)).toBe(true);
+      const mod = evalCjs(boundarySourceFor(p)!);
+      expect(mod).toEqual({});
+    }
+    // Other expo modules stay untouched.
+    expect(isBoundary("/x/node_modules/expo/src/Expo.fx.tsx")).toBe(false);
+    expect(boundarySourceFor("/x/node_modules/expo/src/async-require/index.ts")).toBe(null);
+  });
+
   it("TurboModuleRegistry mock never throws and returns constants", () => {
     const src = boundarySourceFor("/x/react-native/Libraries/TurboModule/TurboModuleRegistry.js");
     const mod = evalCjs(src!);


### PR DESCRIPTION
## Problem

Under the native engine, any test suite that imports an `expo-*` package (e.g. `expo-image`) in an Expo app dies at import time:

```
Error: Cannot create devtools websocket connections in embedded environments.
 ❯ node_modules/expo/src/async-require/messageSocket.native.ts
 ❯ node_modules/expo/src/Expo.fx.tsx:20  (require('./async-require/messageSocket'))
```

`expo`'s `Expo.fx` requires `async-require/messageSocket` whenever `__DEV__ && typeof globalThis.expo !== 'undefined'` — both true under the test engine. The module then throws at load time because `getDevServer().bundleLoadedFromServer` is false (the bundle comes from disk, not an HTTP dev server). This was the primary named blocker for the Expo class of apps in the migration friction audit.

## Change

`messageSocket`'s only job is a devtools websocket to a live dev server — an environment that doesn't exist under Node — so it is stubbed to a no-op via the existing boundary mechanism, the same approach Jest's dev-server-layer mocks take. Specifics:

- `boundary.mjs`: new `EXPO_DEV_STUBS` map, matched under `/expo/` for all published variants — `build/` output and `src/` TS sources, plain and `.native`. `isBoundary` / `boundarySourceFor` cover both maps, so the CJS require hook and the ESM loader inherit the stub with no new call sites.
- `hooks.mjs`: the `.ts`/`.tsx` require handlers now consult `boundarySourceFor` before transforming (previously only `.js` did). Expo resolves to its `src/*.ts` files in some setups, which is exactly the path the failing stack traces show.

## Validation

- Unit: all four path variants serve a compilable no-op; neighbouring expo modules (`Expo.fx.tsx`, `async-require/index.ts`) are untouched.
- Obytes Expo template bake-off (expo 54, RN 0.81.5), with the real throwing `messageSocket` on disk: the login-form suite goes from import-time failure to passing; **34/40 → 38/40** overall. The two remaining failures pre-date this change (bottom-sheet mock completeness, unrelated to Expo-init).
- Full local gate green: format, lint, typecheck, build, mock suite 1350/1350, native suite 141/141.

The other two walls the login-form chain surfaced are config-level, not product gaps: `react-native-flash-message` needs `transform: [...]` (documented pattern), and the bake-off's keyboard-controller mock was missing an export. Both belong in the bake-off config / migration guide, not in the package.