### PR TITLE
fix(native): report when the precompiled registry cannot be built

### DIFF
--- a/.changeset/registry-fallback-reported.md
+++ b/.changeset/registry-fallback-reported.md
@@ -1,0 +1,17 @@
+---
+"vitest-native": patch
+---
+
+Report when the precompiled React Native registry cannot be built
+
+The native engine compiles React Native's module graph into a single file, and falls
+back to per-file module loading when it cannot. The fallback is correct — tests still
+run and no result changes — which is what made it hard to notice: a degraded run
+looked exactly like a healthy one, only slower. Measured on this package's own native
+suite, roughly 1.4x, and the per-file cost compounds on a larger suite.
+
+Neither failure path said so. The build path logged only under `diagnostics`, which
+is off by default, and the cache-directory path returned without a message under any
+setting. Both now warn once per distinct cause, naming the cause and stating that
+results are unaffected. Setting `VITEST_NATIVE_NO_REGISTRY=1` remains silent, since
+that path is a request rather than a failure.

--- a/packages/vitest-native/src/native/registry.mjs
+++ b/packages/vitest-native/src/native/registry.mjs
@@ -31,8 +31,57 @@ import path from "node:path";
 import fs from "node:fs";
 import crypto from "node:crypto";
 import { transformRN, isFlow, cacheRootFor, TRANSFORM_CACHE_VERSION } from "./transform.mjs";
+
 import { boundarySourceFor, BOUNDARY_SOURCES } from "./boundary.mjs";
 import { resolvePlatformFile } from "./resolve.mjs";
+
+/**
+ * Losing the registry is a silent performance cliff, not a correctness problem:
+ * React Native still loads, file by file, and nothing fails. Measured on this
+ * package's own native suite (~42 files), that costs roughly 1.4x — 1.8s becomes
+ * 2.5-2.8s — and the per-file cost compounds on a real app suite.
+ *
+ * Both failure paths used to return null in silence (the build path spoke only
+ * under `diagnostics`, the cache-directory path never spoke at all), so the
+ * fallback was indistinguishable from working normally. A precompile failure is
+ * exactly the kind of thing that happens on one machine and not another — it
+ * happened on a Windows CI runner while this was being reviewed, and reported
+ * nothing but a null.
+ *
+ * Reported once per distinct cause, so a project failing on both platforms says
+ * it once, while two different causes are both visible.
+ */
+const reportedRegistryFailures = new Set();
+
+/**
+ * Exported as a test seam. The shape of the underlying error depends on how the
+ * host resolves modules — under the package's own mock-engine test config,
+ * `react-native` is aliased to a virtual module and the failure is a one-line
+ * argument error, so a test driving `buildRegistry` there can never produce the
+ * multi-line "Require stack:" this collapses. Calling it directly is the only way
+ * to assert the collapse rather than assume the environment supplies one.
+ */
+export function _warnRegistryUnavailable(rawReason) {
+  warnRegistryUnavailable(rawReason);
+}
+
+function warnRegistryUnavailable(rawReason) {
+  // Node appends a "Require stack:" block to resolution failures; one line is
+  // enough to identify the cause without turning a warning into a wall of text.
+  const reason = String(rawReason).split("\n")[0].trim();
+  if (reportedRegistryFailures.has(reason)) return;
+  reportedRegistryFailures.add(reason);
+  console.warn(
+    `[vitest-native] (native) could not precompile the React Native registry (${reason}); ` +
+      "falling back to per-file module loading, which is slower. Tests still run and " +
+      "results are unaffected. Set VITEST_NATIVE_NO_REGISTRY=1 to opt out silently.",
+  );
+}
+
+/** Test seam: the warning is once-per-cause for the life of the process. */
+export function _resetRegistryFailureReports() {
+  reportedRegistryFailures.clear();
+}
 
 const RN_PATH = /[\\/]node_modules[\\/](react-native|@react-native)[\\/]/;
 // Bump when the emitted registry's shape or the walk's semantics change, so a
