### PR TITLE
fix(fidelity): make the matrix page describe the run it was built from

### DIFF
--- a/packages/vitest-native/scripts/fidelity-matrix.mjs
+++ b/packages/vitest-native/scripts/fidelity-matrix.mjs
@@ -62,15 +62,64 @@ function collectReports(dir) {
  * The artifact directory name carries the matrix axes
  * (crosscheck-report-rn<version>-<vitest-flavor>); the report body carries the
  * RESOLVED versions. Prefer the body, fall back to the directory name.
+ *
+ * The flavor is matched openly rather than against a list of known names. An
+ * allow-list here silently mislabels any cell added later: `v5` cells went in
+ * without one and were read as `locked`, because the fallback picked a real
+ * flavor name instead of admitting the parse had failed. An unrecognized
+ * directory now says so.
  */
 function describeCell(reportPath, report) {
   const dirName = path.basename(path.dirname(reportPath));
-  const m = /^crosscheck-report-rn(.+?)-(locked|latest-supported)$/.exec(dirName);
+  const m = /^crosscheck-report-rn(.+?)-(.+)$/.exec(dirName);
   return {
     rn: report.reactNativeVersion ?? m?.[1] ?? "unknown",
-    vitest: report.vitestVersion ?? (m?.[2] === "latest-supported" ? "latest 4.x" : "locked"),
-    flavor: m?.[2] ?? "locked",
+    // Only the report body knows the RESOLVED Vitest version. The flavor is the
+    // axis, carried in its own column, so an absent body version is reported as
+    // unknown rather than restated as the axis name.
+    vitest: report.vitestVersion ?? "unknown",
+    flavor: m?.[2] ?? "unknown",
   };
+}
+
+/**
+ * The matrix axes, read from the workflow that defines them, so the page can
+ * state what was gated rather than only what happened to arrive. Artifacts are
+ * downloaded best-effort at deploy time (`|| true`, `if-no-files-found: ignore`,
+ * 30-day retention), so a partial set is an ordinary outcome — and a table built
+ * from it still read "Every probe matches on every gated React Native version",
+ * a claim about cells that were never in the render.
+ */
+function expectedCells() {
+  try {
+    const wf = fs.readFileSync(
+      path.join(repoRoot, ".github", "workflows", "native-rn-matrix.yml"),
+      "utf8",
+    );
+    const lines = wf.split("\n");
+    const axis = (name) => {
+      const line = lines.find((l) => new RegExp(`^\\s*${name}:\\s*\\[`).test(l));
+      return [...(line?.matchAll(/'([^']+)'/g) ?? [])].map((m) => m[1]);
+    };
+    const rns = axis("rn");
+    const flavors = axis("vitest");
+    if (rns.length === 0 || flavors.length === 0) return null;
+    const cells = new Set(rns.flatMap((rn) => flavors.map((f) => `${rn}-${f}`)));
+    // `include:` entries add cells outside the cross product.
+    const includeBlock = wf.slice(wf.indexOf("include:"));
+    for (const m of includeBlock.matchAll(/-\s*rn:\s*'([^']+)'\s*\n\s*vitest:\s*'([^']+)'/g)) {
+      cells.add(`${m[1]}-${m[2]}`);
+    }
+    return cells;
+  } catch {
+    return null;
+  }
+}
+
+/** Match a rendered cell back to its matrix key: RN is resolved (0.86.0), the axis is a series (0.86). */
+function matrixKey({ rn, flavor }) {
+  const series = String(rn).split(".").slice(0, 2).join(".");
+  return `${series}-${flavor}`;
 }
 
 const HEADER = `<!--
@@ -112,12 +161,24 @@ A local or matrix-less build shows this placeholder. The single-version
     );
 
   const allGreen = cells.every((c) => c.report.summary.matching === c.report.summary.total);
+
+  // Cells that arrived, against the cells the workflow gates.
+  const expected = expectedCells();
+  const present = new Set(cells.map(matrixKey));
+  const missing = expected ? [...expected].filter((k) => !present.has(k)).sort() : [];
+  const complete = expected !== null && missing.length === 0;
+
   const rows = cells
-    .map(({ rn, vitest, report }) => {
+    .map(({ rn, vitest, flavor, report }) => {
       const { matching, total } = report.summary;
       const status = matching === total ? "✅" : "❌";
       const when = (report.generatedAt ?? "").slice(0, 10);
-      return `| ${cell(rn)} | ${cell(vitest)} | ${status} ${matching}/${total} | ${cell(when)} |`;
+      // The flavor is what separates two cells that resolve to the same Vitest
+      // version. Rendering only the resolved version made `locked` and
+      // `latest-supported` byte-identical rows — the published table repeated
+      // every React Native version twice with nothing to tell the pair apart,
+      // and the axis the matrix exists to cover was invisible.
+      return `| ${cell(rn)} | ${cell(vitest)} | ${cell(flavor)} | ${status} ${matching}/${total} | ${cell(when)} |`;
     })
     .join("\n");
 
@@ -135,11 +196,21 @@ A local or matrix-less build shows this placeholder. The single-version
       ),
   );
 
-  body = `
-${allGreen ? `**Every probe matches on every gated React Native version.**` : `**Divergences detected — see the table below.**`}
+  const headline = !allGreen
+    ? `**Divergences detected — see the table below.**`
+    : complete
+      ? `**Every probe matches on every gated React Native version.**`
+      : `**Every probe matches in every cell shown below.** This build is missing ${missing.length} of the ${(expected?.size ?? 0).toString()} gated cells, so it is not a statement about the full matrix.`;
 
-| React Native | Vitest | Probes matching | Generated |
-| --- | --- | --- | --- |
+  const missingNote = missing.length
+    ? `\n::: warning Incomplete matrix data\nNo report arrived for ${missing.map((k) => `\`${cell(k)}\``).join(", ")}. Matrix artifacts are downloaded best-effort at deploy time and expire after 30 days; a cell that failed before the cross-check ran uploads nothing. The rows below are still CI-produced — there are simply fewer of them than the matrix gates.\n:::\n`
+    : "";
+
+  body = `
+${headline}
+${missingNote}
+| React Native | Vitest | Flavor | Probes matching | Generated |
+| --- | --- | --- | --- | --- |
 ${rows}
 
 ## Divergences

