### PR TITLE
fix(bakeoff): classify an unmeasurable run instead of crashing on it

### DIFF
--- a/packages/vitest-native/scripts/bakeoff-ratchet.mjs
+++ b/packages/vitest-native/scripts/bakeoff-ratchet.mjs
@@ -157,6 +157,18 @@ for (const app of apps) {
 
   // Stock (isolate: true) counts.
   const stock = collectCounts(appDir, "vitest.config.mts", "stock");
+  // collectCounts returns null when the run produced nothing to measure. Without this
+  // the script carried on to derive the hot config, hit an unhandled ENOENT reading a
+  // config the failed run had left incomplete, and died BEFORE classifying — so the
+  // workflow could not tell a broken setup from a real regression and filed every
+  // failure as "(infra?)". A tripwire that cannot say what it found teaches people to
+  // ignore it.
+  if (!stock) {
+    console.error(`✗ ${app}: no stock measurement; skipping this app's observation`);
+    failed = true;
+    infrastructureFailed = true;
+    continue;
+  }
 
   // Hot-runtime counts: same config with hotRuntime flipped on. The PR #55
   // lesson — hot changes must be validated against a real app WITH hot on.
@@ -170,6 +182,12 @@ for (const app of apps) {
   }
   fs.writeFileSync(path.join(appDir, "vitest.hot.config.mts"), hotConfig);
   const hot = collectCounts(appDir, "vitest.hot.config.mts", "hot");
+  if (!hot) {
+    console.error(`✗ ${app}: no hot measurement; skipping this app's observation`);
+    failed = true;
+    infrastructureFailed = true;
+    continue;
+  }
 
   results[app] = { stock, hot };
 }

--- a/packages/vitest-native/tests/bakeoff-observation.test.ts
+++ b/packages/vitest-native/tests/bakeoff-observation.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   classifyObservation,
   classifyObservationVerdict,
@@ -20,6 +23,42 @@ describe("external bake-off observation classification", () => {
   it("keeps infrastructure failures distinct from changed observations", () => {
     expect(classifyObservationVerdict({ changed: false, infra: true })).toBe("infra");
     expect(classifyObservationVerdict({ changed: true, infra: false })).toBe("changed");
+    expect(classifyObservationVerdict({ changed: true, infra: true })).toBe("mixed");
+  });
+});
+
+describe("the ratchet script guards unmeasurable runs", () => {
+  // The script died with an unhandled ENOENT when a measurement produced nothing: it
+  // carried on to read a config the failed run had left incomplete, so the step exited
+  // before classifying and the workflow filed every failure as "(infra?)" — unable to
+  // tell a broken setup from a real regression. Two scheduled runs failed that way
+  // before anyone looked. A static check, because reproducing it needs a network-heavy
+  // multi-minute real-app run.
+  const source = fs.readFileSync(
+    path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "scripts", "bakeoff-ratchet.mjs"),
+    "utf8",
+  );
+
+  it("checks every collectCounts result before using it", () => {
+    // Each measurement is assigned, then must be null-checked somewhere after. Kept
+    // deliberately simple: an earlier version demanded a blank line within 400
+    // characters of the call and silently matched only one of the two sites, which
+    // would have reported success while half the code went unchecked.
+    const assignments = [...source.matchAll(/const (\w+) = collectCounts\(/g)].map((m) => ({
+      name: m[1],
+      from: m.index ?? 0,
+    }));
+    expect(assignments.map((a) => a.name).sort()).toEqual(["hot", "stock"]);
+
+    const unguarded = assignments.filter(
+      ({ name, from }) => !new RegExp(`if \\(!${name}\\)`).test(source.slice(from)),
+    );
+    expect(unguarded.map((u) => u.name)).toEqual([]);
+  });
+
+  it("treats an unmeasurable run as infrastructure, never as a changed observation", () => {
+    // classifyObservationVerdict is what the workflow branches on for the issue title.
+    expect(classifyObservationVerdict({ changed: false, infra: true })).toBe("infra");
     expect(classifyObservationVerdict({ changed: true, infra: true })).toBe("mixed");
   });
 });


### PR DESCRIPTION
The external-app ratchet — the tripwire that would validate flipping `hotRuntime` on by default — **has failed on its last two scheduled runs** (14 and 21 July). Its tracking issue (#86) says *"(infra?)"*, with the question mark, because the workflow couldn't tell what happened.

## Cause

`collectCounts` returns `null` when a run produces no JSON to measure. The caller never checked it:

```
✗ stock: vitest produced no JSON output (exit null)
Error: ENOENT: ... open '/tmp/bakeoffs/obytes/.obytes/vitest.config.mts'
```

After a failed measurement the script carried on to derive the hot config, hit an unhandled `ENOENT` reading a config the failed run had left incomplete, and **exited before publishing a verdict**.

An empty verdict is indistinguishable from a real regression at the workflow level, so a broken setup and a genuine drop produce the same inscrutable issue. A tripwire that can't say what it found teaches people to ignore it — which is roughly what happened: two failures, no investigation.

## Fix

Both measurements are now checked, matching the five infrastructure guards already in the file. The run reaches `classifyObservationVerdict` and reports `infra` rather than dying, so the issue gets an accurate title.

## Still open, separately

The underlying setup failure in the pinned obytes app (and an npm `Cannot find matching keyid` signature error in the same run) is a distinct problem in the external bake-off repo. This change makes the ratchet *report* it correctly; it doesn't fix it.

## On the test

The static check enforcing this had to be rewritten once. Its first version required a blank line within 400 characters of the call and matched **only one of the two sites** — it would have reported success while half the code went unchecked. It now fails when either guard is removed, verified by removing one.

## Relevance

Worth stating plainly: the mechanism that's been cited all session as the gate before `hotRuntime` goes default-on has been producing no signal for two weeks. That's a precondition for that decision, not a side issue.