### PR TITLE
fix(crosscheck): make the published reproduce command work from a clone

### DIFF
--- a/packages/vitest-native/scripts/crosscheck.mjs
+++ b/packages/vitest-native/scripts/crosscheck.mjs
@@ -14,11 +14,21 @@ import { createRequire } from "node:module";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { ensureBuilt } from "./ensure-built.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const config = path.join(root, "crosscheck", "vitest.config.mts");
 const outDir = path.join(root, "crosscheck", ".out");
 const vitestBin = path.join(root, "node_modules", ".bin", "vitest");
+
+// The config imports ../dist/index.mjs, which a fresh clone does not have.
+try {
+  ensureBuilt({ root });
+} catch (error) {
+  console.error(`✗ ${error.message}`);
+  process.exit(1);
+}
+
 fs.mkdirSync(outDir, { recursive: true });
 
 function resolveReactNativeVersion() {

--- a/packages/vitest-native/scripts/ensure-built.mjs
+++ b/packages/vitest-native/scripts/ensure-built.mjs
@@ -1,0 +1,44 @@
+// The cross-check runs against the BUILT plugin: crosscheck/vitest.config.mts
+// imports ../dist/index.mjs. dist/ is gitignored and no install hook produces
+// it, so on a fresh clone the published instruction — "clone the repo and run
+// `bun run crosscheck`" — died on an unresolved import before a single probe
+// ran. That instruction is the reproducibility claim the fidelity page rests on,
+// so the command builds what it needs rather than assuming a prior step.
+//
+// Dependencies are injected so the decision can be tested without running a
+// build or touching dist/.
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Ensure the built plugin entry exists, building once if it does not.
+ *
+ * @returns {{ built: boolean }} whether a build was run
+ * @throws if the entry is still absent afterwards
+ */
+export function ensureBuilt({
+  root,
+  exists = fs.existsSync,
+  run = (command, args, options) => spawnSync(command, args, options),
+  log = console.log,
+} = {}) {
+  const entry = path.join(root, "dist", "index.mjs");
+  if (exists(entry)) return { built: false };
+
+  log("── dist/ not found — building the plugin the cross-check runs against ──");
+  const result = run("bun", ["run", "build"], {
+    cwd: root,
+    stdio: "inherit",
+    // Windows resolves bun.exe/bun.cmd through the shell.
+    shell: process.platform === "win32",
+  });
+
+  if (result.status !== 0 || !exists(entry)) {
+    throw new Error(
+      "Could not build the plugin the cross-check needs.\n" +
+        "  Run `bun install && bun run build` in packages/vitest-native, then retry.",
+    );
+  }
+  return { built: true };
+}

--- a/packages/vitest-native/tests/ensure-built.test.ts
+++ b/packages/vitest-native/tests/ensure-built.test.ts
@@ -1,0 +1,90 @@
+/**
+ * The cross-check has to run from a fresh clone, because three published pages
+ * tell readers to do exactly that:
+ *
+ *   index.md      "Anyone can run it (`bun run crosscheck`)"
+ *   fidelity.md   "Reproduce it yourself: `bun run crosscheck`."
+ *   comparison.md "It's reproducible — clone the repo and run `bun run crosscheck`."
+ *
+ * It could not. crosscheck/vitest.config.mts imports ../dist/index.mjs, dist/ is
+ * gitignored, and no install hook builds it — so the command died on
+ * "Could not resolve '../dist/index.mjs'" before a single probe ran. The
+ * reproducibility claim is the whole basis of the fidelity page's authority, so
+ * the failure was not a papercut in a dev script; it was the one instruction a
+ * sceptical reader would actually run.
+ *
+ * Dependencies are injected so these assert the decision without running a build.
+ */
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { ensureBuilt } from "../scripts/ensure-built.mjs";
+
+const ROOT = path.join(path.sep, "repo", "packages", "vitest-native");
+const ENTRY = path.join(ROOT, "dist", "index.mjs");
+
+/** A build that succeeds, and makes the entry appear as a real build would. */
+function buildingRun(present: Set<string>) {
+  return vi.fn(() => {
+    present.add(ENTRY);
+    return { status: 0 };
+  });
+}
+
+describe("ensureBuilt", () => {
+  it("does not build when the entry is already present", () => {
+    const run = vi.fn(() => ({ status: 0 }));
+    const result = ensureBuilt({
+      root: ROOT,
+      exists: (p: string) => p === ENTRY,
+      run,
+      log: () => {},
+    });
+    expect(run).not.toHaveBeenCalled();
+    expect(result).toEqual({ built: false });
+  });
+
+  it("builds when the entry is missing", () => {
+    const present = new Set<string>();
+    const run = buildingRun(present);
+    const result = ensureBuilt({
+      root: ROOT,
+      exists: (p: string) => present.has(p),
+      run,
+      log: () => {},
+    });
+    expect(result).toEqual({ built: true });
+    expect(run).toHaveBeenCalledOnce();
+    const [command, args, options] = run.mock.calls[0] as [string, string[], { cwd: string }];
+    expect(command).toBe("bun");
+    expect(args).toEqual(["run", "build"]);
+    expect(options.cwd).toBe(ROOT);
+  });
+
+  it("throws with actionable guidance when the build fails", () => {
+    const run = vi.fn(() => ({ status: 1 }));
+    expect(() => ensureBuilt({ root: ROOT, exists: () => false, run, log: () => {} })).toThrow(
+      /bun install && bun run build/,
+    );
+  });
+
+  it("throws when the build reports success but produces no entry", () => {
+    // A build that exits 0 without writing dist/ would otherwise hand the
+    // cross-check the same unresolved-import failure this guard exists to prevent.
+    const run = vi.fn(() => ({ status: 0 }));
+    expect(() => ensureBuilt({ root: ROOT, exists: () => false, run, log: () => {} })).toThrow(
+      /Could not build/,
+    );
+  });
+
+  it("says what it is doing, since it runs inside another command", () => {
+    const present = new Set<string>();
+    const log = vi.fn();
+    ensureBuilt({
+      root: ROOT,
+      exists: (p: string) => present.has(p),
+      run: buildingRun(present),
+      log,
+    });
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("building the plugin"));
+  });
+});