--- a/packages/vitest-native/tests/fidelity-matrix-cells.test.ts
+++ b/packages/vitest-native/tests/fidelity-matrix-cells.test.ts
@@ -1,0 +1,115 @@
+/**
+ * The published fidelity matrix has to describe the run it was built from.
+ *
+ * Three ways it did not. Every row rendered only the RESOLVED Vitest version, so
+ * the `locked` and `latest-supported` cells — which normally resolve to the same
+ * version — came out byte-identical: the live page listed each React Native
+ * version twice with nothing to tell the pair apart, and the axis the matrix
+ * exists to cover was invisible. The artifact-name parser matched flavors against
+ * a list of known names, so the `v5` cells added later fell through to a fallback
+ * that named a different real flavor rather than admitting the parse failed. And
+ * the headline — "Every probe matches on every gated React Native version" — was
+ * quantified over whatever artifacts happened to download, while the deploy step
+ * downloads best-effort (`|| true`, `if-no-files-found: ignore`, 30-day
+ * retention), so a partial set still published a claim about the whole matrix.
+ *
+ * These render through the real script into a temp file, so nothing committed is
+ * touched.
+ */
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, describe, expect, it } from "vitest";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const script = path.join(packageRoot, "scripts", "fidelity-matrix.mjs");
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fidelity-matrix-"));
+
+afterAll(() => fs.rmSync(tmpRoot, { recursive: true, force: true }));
+
+/** Build a reports directory shaped exactly like the CI artifact download. */
+function reportsDir(cells: Array<{ rn: string; flavor: string; vitest: string }>): string {
+  const dir = fs.mkdtempSync(path.join(tmpRoot, "reports-"));
+  for (const { rn, flavor, vitest } of cells) {
+    const cellDir = path.join(dir, `crosscheck-report-rn${rn}-${flavor}`);
+    fs.mkdirSync(cellDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(cellDir, "report.json"),
+      JSON.stringify({
+        reactNativeVersion: `${rn}.0`,
+        vitestVersion: vitest,
+        generatedAt: "2026-07-25T00:00:00.000Z",
+        summary: { total: 81, matching: 81 },
+        probes: [{ name: "a11y-role", match: true }],
+      }),
+    );
+  }
+  return dir;
+}
+
+let renderCount = 0;
+function render(cells: Parameters<typeof reportsDir>[0]): string {
+  const out = path.join(tmpRoot, `out-${renderCount++}.md`);
+  const res = spawnSync(process.execPath, [script, "--reports", reportsDir(cells), "--out", out], {
+    cwd: packageRoot,
+    encoding: "utf8",
+  });
+  expect(res.status).toBe(0);
+  return fs.readFileSync(out, "utf8");
+}
+
+/** Every cell the matrix workflow gates — the set the headline quantifies over. */
+const ALL_CELLS = (() => {
+  const rns = ["0.81", "0.82", "0.83", "0.84", "0.85", "0.86"];
+  const cells = rns.flatMap((rn) => [
+    { rn, flavor: "locked", vitest: "4.1.9" },
+    { rn, flavor: "latest-supported", vitest: "4.1.9" },
+  ]);
+  cells.push({ rn: "0.81", flavor: "v5", vitest: "5.0.0-beta.6" });
+  cells.push({ rn: "0.86", flavor: "v5", vitest: "5.0.0-beta.6" });
+  return cells;
+})();
+
+function tableRows(page: string): string[] {
+  return page.split("\n").filter((l) => /^\|\s*0\.\d/.test(l));
+}
+
+describe("fidelity matrix cells", () => {
+  it("renders cells that resolve to the same Vitest version as distinguishable rows", () => {
+    const rows = tableRows(render(ALL_CELLS));
+    expect(rows.length).toBe(ALL_CELLS.length);
+    expect(new Set(rows).size).toBe(rows.length);
+  });
+
+  it("does not label a v5 cell as locked", () => {
+    const page = render([
+      { rn: "0.86", flavor: "locked", vitest: "4.1.9" },
+      { rn: "0.86", flavor: "v5", vitest: "5.0.0-beta.6" },
+    ]);
+    expect(page).toContain("| v5 |");
+    expect(tableRows(page).filter((r) => r.includes("| locked |")).length).toBe(1);
+  });
+
+  it("claims the full matrix only when every gated cell reported", () => {
+    const page = render(ALL_CELLS);
+    expect(page).toContain("Every probe matches on every gated React Native version.");
+    expect(page).not.toContain("Incomplete matrix data");
+  });
+
+  it("qualifies the claim and names the gap when cells are missing", () => {
+    const page = render(ALL_CELLS.filter((c) => !(c.rn === "0.84" && c.flavor === "locked")));
+    expect(page).not.toContain("on every gated React Native version.");
+    expect(page).toContain("Incomplete matrix data");
+    expect(page).toContain("0.84-locked");
+    expect(page).toContain(`missing 1 of the ${ALL_CELLS.length} gated cells`);
+  });
+
+  it("counts a wholly absent flavor as missing rather than passing silently", () => {
+    const page = render(ALL_CELLS.filter((c) => c.flavor !== "v5"));
+    expect(page).toContain("Incomplete matrix data");
+    expect(page).toContain("0.81-v5");
+    expect(page).toContain("0.86-v5");
+  });
+});

