### PR TITLE
ci(release): refuse to publish a tag that is not on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Full history: the tag-on-main check below compares the tagged commit
+          # against origin/main, which a shallow checkout cannot see.
+          fetch-depth: 0
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
@@ -29,6 +33,19 @@ jobs:
         with:
           node-version: 22.13.0
           registry-url: https://registry.npmjs.org
+
+      - name: Verify the tag is on main
+        # This workflow fires on any v* tag from any commit, and the release flow tags a
+        # SHA by hand after merging. Tagging the wrong one — a branch commit, or a stale
+        # commit from before a fix landed — would publish it: the gate below still passes,
+        # so nothing else catches it, and the result carries provenance and looks
+        # authoritative. Refuse anything main cannot reach.
+        run: |
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor HEAD origin/main; then
+            echo "::error::The tagged commit $(git rev-parse HEAD) is not on main. Tag a commit that main can reach."
+            exit 1
+          fi
 
       - name: Verify tag matches package version
         env:


### PR DESCRIPTION
The release workflow fires on **any `v*` tag from any commit**, and the documented flow tags a SHA by hand after merging the release PR:

```
git tag -a vX <merge-commit> && git push origin vX
```

Tagging the wrong one — a commit still on a branch, or a stale commit from before a fix landed — publishes it. Nothing catches that today:

- the existing check only compares the **tag name** against `package.json`'s version, so `v0.9.0` on any commit carrying that version passes;
- the full gate still passes, because the code isn't *broken* — it's just not the code that was meant to ship;
- the result is staged to npm **with provenance**, so it looks authoritative.

This refuses any commit `main` cannot reach. Checkout takes full history, since the comparison is invisible to the default shallow fetch.

## Verified against real commits in this repository

```
branch head (feat/error-classes) → rejected
commit on main                   → allowed
```

## Context

Found while auditing the release path more broadly. Two things checked and **not** defects, worth recording so they aren't re-investigated:

- The release gate omits `check:size`, `fidelity:check`, `test:native:forks`, `test:native:navigation` and `validate:hot-parity` compared to CI — but `npm stage publish` runs `prepublishOnly`, which covers all five. Confirmed from the 0.9.0 release log, where the full gate executes inside the publish step.
- Consequence of that: most of the suite runs **twice** per release, once inline and again under `prepublishOnly`. Wasteful but harmless, and not changed here.