### PR TITLE
fix(fidelity): treat a shrinking cross-check corpus as a regression

### DIFF
--- a/packages/vitest-native/scripts/fidelity-report.mjs
+++ b/packages/vitest-native/scripts/fidelity-report.mjs
@@ -58,6 +58,41 @@ if (!summary?.total) {
   console.error("✗ report has zero probes — the cross-check likely failed to run.");
   process.exit(1);
 }
+
+// The corpus size is a ratchet, not just a number to re-render. Probes can stop
+// registering silently — a throwing import, a helper that returns early, a
+// `describe` that never runs — and the arithmetic downstream stays honest while
+// the evidence behind it disappears: 12/12 is still "100%", still brightgreen.
+// Comparing the artifacts for equality catches the change but reports it as
+// staleness, and the remedy it prints ("regenerate and commit") is exactly the
+// action that republishes the smaller corpus as a passing result. So a shrink is
+// treated as a regression here and has to be acknowledged explicitly. Growth
+// needs no ceremony. The committed badge is the floor, which keeps the ratchet in
+// the same artifact the page publishes rather than in a second file that could
+// drift away from it.
+const ALLOW_SHRINK_FLAG = "--allow-corpus-shrink";
+function committedProbeCount() {
+  try {
+    const badge = JSON.parse(fs.readFileSync(badgePath, "utf8"));
+    const matched = /(\d+)\s*\/\s*(\d+)\s+probes/.exec(badge.message ?? "");
+    return matched ? Number(matched[2]) : null;
+  } catch {
+    return null; // No committed badge yet (first run) — nothing to ratchet against.
+  }
+}
+const floor = committedProbeCount();
+if (floor !== null && summary.total < floor && !process.argv.includes(ALLOW_SHRINK_FLAG)) {
+  console.error(
+    `✗ the cross-check corpus shrank: ${summary.total} probes ran, but ${floor} are published.\n` +
+      `  ${floor - summary.total} probe(s) stopped reporting. This is a loss of evidence, not stale\n` +
+      "  artifacts — regenerating would republish the smaller corpus as a passing result.\n\n" +
+      "  Check for a probe that throws on import, a skipped block, or a helper returning early:\n" +
+      "      bun run crosscheck\n\n" +
+      `  If probes were retired deliberately, rerun with ${ALLOW_SHRINK_FLAG} to lower the floor.`,
+  );
+  process.exit(1);
+}
+
 const allMatch = summary.matching === summary.total;
 // In --check mode the artifacts are rendered and compared to what's committed,
 // but never written; a difference exits non-zero. This is the CI drift guard:

--- a/packages/vitest-native/tests/fidelity-corpus-floor.test.ts
+++ b/packages/vitest-native/tests/fidelity-corpus-floor.test.ts
@@ -1,0 +1,114 @@
+/**
+ * The published fidelity numbers are a ratchet, not a rendering.
+ *
+ * Probes can stop registering without anything going red: an import that throws,
+ * a `describe` that never runs, a helper that returns early. The arithmetic stays
+ * honest while the evidence behind it disappears — 12/12 reads as "100%" and the
+ * badge stays brightgreen. Comparing artifacts for equality does notice the
+ * change, but classifies it as staleness, and the remedy it prints ("regenerate
+ * and commit") is precisely the step that republishes the smaller corpus as a
+ * pass. Before this guard, a corpus shrinking 81 → 12 could be walked back to
+ * green by following the instructions the tool itself printed.
+ *
+ * These run the real script against a crafted report so the exit codes are the
+ * ones CI would see. Only `--check` is exercised: it never writes, so the
+ * committed badge and page cannot be disturbed by a failing test run.
+ */
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const script = path.join(packageRoot, "scripts", "fidelity-report.mjs");
+const reportPath = path.join(packageRoot, "crosscheck", ".out", "report.json");
+const badgePath = path.join(packageRoot, "crosscheck", "fidelity-badge.json");
+
+/** The floor the script ratchets against: the count in the committed badge. */
+function committedProbeCount(): number {
+  const badge = JSON.parse(fs.readFileSync(badgePath, "utf8"));
+  const matched = /(\d+)\s*\/\s*(\d+)\s+probes/.exec(badge.message);
+  if (!matched) throw new Error(`Unreadable badge message: ${badge.message}`);
+  return Number(matched[2]);
+}
+
+function writeReport(total: number): void {
+  fs.mkdirSync(path.dirname(reportPath), { recursive: true });
+  fs.writeFileSync(
+    reportPath,
+    `${JSON.stringify(
+      {
+        reactNativeVersion: "0.86.0",
+        vitestVersion: "4.0.0",
+        generatedAt: "2026-01-01T00:00:00.000Z",
+        summary: { total, matching: total },
+        probes: Array.from({ length: total }, (_, i) => ({ name: `probe-${i}`, match: true })),
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+function runCheck(...extraArgs: string[]) {
+  const res = spawnSync(process.execPath, [script, "--check", "--no-run", ...extraArgs], {
+    cwd: packageRoot,
+    encoding: "utf8",
+  });
+  return { status: res.status, output: `${res.stdout ?? ""}${res.stderr ?? ""}` };
+}
+
+describe("fidelity corpus floor", () => {
+  let saved: string | null = null;
+  const floor = committedProbeCount();
+
+  beforeAll(() => {
+    saved = fs.existsSync(reportPath) ? fs.readFileSync(reportPath, "utf8") : null;
+  });
+
+  afterAll(() => {
+    if (saved === null) fs.rmSync(reportPath, { force: true });
+    else fs.writeFileSync(reportPath, saved);
+  });
+
+  it("fails when the corpus shrinks below the published count", () => {
+    writeReport(Math.max(1, Math.floor(floor / 4)));
+    const { status, output } = runCheck();
+    expect(status).toBe(1);
+    expect(output).toContain("corpus shrank");
+  });
+
+  it("does not tell the reader to regenerate, which would republish the shrunken corpus", () => {
+    writeReport(Math.max(1, Math.floor(floor / 4)));
+    const { output } = runCheck();
+    // The staleness path prints this; the shrink path must not, or the remedy
+    // launders the regression.
+    expect(output).not.toContain("run `bun run fidelity:report` and commit");
+  });
+
+  it("reports how many probes stopped reporting", () => {
+    const total = Math.max(1, floor - 3);
+    writeReport(total);
+    const { output } = runCheck();
+    expect(output).toContain(`${floor - total} probe(s) stopped reporting`);
+  });
+
+  it("allows a deliberate reduction behind an explicit flag", () => {
+    writeReport(Math.max(1, Math.floor(floor / 4)));
+    const { output } = runCheck("--allow-corpus-shrink");
+    expect(output).not.toContain("corpus shrank");
+  });
+
+  it("does not block growth", () => {
+    writeReport(floor + 5);
+    const { output } = runCheck();
+    expect(output).not.toContain("corpus shrank");
+  });
+
+  it("does not block a corpus that exactly matches the published count", () => {
+    writeReport(floor);
+    const { output } = runCheck();
+    expect(output).not.toContain("corpus shrank");
+  });
+});


### PR DESCRIPTION
The cross-check corpus is the mock engine's trust mechanism, and the fidelity badge/page are the public claim built from it. That claim currently has **no floor**: the report renders however many probes happened to report.

## The problem

Probes can stop registering without anything going red — an import that throws, a `describe` that never runs, a helper that returns early. The arithmetic downstream stays honest while the evidence behind it disappears. A corpus of 12 renders as `12/12`, "100%", brightgreen.

Artifact equality *does* notice the change — but classifies it as staleness:

```
✗ fidelity artifacts are stale — run `bun run fidelity:report` and commit
```

**Following that instruction republishes the smaller corpus as a pass.** Verified end to end by shrinking a report 81 → 12 and running the printed command:

```
badge:  "message": "12/12 probes",  "color": "brightgreen"
page:   **12 / 12 probes** match between the mock engine and real React Native
gate:   ✓ fidelity artifacts are up to date (12/12 probes)
```

The page then claims full parity on 86% less evidence, and the tool's own remedy is what got it there.

## The fix

The committed badge becomes the floor, enforced in **both** `--check` and write modes so the remedy can't launder the loss:

```
✗ the cross-check corpus shrank: 12 probes ran, but 81 are published.
  69 probe(s) stopped reporting. This is a loss of evidence, not stale
  artifacts — regenerating would republish the smaller corpus as a passing result.
```

Growth needs no ceremony. A deliberate retirement passes `--allow-corpus-shrink`, making a lowered number an explicit, reviewable act rather than a side effect of regenerating.

The floor lives in the badge rather than a new file so it can't drift away from the number actually published.

## Verification

- Six regression tests spawn the real script and assert real exit codes; `--check` never writes, so a failing run can't disturb committed artifacts.
- **Control**: disabling the guard fails 3 of the 6 (the positive-detection ones); the negative assertions correctly still pass.
- Cases covered: shrink (blocked, both modes, exit 1), equal, growth, escape hatch.
- End-to-end `fidelity:check` still passes unchanged: `81/81 probes`, artifacts up to date.
- Full gate: 1464 passed / 3 skipped, lint + typecheck + format:check clean.

## Context

`check-compat` in the same package already guards the analogous case (`exports.length < 50` → "update the parser before making coverage claims"). This applies the same reasoning to the corpus the public fidelity claim is derived from.