### PR DESCRIPTION
The cross-check is what makes the mock engine's fidelity a *demonstration* rather than an assertion, and three published pages invite readers to run it:

| Page | Wording |
| --- | --- |
| `index.md` | "Anyone can run it (`bun run crosscheck`)" |
| `guide/fidelity.md` | "Reproduce it yourself: `bun run crosscheck`." |
| `guide/comparison.md` | "It's reproducible — **clone the repo and run** `bun run crosscheck`." |

**None of them worked.** `crosscheck/vitest.config.mts` imports `../dist/index.mjs`, `dist/` is gitignored, and there is no `prepare`/`postinstall` hook that builds it. Verified by moving `dist/` aside and running the published command:

```
── cross-check: native engine ──
failed to load config from crosscheck/vitest.config.mts
Error: Build failed with 1 error:
[UNRESOLVED_IMPORT] Could not resolve '../dist/index.mjs' in crosscheck/vitest.config.mts
```

That is the first thing a sceptical reader does, and it fails before a single probe runs — on the one claim the fidelity page's authority rests on.

## Fix

`bun run crosscheck` now builds the plugin it runs against when the entry is missing, and is unchanged when it is present, so CI (which builds first) does no extra work. A build that fails — or exits `0` without producing the entry — stops with instructions instead of falling through to the same unresolved import.

Verified end to end from fresh-clone state:

```
── dist/ not found — building the plugin the cross-check runs against ──
$ tsdown && node scripts/copy-static-types.mjs
...
81/81 probes match between mock and real React Native.
✓ mock engine matches real React Native across the corpus.
```

No documentation changed: the pages were already making the right promise.

## Verification

- The decision lives in `scripts/ensure-built.mjs` with dependencies injected, following the `findDuplicateReact(resolve, …)` pattern already used in this package, so it is tested without running a build.
- 5 tests: skips when built, builds when missing (asserting `bun run build` in the right cwd), fails with actionable guidance, fails when a "successful" build produces nothing, and announces itself.
- **Controls**: removing the already-built early return fails 1; trusting the exit code without verifying the entry appeared fails 1.
- Full gate: 1463 passed / 3 skipped, lint + typecheck + format:check clean.