--- a/packages/vitest-native/tests/fidelity-matrix.test.ts
+++ b/packages/vitest-native/tests/fidelity-matrix.test.ts
@@ -61,8 +61,8 @@ describe("fidelity-matrix renderer", () => {
     // Sorted by RN version: 0.81 row before 0.85.
     expect(page.indexOf("0.81.5")).toBeLessThan(page.indexOf("0.85.2"));
     // Per-cell summary rows with pass state.
-    expect(page).toContain("| 0.85.2 | 4.1.8 | ✅ 75/75 | 2026-07-04 |");
-    expect(page).toContain("| 0.81.5 | 4.2.1 | ❌ 74/75 | 2026-07-04 |");
+    expect(page).toContain("| 0.85.2 | 4.1.8 | locked | ✅ 75/75 | 2026-07-04 |");
+    expect(page).toContain("| 0.81.5 | 4.2.1 | latest-supported | ❌ 74/75 | 2026-07-04 |");
     // Divergence table present, with hazards escaped.
     expect(page).toContain("| press-event |");
     expect(page).toContain("mock &lt;Text&gt; got a\\|b \\\\\\| &#123;&#123; nope &#125;&#125;");
@@ -109,7 +109,7 @@ describe("fidelity-matrix renderer", () => {
     ).toThrow();
   });
 
-  it("declares all-green when every cell matches fully", () => {
+  it("declares the cells green but does not claim the matrix from one cell", () => {
     const reports = fs.mkdtempSync(path.join(os.tmpdir(), "vn-matrix-reports-"));
     writeReport(reports, "crosscheck-report-rn0.86-locked", {
       reactNativeVersion: "0.86.0",
@@ -119,7 +119,10 @@ describe("fidelity-matrix renderer", () => {
       probes: [{ name: "a11y-role", match: true }],
     });
     const { page } = render(["--reports", reports]);
-    expect(page).toContain("Every probe matches on every gated React Native version.");
+    // One cell is not the matrix: the strong claim is reserved for a complete
+    // set (asserted in fidelity-matrix-cells.test.ts), and a partial render says so.
+    expect(page).toContain("Every probe matches in every cell shown below.");
+    expect(page).not.toContain("on every gated React Native version.");
     expect(page).toContain("_None. Every probe matched in every cell of the latest matrix run._");
   });
 
@@ -131,6 +134,6 @@ describe("fidelity-matrix renderer", () => {
       probes: [],
     });
     const { page } = render(["--reports", reports]);
-    expect(page).toContain("| 0.83 | latest 4.x | ✅ 10/10 |");
+    expect(page).toContain("| 0.83 | unknown | latest-supported | ✅ 10/10 |");
   });
 });


### PR DESCRIPTION
Three ways the **live** [fidelity matrix page](https://danfry1.github.io/vitest-native/guide/fidelity-matrix.html) misstated what CI had gated. All three were verified against the real artifacts of the deploy-source run (`30162014291`) and against the deployed HTML.

## 1. Six pairs of byte-identical rows

Rows rendered only the *resolved* Vitest version. `locked` and `latest-supported` normally resolve to the same version, so the pair rendered identically — currently live:

```
<td>0.81.6</td>  <td>4.1.9</td>  <td>✅ 81/81</td>  <td>2026-07-25</td>
<td>0.81.6</td>  <td>4.1.9</td>  <td>✅ 81/81</td>  <td>2026-07-25</td>
```

Every React Native version listed twice with nothing to tell the pair apart. The `flavor` was already computed — for sorting — and simply never displayed. It now has a column.

## 2. Vitest 5 cells labelled `locked`

The artifact-name parser matched flavors against an allow-list:

```js
/^crosscheck-report-rn(.+?)-(locked|latest-supported)$/
```

The `v5` cells were added to the matrix later without updating it, so they failed the match and hit `flavor: m?.[2] ?? "locked"` — a fallback that names *a different real flavor*. The parser now matches any flavor and reports `unknown` rather than guessing a plausible wrong answer.

## 3. A whole-matrix claim from a partial set

> **Every probe matches on every gated React Native version.**

That was quantified over whatever artifacts arrived, while the deploy step is best-effort throughout: `|| true` on the download, `if-no-files-found: ignore` on the upload, 30-day retention. A cell that fails before the cross-check runs uploads nothing, and the page would still have claimed the full matrix.

Expected cells are now derived from the workflow that defines them — the same source-of-truth approach `fidelity-report.mjs` already uses for the RN range. Complete sets keep the strong claim; incomplete ones state the count, name the gap, and explain it:

```
**Every probe matches in every cell shown below.** This build is missing 2 of the 14
gated cells, so it is not a statement about the full matrix.

::: warning Incomplete matrix data
No report arrived for `0.84-locked`, `0.86-v5`. ...
:::
```

## Verification

- Rendered from the **real** artifacts of the deploy-source run: 14/14 cells, all rows now distinct, `v5` correctly labelled, strong claim retained.
- Rendered from a deliberately-incomplete copy: claim qualified, missing cells named.
- 5 new tests, plus 3 existing tests in `fidelity-matrix.test.ts` updated to the new column contract.
- **Controls** (each fix reverted individually): dropping the flavor column fails 2; restoring the allow-list regex fails 3; making the headline unconditional fails 1.
- Committed placeholder unchanged — `--check` still passes.
- Full gate: 1463 passed / 3 skipped, lint + typecheck + format:check clean.

## Note

The resolved-version fallback no longer restates the axis name when a report body lacks a version, since the flavor is now its own column — so that column reads `unknown` instead of inventing `latest 4.x`.