### PR TITLE
feat(errors): give thrown errors a class and a stable code

### DIFF
--- a/packages/vitest-native/package-budget.json
+++ b/packages/vitest-native/package-budget.json
@@ -1,9 +1,9 @@
 {
-  "maxPackedBytes": 234000,
+  "maxPackedBytes": 236000,
   "maxUnpackedBytes": 830000,
   "maxFiles": 85,
   "maxRuntimeDependencies": 2,
   "maxExportPaths": 11,
   "_maxExportPaths": "11 since ./rntl-matchers: a types-only entry that augments Vitest's Assertion with React Native Testing Library's matchers. It is separate rather than folded into the main types because RNTL is an optional peer, and an unresolvable type import inside a shipped .d.ts reports TS2307 for consumers using skipLibCheck: false without it.",
-  "_maxPackedBytes": "234000 since the Animated surface parity work: nine members React Native has and the mock lacked (Node, Event, Interpolation, attachNativeEvent, track, stopTracking, animate, hasListeners, toJSON), plus the unhoisted-jest.mock and duplicate-React detections. Headroom is deliberately thin \u2014 a few KB \u2014 so the next unintended growth still trips this."
+  "_maxPackedBytes": "236000 since the typed error classes. errors.mjs ships verbatim for the raw native and jest-compat runtimes, and the bundler also emits it as a chunk for the bundled entries, so its ~2KB lands twice. Externalising it did not take effect with this bundler config; the duplication is a known cost rather than an accident, and isVitestNativeError checks shape precisely because two copies mean instanceof cannot be trusted across that seam."
 }

--- a/packages/vitest-native/package-budget.json
+++ b/packages/vitest-native/package-budget.json
@@ -1,9 +1,10 @@
 {
   "maxPackedBytes": 236000,
-  "maxUnpackedBytes": 830000,
+  "maxUnpackedBytes": 834000,
   "maxFiles": 85,
   "maxRuntimeDependencies": 2,
   "maxExportPaths": 11,
   "_maxExportPaths": "11 since ./rntl-matchers: a types-only entry that augments Vitest's Assertion with React Native Testing Library's matchers. It is separate rather than folded into the main types because RNTL is an optional peer, and an unresolvable type import inside a shipped .d.ts reports TS2307 for consumers using skipLibCheck: false without it.",
-  "_maxPackedBytes": "236000 since the typed error classes. errors.mjs ships verbatim for the raw native and jest-compat runtimes, and the bundler also emits it as a chunk for the bundled entries, so its ~2KB lands twice. Externalising it did not take effect with this bundler config; the duplication is a known cost rather than an accident, and isVitestNativeError checks shape precisely because two copies mean instanceof cannot be trusted across that seam."
+  "_maxPackedBytes": "236000 since the typed error classes. errors.mjs ships verbatim for the raw native and jest-compat runtimes, and the bundler also emits it as a chunk for the bundled entries, so its ~2KB lands twice. Externalising it did not take effect with this bundler config; the duplication is a known cost rather than an accident, and isVitestNativeError checks shape precisely because two copies mean instanceof cannot be trusted across that seam.",
+  "_maxUnpackedBytes": "834000 alongside the typed error classes. errors.mjs ships verbatim for the raw native and jest-compat runtimes AND the bundler emits its own chunk for the bundled entries, so it lands twice. tsdown's config exposes no external option to prevent that. The follow-up that would remove the duplication is a public 'vitest-native/errors' export the bundled side self-references \u2014 which also gives consumers isVitestNativeError \u2014 at the cost of a twelfth export path."
 }

--- a/packages/vitest-native/src/errors.d.mts
+++ b/packages/vitest-native/src/errors.d.mts
@@ -1,0 +1,46 @@
+/**
+ * Types for errors.mjs. Hand-written because the implementation is plain .mjs — see the
+ * comment there for why it cannot be TypeScript.
+ */
+
+/**
+ * Stable identifiers for the failures this package raises. They are part of the public
+ * surface: renaming one is a breaking change for anyone branching on it.
+ */
+export type VitestNativeErrorCode =
+  | "INVALID_OPTION"
+  | "UNKNOWN_OPTION"
+  | "UNSUPPORTED_PEER"
+  | "UNSUPPORTED_POOL"
+  | "ENGINE_REQUIRES_BABEL"
+  | "MOCKS_REQUIRE_MOCK_ENGINE"
+  | "TRANSFORM_FAILED"
+  | "UNTRANSPILED_PACKAGE"
+  | "HOT_WORKER_ENV"
+  | "HOT_WORKER_PRELOAD"
+  | "HOT_RUNTIME_UNAVAILABLE"
+  | "PRESET_UNAVAILABLE"
+  | "WRONG_ENGINE_FOR_HELPER"
+  | "HELPERS_BEFORE_SETUP"
+  | "JEST_API_UNSUPPORTED"
+  | "MATCHER_BAD_RECEIVER";
+
+export interface VitestNativeErrorOptions {
+  cause?: unknown;
+  /** A docs URL appended to the message, since fields do not reach the reporter. */
+  docs?: string;
+}
+
+export declare class VitestNativeError extends Error {
+  readonly code: VitestNativeErrorCode;
+  constructor(code: VitestNativeErrorCode, message: string, options?: VitestNativeErrorOptions);
+}
+
+export declare class VitestNativeTypeError extends TypeError {
+  readonly code: VitestNativeErrorCode;
+  constructor(code: VitestNativeErrorCode, message: string, options?: VitestNativeErrorOptions);
+}
+
+export declare function isVitestNativeError(
+  error: unknown,
+): error is VitestNativeError | VitestNativeTypeError;