@@ -312,6 +361,9 @@ export function buildRegistry({
   assetExts = [],
   diagnostics = false,
 }) {
+  // See warnRegistryUnavailable: this is the one path that stays quiet, because
+  // the user asked for it.
+  //
   // Escape hatch. The registry is transparent by design, but it is also the piece
   // most likely to be implicated if a project sees something unexpected from React
   // Native — so there is a way to take it out of the picture and get the per-file
@@ -330,7 +382,8 @@ export function buildRegistry({
     key = registryKey({ projectRoot, platform, reactNativeVersion });
     dir = path.join(cacheRootFor(projectRoot), "registry");
     fs.mkdirSync(dir, { recursive: true });
-  } catch {
+  } catch (error) {
+    warnRegistryUnavailable(error?.message ?? "cache directory unavailable");
     return null;
   }
 
@@ -410,12 +463,7 @@ export function buildRegistry({
     }
     return registryFile;
   } catch (error) {
-    if (diagnostics) {
-      console.warn(
-        `[vitest-native] (native) could not precompile the RN registry (${error?.message}); ` +
-          `falling back to per-file module loading.`,
-      );
-    }
+    warnRegistryUnavailable(error?.message ?? "unknown error");
     return null;
   }
 }

--- a/packages/vitest-native/tests/registry-fallback-warning.test.ts
+++ b/packages/vitest-native/tests/registry-fallback-warning.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Losing the precompiled registry must not be silent.
+ *
+ * When `buildRegistry` cannot produce a registry it returns null and React Native
+ * loads file by file instead. Nothing fails and no result changes — which is
+ * precisely the problem: the suite just gets slower, with no way to tell a
+ * degraded run from a healthy one. Measured on this package's own native suite
+ * (~42 files), that is roughly 1.4x: ~1.8s becomes ~2.5-2.8s, and the per-file
+ * cost compounds on a real app suite.
+ *
+ * Both failure paths were quiet. The build path spoke only under `diagnostics`,
+ * which defaults to false, and the cache-directory path never spoke at all. This
+ * is not hypothetical: the build failed on a Windows CI runner while this was
+ * being reviewed and reported nothing but a null, which is why that failure took
+ * a re-run rather than a log to diagnose.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  _resetRegistryFailureReports,
+  _warnRegistryUnavailable,
+  buildRegistry,
+} from "../src/native/registry.mjs";
+
+/**
+ * A real directory containing an empty node_modules but no react-native.
+ *
+ * The node_modules matters. Node only appends its multi-line "Require stack:"
+ * block when there is a module tree to report, so a fixture pointing at a path
+ * that does not exist yields a tidy one-line error and never exercises the
+ * collapse — which is how the first version of this file passed while the
+ * collapse was removed.
+ */
+const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vn-registry-"));
+fs.mkdirSync(path.join(projectRoot, "node_modules"), { recursive: true });
+afterAll(() => fs.rmSync(projectRoot, { recursive: true, force: true }));
+
+const UNBUILDABLE = {
+  projectRoot,
+  platform: "ios" as const,
+  reactNativeVersion: "0.86.0",
+  assetExts: ["png"],
+  diagnostics: false,
+};
+
+describe("registry fallback", () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    _resetRegistryFailureReports();
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+    _resetRegistryFailureReports();
+  });
+
+  it("warns when it cannot precompile, with diagnostics off", () => {
+    expect(buildRegistry(UNBUILDABLE)).toBeNull();
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0][0]).toContain("could not precompile");
+  });
+
+  it("says the run still works and only got slower", () => {
+    buildRegistry(UNBUILDABLE);
+    const message = warn.mock.calls[0][0] as string;
+    expect(message).toContain("slower");
+    expect(message).toContain("results are unaffected");
+  });
+
+  it("names a cause rather than reporting a bare failure", () => {
+    buildRegistry(UNBUILDABLE);
+    // The Windows failure surfaced as "registry build returned null" and nothing
+    // else, which is what made it undiagnosable.
+    expect(warn.mock.calls[0][0]).toMatch(/\(.+\)/);
+  });
+
+  it("keeps the warning to one line", () => {
+    // Driven directly with a multi-line cause. Going through buildRegistry here
+    // would assert nothing: under this suite's config `react-native` resolves to
+    // a virtual module, so the failure is always a one-line argument error and
+    // the collapse is never reached. An earlier version of this test did exactly
+    // that and passed with the collapse deleted.
+    _warnRegistryUnavailable(
+      "Cannot find module 'react-native'\nRequire stack:\n- /app/package.json",
+    );
+    const message = warn.mock.calls[0][0] as string;
+    expect(message).not.toContain("\n");
+    expect(message).toContain("Cannot find module 'react-native'");
+    expect(message).not.toContain("Require stack");
+  });
+
+  it("does not repeat itself for the same cause", () => {
+    buildRegistry(UNBUILDABLE);
+    buildRegistry(UNBUILDABLE);
+    buildRegistry({ ...UNBUILDABLE, platform: "android" });
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it("stays silent when the registry was switched off deliberately", () => {
+    vi.stubEnv("VITEST_NATIVE_NO_REGISTRY", "1");
+    try {
+      expect(buildRegistry(UNBUILDABLE)).toBeNull();
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+});


### PR DESCRIPTION
The precompiled registry collapses React Native's ~440 per-file module loads into one compiled file. When it can't be built, the engine falls back to per-file loading — which is **correct**: nothing fails, no result changes. That's exactly what made it hard to notice. A degraded run looks identical to a healthy one, only slower.

## Measured cost

Full native suite (~42 files), warm cache, alternating runs:

```
registry ON   1847ms   1813ms
NO_REGISTRY   2767ms   2460ms
```

Roughly **1.4×**, and the per-file cost compounds on a real app suite. (The knob was verified before measuring: with the registry on, a cleared cache produces 3 files; with `NO_REGISTRY=1`, zero.)

## Neither failure path said anything

- The build path logged only under `diagnostics`, which defaults to `false`.
- The cache-directory path returned `null` with no message under any setting.

Reproduced directly — a project without React Native installed:

```
result: null
^ diagnostics:false — that is everything a user would see
```

**Not hypothetical**: this build failed on a Windows CI runner during review and produced nothing but `registry build returned null`, which is why diagnosing it took a re-run rather than a log. (That re-run passed — it was a flake.)

## Change

Both paths now warn **once per distinct cause**, naming the cause and stating results are unaffected:

```
[vitest-native] (native) could not precompile the React Native registry (Cannot find module
'react-native'); falling back to per-file module loading, which is slower. Tests still run
and results are unaffected. Set VITEST_NATIVE_NO_REGISTRY=1 to opt out silently.
```

`VITEST_NATIVE_NO_REGISTRY=1` stays silent — that path is a request, not a failure. Node's multi-line `Require stack:` block is collapsed to its first line.

## The test for the collapse was wrong twice

Worth recording, because it passed both times.

Driving it through `buildRegistry` asserts **nothing**: under this suite's config `react-native` resolves to a virtual module, so the failure is always a one-line argument error and the collapse is never reached. The first version passed with the collapse deleted; so did the second, after I changed the fixture to add a `node_modules`. Only capturing the message to a file (this suite swallows `console.log`) showed the real cause.

It now drives the warning directly with a multi-line input, via an exported seam.

**Controls**: re-gating the warning behind `diagnostics` fails 5; removing the once-per-cause dedup fails 1; removing the collapse fails 1 — the last of which is the one that previously passed.

## Verification

- 6 tests; mock suite 1464 passed / 3 skipped; native suite 198 passed; lint + typecheck + format:check clean.