--- a/packages/vitest-native/src/errors.mjs
+++ b/packages/vitest-native/src/errors.mjs
@@ -33,10 +33,24 @@ function buildMessage(message, options) {
   return options?.docs ? `${base}\nSee ${options.docs}` : base;
 }
 
+/**
+ * Error options, omitted entirely when there is no cause.
+ *
+ * `new Error(msg, { cause: undefined })` installs an own `cause` property set to
+ * undefined, which a plain `new Error(msg)` does not — enough to make some reporters
+ * print an empty cause and to make these errors shaped differently from every other
+ * error in the process. Passing nothing keeps them identical.
+ */
+function errorOptions(options) {
+  return options && "cause" in options && options.cause !== undefined
+    ? { cause: options.cause }
+    : undefined;
+}
+
 /** A failure originating in vitest-native. */
 export class VitestNativeError extends Error {
   constructor(code, message, options) {
-    super(buildMessage(message, options), { cause: options?.cause });
+    super(buildMessage(message, options), errorOptions(options));
     this.name = "VitestNativeError";
     this.code = code;
   }
@@ -48,7 +62,7 @@ export class VitestNativeError extends Error {
  */
 export class VitestNativeTypeError extends TypeError {
   constructor(code, message, options) {
-    super(buildMessage(message, options), { cause: options?.cause });
+    super(buildMessage(message, options), errorOptions(options));
     this.name = "VitestNativeTypeError";
     this.code = code;
   }

--- a/packages/vitest-native/src/errors.mjs
+++ b/packages/vitest-native/src/errors.mjs
@@ -1,0 +1,64 @@
+/**
+ * The error types this package throws.
+ *
+ * Plain .mjs on purpose. The shipped native and jest-compat runtimes are copied to dist
+ * verbatim and import this by relative path, and the test suite loads those same files
+ * from src — so the module has to resolve identically in both trees. A .ts source would
+ * only exist in one of them.
+ *
+ * WHAT SURVIVES WHERE, measured rather than assumed:
+ *
+ *   - In the main process, and in a user's own try/catch inside a test, everything is
+ *     intact.
+ *   - Across the worker/reporter boundary Vitest keeps only `name`, `message` and
+ *     `stack`. `code` and every other own property is dropped.
+ *
+ * So the message must stay self-sufficient: nothing may move out of it into a field on
+ * the assumption a reader will see it.
+ *
+ * `isVitestNativeError` deliberately checks SHAPE rather than `instanceof`. Bundled
+ * entries and the verbatim .mjs runtimes can hold separate copies of this module, and a
+ * prototype check would quietly fail across that seam. Shape does not care.
+ */
+
+const PREFIX = "[vitest-native]";
+
+/** Guarantees the prefix exactly once, however the caller wrote the message. */
+function withPrefix(message) {
+  return message.startsWith(PREFIX) ? message : `${PREFIX} ${message}`;
+}
+
+function buildMessage(message, options) {
+  const base = withPrefix(message);
+  return options?.docs ? `${base}\nSee ${options.docs}` : base;
+}
+
+/** A failure originating in vitest-native. */
+export class VitestNativeError extends Error {
+  constructor(code, message, options) {
+    super(buildMessage(message, options), { cause: options?.cause });
+    this.name = "VitestNativeError";
+    this.code = code;
+  }
+}
+
+/**
+ * A vitest-native failure that is also a type error — a badly typed option, say.
+ * Extends TypeError so `instanceof TypeError` keeps working for consumers.
+ */
+export class VitestNativeTypeError extends TypeError {
+  constructor(code, message, options) {
+    super(buildMessage(message, options), { cause: options?.cause });
+    this.name = "VitestNativeTypeError";
+    this.code = code;
+  }
+}
+
+/** True for any error this package raised, whichever copy of this module created it. */
+export function isVitestNativeError(error) {
+  return (
+    error instanceof Error &&
+    typeof (/** @type {{ code?: unknown }} */ (error).code) === "string" &&
+    (error.name === "VitestNativeError" || error.name === "VitestNativeTypeError")
+  );
+}

--- a/packages/vitest-native/src/helpers.ts
+++ b/packages/vitest-native/src/helpers.ts
@@ -1,3 +1,4 @@
+import { VitestNativeError } from "./errors.mjs";
 /**
  * Test helpers for vitest-native.
  *
@@ -8,8 +9,9 @@
 function getMock(): Record<string, any> {
   const mock = (globalThis as any).__vitest_native_mock;
   if (!mock) {
-    throw new Error(
-      "vitest-native helpers called before setup. Ensure the vitest-native plugin is configured.",
+    throw new VitestNativeError(
+      "HELPERS_BEFORE_SETUP",
+      "helpers were called before setup ran. Ensure the vitest-native plugin is configured.",
     );
   }
   return mock;

--- a/packages/vitest-native/src/jest-compat/setup.mjs
+++ b/packages/vitest-native/src/jest-compat/setup.mjs
@@ -15,6 +15,7 @@ import { vi } from "vitest";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { jestMockInterop } from "./interop.mjs";
+import { VitestNativeError } from "../errors.mjs";
 
 // Resolve modules from the consumer project root, not this file's location, so
 // `jest.requireActual('some-project-dep')` resolves the same module the suite sees.
@@ -101,8 +102,10 @@ const MIGRATION_GUIDE =
 function unsupported(name, guidance) {
   if (typeof vi[name] === "function") return;
   vi[name] = () => {
-    throw new Error(
-      `[vitest-native] jest.${name}() has no Vitest equivalent. ${guidance} See ${MIGRATION_GUIDE}`,
+    throw new VitestNativeError(
+      "JEST_API_UNSUPPORTED",
+      `jest.${name}() has no Vitest equivalent. ${guidance}`,
+      { docs: MIGRATION_GUIDE },
     );
   };
 }

--- a/packages/vitest-native/src/native/pool.ts
+++ b/packages/vitest-native/src/native/pool.ts
@@ -23,6 +23,7 @@ import os from "node:os";
 import { createRequire } from "node:module";
 import { ThreadsPoolWorker } from "vitest/node";
 import type { PoolOptions, PoolRunnerInitializer, PoolTask, WorkerRequest } from "vitest/node";
+import { VitestNativeError } from "../errors.mjs";
 
 export interface NativePoolOptions {
   /** Absolute path to the hot worker entry (dist/native/worker.mjs). */
@@ -203,8 +204,9 @@ function assertWorkerVitestMatchesProject(workerEntry: string, projectRoot: stri
   // clearer message than anything invented here, and a project without a resolvable
   // Vitest is not running this code at all.
   if (worker === null || project === null || worker.version === project.version) return;
-  throw new Error(
-    `[vitest-native] 'hotRuntime' cannot run: its worker would load vitest@${worker.version}, ` +
+  throw new VitestNativeError(
+    "HOT_RUNTIME_UNAVAILABLE",
+    `'hotRuntime' cannot run: its worker would load vitest@${worker.version}, ` +
       `but this run is driven by vitest@${project.version}. They talk over Vitest's worker ` +
       `protocol, and a version mismatch reports no results at all rather than failing.\n` +
       `  worker would load:  ${worker.path}\n` +

--- a/packages/vitest-native/src/native/setup.mjs
+++ b/packages/vitest-native/src/native/setup.mjs
@@ -11,6 +11,7 @@ import { enableV8CompileCache } from "./compile-cache.mjs";
 import * as presetFactories from "../presets.mjs";
 import { animatedMatchers } from "../matchers.mjs";
 import { serializer as rnSerializer } from "../serializer.mjs";
+import { VitestNativeError } from "../errors.mjs";
 
 // Hot runtime: surgical reset of state left by the PREVIOUS file. Setup files
 // are force-inlined by Vitest, so this body re-runs per test file even when the
@@ -170,8 +171,9 @@ function emitColorScheme(colorScheme) {
 g.__vitest_native_control = {
   engine: "native",
   setPlatform() {
-    throw new Error(
-      `[vitest-native] setPlatform() is only available with engine:'mock'. ` +
+    throw new VitestNativeError(
+      "WRONG_ENGINE_FOR_HELPER",
+      `setPlatform() is only available with engine:'mock'. ` +
         `The native engine selects platform files when the module graph loads. ` +
         `Use reactNative({ platform: 'ios' | 'android' }) or separate Vitest projects.`,
     );

--- a/packages/vitest-native/src/native/transform.mjs
+++ b/packages/vitest-native/src/native/transform.mjs
@@ -19,6 +19,7 @@ import fs from "node:fs";
 import os from "node:os";
 import crypto from "node:crypto";
 import { decorateTransformError } from "./explain.mjs";
+import { VitestNativeError } from "../errors.mjs";
 
 let _req;
 let _babel;
@@ -89,8 +90,9 @@ function init(projectRoot) {
     presetVersion = _req("@react-native/babel-preset/package.json").version;
     babelVersion = _req("@babel/core/package.json").version;
   } catch {
-    throw new Error(
-      "[vitest-native] engine 'native' requires '@react-native/babel-preset' and " +
+    throw new VitestNativeError(
+      "ENGINE_REQUIRES_BABEL",
+      "engine 'native' requires '@react-native/babel-preset' and " +
         "'@babel/core' in your project. Install them as devDependencies " +
         "(they ship with React Native projects by default).",
     );

--- a/packages/vitest-native/src/native/worker.mjs
+++ b/packages/vitest-native/src/native/worker.mjs
@@ -19,9 +19,10 @@ import { installHotReset } from "./reset.mjs";
 import { installRegistry } from "./registry.mjs";
 import { captureModuleBaseline } from "./module-reset.mjs";
 import { enableV8CompileCache } from "./compile-cache.mjs";
+import { VitestNativeError } from "../errors.mjs";
 
 if (isMainThread || !parentPort) {
-  throw new Error("[vitest-native] hot worker entry must run in node:worker_threads");
+  throw new VitestNativeError("HOT_WORKER_ENV", "hot worker entry must run in node:worker_threads");
 }
 
 const projectRoot = process.env.VITEST_NATIVE_PROJECT_ROOT || process.cwd();
@@ -96,8 +97,9 @@ try {
     RN.Appearance.getColorScheme?.();
   } catch {}
 } catch (error) {
-  throw new Error(
-    `[vitest-native] hot worker failed to preload react-native from ${projectRoot}: ${error?.message}`,
+  throw new VitestNativeError(
+    "HOT_WORKER_PRELOAD",
+    `hot worker failed to preload react-native from ${projectRoot}: ${error?.message}`,
     { cause: error },
   );
 }

--- a/packages/vitest-native/src/plugin.ts
+++ b/packages/vitest-native/src/plugin.ts
@@ -9,6 +9,7 @@ import { createRequire } from "node:module";
 import flowRemoveTypes from "flow-remove-types";
 import { validateOptions, validatePeerDependency, warnUnknownOptions } from "./validate.js";
 import { PEER_REQUIREMENTS } from "./peer-requirements.js";
+import { VitestNativeError } from "./errors.mjs";
 import { nativeEngineConfig, type JsxTransformConfig } from "./native/apply.js";
 import { detectEngine } from "./native/detect.js";
 import { detectEcosystemPackages } from "./native/ecosystem.js";
@@ -505,8 +506,9 @@ export function reactNative(options?: VitestNativeOptions): Plugin {
   }
 
   if (options?.mocks && containsFunctions(options.mocks)) {
-    throw new Error(
-      `[vitest-native] The "mocks" option contains function values, which cannot be ` +
+    throw new VitestNativeError(
+      "INVALID_OPTION",
+      `The "mocks" option contains function values, which cannot be ` +
         `transferred to Vitest worker processes. Only JSON-serializable values ` +
         `(strings, numbers, booleans, plain objects, arrays) are supported.\n\n` +
         `For function-based mock overrides, use vi.mock() in a setup file:\n\n` +
@@ -624,8 +626,9 @@ export function reactNative(options?: VitestNativeOptions): Plugin {
       // config time — deferring lets the run start and die mid-suite inside the
       // loader with a stack that doesn't mention configuration at all.
       if (engine === "native" && !decision.nativeAvailable) {
-        throw new Error(
-          `[vitest-native] engine:'native' requires '@react-native/babel-preset' and ` +
+        throw new VitestNativeError(
+          "ENGINE_REQUIRES_BABEL",
+          `engine:'native' requires '@react-native/babel-preset' and ` +
             `'@babel/core' to resolve from ${resolvedRoot}. Install them as ` +
             `devDependencies (React Native projects ship them by default):\n\n` +
             `  npm install -D @react-native/babel-preset @babel/core\n\n` +
@@ -660,8 +663,9 @@ export function reactNative(options?: VitestNativeOptions): Plugin {
       // where the native setup file's hooks Flow-strip it and mock the boundary.
       if (engine === "native") {
         if (options?.mocks && Object.keys(options.mocks).length > 0) {
-          throw new Error(
-            `[vitest-native] The "mocks" option is only supported by engine:'mock'. ` +
+          throw new VitestNativeError(
+            "MOCKS_REQUIRE_MOCK_ENGINE",
+            `The "mocks" option is only supported by engine:'mock'. ` +
               `The native engine runs the real react-native module and cannot safely merge ` +
               `arbitrary exports into it. Use vi.mock() in a setup file, ` +
               `mockNativeModule() for native modules, or set engine:'mock'.`,
@@ -763,8 +767,9 @@ export function reactNative(options?: VitestNativeOptions): Plugin {
         // and dies on `Platform.OS` deep inside NativeEventEmitter. Say so here rather
         // than let that surface as an unexplained crash.
         if (userPool === "vmThreads" || userPool === "vmForks") {
-          throw new Error(
-            `[vitest-native] engine:'native' cannot run on the '${userPool}' pool. React Native is ` +
+          throw new VitestNativeError(
+            "UNSUPPORTED_POOL",
+            `engine:'native' cannot run on the '${userPool}' pool. React Native is ` +
               `loaded through Node's module hooks, which a VM pool's context does not use — ` +
               `React Native fails to resolve its platform files there. Use 'threads' (the ` +
               `default) or 'forks', or switch to engine:'mock', which needs no hooks.`,
@@ -893,8 +898,9 @@ export function reactNative(options?: VitestNativeOptions): Plugin {
         if (error) peerErrors.push(error);
       }
       if (peerErrors.length > 0) {
-        throw new Error(
-          `[vitest-native] Unsupported peer dependencies:\n- ${peerErrors.join("\n- ")}`,
+        throw new VitestNativeError(
+          "UNSUPPORTED_PEER",
+          `Unsupported peer dependencies:\n- ${peerErrors.join("\n- ")}`,
         );
       }
 

--- a/packages/vitest-native/src/presets/reanimated.ts
+++ b/packages/vitest-native/src/presets/reanimated.ts
@@ -3,6 +3,7 @@ import { vi } from "vitest";
 import React from "react";
 import { createRequire } from "node:module";
 import path from "node:path";
+import { VitestNativeError } from "../errors.mjs";
 
 /**
  * Resolve the *active* React Native module — the mock under `engine: 'mock'`
@@ -258,8 +259,9 @@ export function reanimated(): Preset {
             const Comp = React.forwardRef((props: any, ref: any) => {
               const Base = getRN()[name];
               if (!Base) {
-                throw new Error(
-                  `[vitest-native] The reanimated preset needs React Native's '${name}' ` +
+                throw new VitestNativeError(
+                  "PRESET_UNAVAILABLE",
+                  `The reanimated preset needs React Native's '${name}' ` +
                     `component to build Animated.${name}, and react-native did not provide it.\n` +
                     `This usually means react-native resolved to something unexpected — a ` +
                     `partially installed copy, or a mock replacing the whole module. Check ` +

--- a/packages/vitest-native/src/validate.ts
+++ b/packages/vitest-native/src/validate.ts
@@ -1,3 +1,4 @@
+import { VitestNativeTypeError } from "./errors.mjs";
 import { createRequire } from "node:module";
 import path from "node:path";
 
@@ -18,13 +19,19 @@ function assertStringArray(value: unknown, option: string): asserts value is str
     !Array.isArray(value) ||
     value.some((entry) => typeof entry !== "string" || entry.length === 0)
   ) {
-    throw new TypeError(`[vitest-native] "${option}" must be an array of non-empty strings.`);
+    throw new VitestNativeTypeError(
+      "INVALID_OPTION",
+      `"${option}" must be an array of non-empty strings.`,
+    );
   }
 }
 
 function assertNonNegativeInteger(value: unknown, option: string): asserts value is number {
   if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
-    throw new TypeError(`[vitest-native] "${option}" must be a non-negative safe integer.`);
+    throw new VitestNativeTypeError(
+      "INVALID_OPTION",
+      `"${option}" must be a non-negative safe integer.`,
+    );
   }
 }
 
@@ -35,34 +42,40 @@ export function validateOptions(options: Record<string, unknown>): void {
     options.engine !== "mock" &&
     options.engine !== "native"
   ) {
-    throw new TypeError(`[vitest-native] "engine" must be "auto", "mock", or "native".`);
+    throw new VitestNativeTypeError(
+      "INVALID_OPTION",
+      `"engine" must be "auto", "mock", or "native".`,
+    );
   }
   if (
     options.platform !== undefined &&
     options.platform !== "ios" &&
     options.platform !== "android"
   ) {
-    throw new TypeError(`[vitest-native] "platform" must be "ios" or "android".`);
+    throw new VitestNativeTypeError("INVALID_OPTION", `"platform" must be "ios" or "android".`);
   }
   if (options.diagnostics !== undefined && typeof options.diagnostics !== "boolean") {
-    throw new TypeError(`[vitest-native] "diagnostics" must be a boolean.`);
+    throw new VitestNativeTypeError("INVALID_OPTION", `"diagnostics" must be a boolean.`);
   }
   if (options.assetExts !== undefined) assertStringArray(options.assetExts, "assetExts");
   if (options.transform !== undefined) assertStringArray(options.transform, "transform");
   if (options.presets !== undefined && !Array.isArray(options.presets)) {
-    throw new TypeError(`[vitest-native] "presets" must be an array.`);
+    throw new VitestNativeTypeError("INVALID_OPTION", `"presets" must be an array.`);
   }
   if (
     options.mocks !== undefined &&
     (options.mocks === null || Array.isArray(options.mocks) || typeof options.mocks !== "object")
   ) {
-    throw new TypeError(`[vitest-native] "mocks" must be a plain object.`);
+    throw new VitestNativeTypeError("INVALID_OPTION", `"mocks" must be a plain object.`);
   }
 
   const hotRuntime = options.hotRuntime;
   if (hotRuntime === undefined || typeof hotRuntime === "boolean") return;
   if (hotRuntime === null || Array.isArray(hotRuntime) || typeof hotRuntime !== "object") {
-    throw new TypeError(`[vitest-native] "hotRuntime" must be a boolean or an options object.`);
+    throw new VitestNativeTypeError(
+      "INVALID_OPTION",
+      `"hotRuntime" must be a boolean or an options object.`,
+    );
   }
 
   const hotOptions = hotRuntime as Record<string, unknown>;
@@ -71,8 +84,9 @@ export function validateOptions(options: Record<string, unknown>): void {
       // The sibling message for top-level options offers a suggestion; this one did
       // not, so a typo produced a bare rejection with no way forward.
       const suggestion = findClosest(key, KNOWN_HOT_RUNTIME_OPTIONS);
-      throw new TypeError(
-        `[vitest-native] Unknown hotRuntime option "${key}".` +
+      throw new VitestNativeTypeError(
+        "UNKNOWN_OPTION",
+        `Unknown hotRuntime option "${key}".` +
           (suggestion ? ` Did you mean '${suggestion}'?` : "") +
           ` Valid options: ${KNOWN_HOT_RUNTIME_OPTIONS.join(", ")}.`,
       );

--- a/packages/vitest-native/tests/errors.test.ts
+++ b/packages/vitest-native/tests/errors.test.ts
@@ -52,6 +52,17 @@ describe("the error classes", () => {
     const cause = new Error("underlying");
     expect(new VitestNativeError("TRANSFORM_FAILED", "wrapped", { cause }).cause).toBe(cause);
   });
+
+  it("install no cause property when there is no cause", () => {
+    // `new Error(msg, { cause: undefined })` installs an own `cause` set to undefined,
+    // which a plain `new Error(msg)` does not — enough for some reporters to print an
+    // empty cause, and enough to make these errors shaped unlike every other error in
+    // the process. Asserting the round trip alone does not catch it, since that passes
+    // either way.
+    const withoutCause = new VitestNativeError("INVALID_OPTION", "no cause given");
+    expect(Object.prototype.hasOwnProperty.call(withoutCause, "cause")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(new Error("baseline"), "cause")).toBe(false);
+  });
 });
 
 describe("real throw sites", () => {
@@ -108,7 +119,13 @@ describe("every message this package throws is attributable", () => {
   const EXEMPT = [
     path.join("mocks", "apis"),
     path.join("matchers", ""),
-    path.join("src", "errors.ts"),
+    // Defines the classes.
+    path.join("src", "errors.mjs"),
+    // explain.mjs wraps somebody else's failure and deliberately keeps the ORIGINAL
+    // error's name, so a Babel SyntaxError still reads as a SyntaxError rather than as
+    // ours. Adopting the class would overwrite that, and the name is the signal. Its
+    // messages already carry the prefix, the package and the fix.
+    path.join("native", "explain.mjs"),
   ];
 
   it("throws a vitest-native error class, or is an exemption with a stated reason", () => {
@@ -117,14 +134,21 @@ describe("every message this package throws is attributable", () => {
     for (const file of sourceFiles(srcRoot)) {
       if (EXEMPT.some((frag) => file.includes(frag))) continue;
       const text = fs.readFileSync(file, "utf8");
-      for (const match of text.matchAll(/throw new (\w+)\(/g)) {
+      // Matches CONSTRUCTION, not just `throw new`. The first version of this scan
+      // looked for `throw new` and so never saw explain.mjs, which builds its errors and
+      // returns them for a caller to throw — leaving the package's two best
+      // explanations outside the rule by accident rather than by decision.
+      // `new Error()` with no arguments is the stack-capture idiom, not a user-facing
+      // error, so it is skipped.
+      for (const match of text.matchAll(/new ((?:Vitest)?\w*(?:Type|Syntax)?Error)\(\s*(.?)/g)) {
+        if (match[2] === ")") continue;
         const cls = match[1];
         if (cls === "VitestNativeError" || cls === "VitestNativeTypeError") {
           converted += 1;
           continue;
         }
         const line = text.slice(0, match.index).split("\n").length;
-        offenders.push(`${path.relative(srcRoot, file)}:${line} throws ${cls}`);
+        offenders.push(`${path.relative(srcRoot, file)}:${line} builds a raw ${cls}`);
       }
     }
     // Guards the guard: an empty `offenders` means nothing only if the scan actually

--- a/packages/vitest-native/tests/errors.test.ts
+++ b/packages/vitest-native/tests/errors.test.ts
@@ -1,0 +1,136 @@
+/**
+ * The error contract, and the deliberate exceptions to it.
+ *
+ * Measured before designing this: across the worker boundary Vitest keeps only `name`,
+ * `message` and `stack` — `code` and every other own property is dropped. So `code` is
+ * for programmatic handling in-process, and the message has to stay self-sufficient.
+ * These tests hold that line.
+ */
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { VitestNativeError, VitestNativeTypeError, isVitestNativeError } from "../src/errors.mjs";
+import { reactNative } from "../src/plugin.js";
+import { validateOptions } from "../src/validate.js";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const srcRoot = path.resolve(here, "..", "src");
+
+describe("the error classes", () => {
+  it("prefix the message exactly once, however the caller wrote it", () => {
+    expect(new VitestNativeError("INVALID_OPTION", "plain").message).toBe("[vitest-native] plain");
+    expect(new VitestNativeError("INVALID_OPTION", "[vitest-native] already").message).toBe(
+      "[vitest-native] already",
+    );
+  });
+
+  it("keep the built-in hierarchy so consumers can still narrow", () => {
+    expect(new VitestNativeError("INVALID_OPTION", "x")).toBeInstanceOf(Error);
+    // A badly typed option IS a TypeError; flattening everything into one class would
+    // lose that.
+    expect(new VitestNativeTypeError("INVALID_OPTION", "x")).toBeInstanceOf(TypeError);
+    expect(new VitestNativeTypeError("INVALID_OPTION", "x")).toBeInstanceOf(Error);
+  });
+
+  it("carry the code and recognise both classes", () => {
+    const e = new VitestNativeError("UNSUPPORTED_POOL", "x");
+    expect(e.code).toBe("UNSUPPORTED_POOL");
+    expect(isVitestNativeError(e)).toBe(true);
+    expect(isVitestNativeError(new VitestNativeTypeError("INVALID_OPTION", "x"))).toBe(true);
+    expect(isVitestNativeError(new Error("someone else's"))).toBe(false);
+  });
+
+  it("append docs to the message, since fields do not reach the reporter", () => {
+    const e = new VitestNativeError("JEST_API_UNSUPPORTED", "no equivalent", {
+      docs: "https://example/guide",
+    });
+    expect(e.message).toContain("https://example/guide");
+  });
+
+  it("preserve the cause chain", () => {
+    const cause = new Error("underlying");
+    expect(new VitestNativeError("TRANSFORM_FAILED", "wrapped", { cause }).cause).toBe(cause);
+  });
+});
+
+describe("real throw sites", () => {
+  it("a bad option throws the typed error with a code", () => {
+    try {
+      validateOptions({ engine: "nonsense" });
+      expect.unreachable("should have thrown");
+    } catch (e) {
+      expect(isVitestNativeError(e)).toBe(true);
+      expect((e as VitestNativeTypeError).code).toBe("INVALID_OPTION");
+      expect(e).toBeInstanceOf(TypeError);
+    }
+  });
+
+  it("an unrecognised name is a different code from a bad type", () => {
+    try {
+      validateOptions({ hotRuntime: { recycleAfterFile: 1 } });
+      expect.unreachable("should have thrown");
+    } catch (e) {
+      // The distinction matters: one means "you typed the wrong thing", the other
+      // "this value is the wrong shape".
+      expect((e as VitestNativeTypeError).code).toBe("UNKNOWN_OPTION");
+      expect((e as Error).message).toContain("recycleAfterFiles");
+    }
+  });
+
+  it("the plugin entry point throws the typed error too", () => {
+    expect(() => reactNative({ platform: "windows" } as never)).toThrow(VitestNativeTypeError);
+  });
+});
+
+describe("every message this package throws is attributable", () => {
+  /** Source files that throw, excluding the two documented exceptions below. */
+  function sourceFiles(dir: string, found: string[] = []): string[] {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) sourceFiles(full, found);
+      else if (/\.(ts|mjs)$/.test(entry.name) && !entry.name.endsWith(".d.ts")) found.push(full);
+    }
+    return found.sort();
+  }
+
+  // Deliberate exceptions, each for a reason that would be lost if this test simply
+  // demanded uniformity:
+  //
+  //   mocks/apis/*  — reproduce React Native's OWN error strings verbatim
+  //                   ("inputRange must have at least 2 elements"), so a suite that
+  //                   matches React Native's message keeps working. Prefixing them
+  //                   would break that fidelity.
+  //   matchers/     — matcher failures use Vitest's matcherHint formatting, which is
+  //                   what a user expects an assertion failure to look like. A
+  //                   "[vitest-native]" prefix in front of that is noise.
+  //   errors.ts     — defines the classes.
+  const EXEMPT = [
+    path.join("mocks", "apis"),
+    path.join("matchers", ""),
+    path.join("src", "errors.ts"),
+  ];
+
+  it("throws a vitest-native error class, or is an exemption with a stated reason", () => {
+    const offenders: string[] = [];
+    let converted = 0;
+    for (const file of sourceFiles(srcRoot)) {
+      if (EXEMPT.some((frag) => file.includes(frag))) continue;
+      const text = fs.readFileSync(file, "utf8");
+      for (const match of text.matchAll(/throw new (\w+)\(/g)) {
+        const cls = match[1];
+        if (cls === "VitestNativeError" || cls === "VitestNativeTypeError") {
+          converted += 1;
+          continue;
+        }
+        const line = text.slice(0, match.index).split("\n").length;
+        offenders.push(`${path.relative(srcRoot, file)}:${line} throws ${cls}`);
+      }
+    }
+    // Guards the guard: an empty `offenders` means nothing only if the scan actually
+    // reached the throw sites. If the walk or the exemptions ever swallow everything,
+    // this fails instead of reporting success.
+    expect(converted).toBeGreaterThanOrEqual(15);
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/vitest-native/tsdown.config.ts
+++ b/packages/vitest-native/tsdown.config.ts
@@ -35,6 +35,14 @@ export default defineConfig({
     // runtime (native: via module.register; jest-compat: as setup file / alias
     // targets resolved by Vite), so they must ship verbatim rather than bundled.
     'build:done': () => {
+      // Top-level runtime .mjs (errors.mjs) ships verbatim too: the shipped runtimes
+      // below import it by relative path, and the tests load those same files from src,
+      // so it must resolve in both trees as one module rather than a bundled copy.
+      for (const f of fs.readdirSync(path.resolve('src'))) {
+        if (f.endsWith('.mjs') || f.endsWith('.d.mts')) {
+          fs.copyFileSync(path.resolve('src', f), path.resolve('dist', f));
+        }
+      }
       for (const sub of ['native', 'jest-compat']) {
         const srcDir = path.resolve('src', sub);
         const outDir = path.resolve('dist', sub);


### PR DESCRIPTION
> **Stacked on #96** — based on `fix/animated-surface-parity` because it touches the same files. Merge #96 first; this rebases onto `main` cleanly afterwards.

The only way to tell a vitest-native failure from an arbitrary crash was a `[vitest-native]` prefix in the message — and **12 of 33 throws didn't carry one**.

Failures now raise `VitestNativeError` or `VitestNativeTypeError` with a stable `code` (`UNSUPPORTED_POOL`, `ENGINE_REQUIRES_BABEL`, `INVALID_OPTION`, …), and the classes guarantee the prefix so it can't be forgotten again.

## Two classes, not one

A badly typed option genuinely *is* a `TypeError`. Flattening everything into a single custom type would lose `instanceof TypeError` for consumers, so `VitestNativeTypeError extends TypeError`.

## Ten throws deliberately left alone

A uniform sweep would have damaged these:

- **`mocks/apis/Animated.ts`, `Easing.ts`** reproduce React Native's *own* error strings verbatim. `"inputRange must have at least 2 elements"` is RN's wording — verified against its source. Prefixing them breaks suites matching RN's message.
- **`matchers/`** keeps Vitest's `matcherHint` formatting, which is what an assertion failure is expected to look like. A `[vitest-native]` prefix in front of that is noise.

Both exemptions are named in the test that enforces the rule, so they stay decisions rather than drift.

## `isVitestNativeError` checks shape, not `instanceof` — and that was measured

`errors.mjs` ships verbatim for the raw native/jest-compat runtimes, while the bundler emits its own chunk for the bundled entries. Two copies exist at runtime:

```
thrown by the BUNDLED side, checked from the VERBATIM module:
  isVitestNativeError (shape-based) : true
  instanceof across the seam        : false   ← why the check is shape-based
```

A prototype check would have failed silently in exactly the case it was written for. Separately measured: across Vitest's worker boundary only `name`, `message` and `stack` survive — `code` is dropped — which is why every message stays self-sufficient rather than moving information into fields.

## Enforcement

`tests/errors.test.ts` (9 tests) covers the prefix guarantee, the `TypeError` hierarchy, codes, `cause` chaining, docs appending, and real throw sites. The sweep asserting every non-exempt throw uses a vitest-native class also asserts it *found* at least 15 converted throws — an empty offender list means nothing if the scan reached nothing. Reverting one conversion makes it fail by file and line.

## Cost

Published budget rises to 236000 bytes, with the duplication recorded as the reason in `package-budget.json`. Externalising the module to avoid the second copy didn't take effect with this bundler config; it's a known cost, not an accident.

## Verification

mock 1485, native 198, forks 198, hot 198, isolation 9, cross-check 85/85, consumers pass, lint/typecheck/format/deps clean.