### PR TITLE
fix(cli): make doctor's config check reflect whether the plugin is actually used

### DIFF
--- a/.changeset/doctor-config-actually-used.md
+++ b/.changeset/doctor-config-actually-used.md
@@ -1,0 +1,21 @@
+---
+"vitest-native": patch
+---
+
+`doctor` now reports whether the config actually uses the plugin
+
+The config check was a substring test for "vitest-native", so a config whose only
+mention was a `// TODO: migrate to vitest-native` comment reported "uses
+vitest-native" and "No blocking problems found" — on a project where every React
+Native import fails. A config that imports the plugin but never adds it to
+`plugins: [...]`, or where the import has been commented out, read the same way.
+Diagnosing exactly that is the command's purpose.
+
+The check now reads the import, takes the binding name from it so an aliased import
+still counts, and confirms that binding is called. Import forms it does not recognise
+are accepted rather than risking a false alarm on a working project.
+
+`vite.config.*` is also recognised now. Vitest reads it when there is no
+`vitest.config.*`, but it was missing from the list, so a correct setup was told to
+run `vitest-native init` — advice that writes a second config which then takes
+precedence over the working one.

--- a/packages/vitest-native/src/cli/doctor.ts
+++ b/packages/vitest-native/src/cli/doctor.ts
@@ -25,18 +25,93 @@ function packageVersion(root: string, name: string): string | null {
   }
 }
 
+/**
+ * In Vitest's own precedence order: a `vitest.config.*` wins, and `vite.config.*`
+ * is used when there is none.
+ *
+ * The vite.config entries were missing, so a correct setup that configures Vitest
+ * from vite.config.ts — normal in projects that already had Vite — was told "no
+ * vitest.config.* found — run `vitest-native init`". Following that produces a
+ * second config which then TAKES PRECEDENCE over the working one, so the advice
+ * did not just misreport, it would have broken the project.
+ */
+const CONFIG_FILES = [
+  "vitest.config.ts",
+  "vitest.config.mts",
+  "vitest.config.js",
+  "vitest.config.mjs",
+  "vitest.config.cts",
+  "vitest.config.cjs",
+  "vite.config.ts",
+  "vite.config.mts",
+  "vite.config.js",
+  "vite.config.mjs",
+  "vite.config.cts",
+  "vite.config.cjs",
+];
+
 function findConfigFile(root: string): string | null {
-  for (const name of [
-    "vitest.config.ts",
-    "vitest.config.mts",
-    "vitest.config.js",
-    "vitest.config.mjs",
-    "vitest.config.cts",
-    "vitest.config.cjs",
-  ]) {
+  for (const name of CONFIG_FILES) {
     if (fs.existsSync(path.join(root, name))) return name;
   }
   return null;
+}
+
+/** Source with comments removed, so a mention inside one cannot be mistaken for use. */
+function withoutComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+}
+
+export interface ConfigUsage {
+  /** The config imports vitest-native (not merely mentions it). */
+  imports: boolean;
+  /** The imported plugin factory is actually called. */
+  invokes: boolean;
+}
+
+/**
+ * Whether a config genuinely uses the plugin.
+ *
+ * This was a substring test — `content.includes("vitest-native")` — so a config
+ * whose only mention was a `// TODO: migrate to vitest-native` comment reported
+ * "uses vitest-native" and "No blocking problems found", on a project where every
+ * React Native import would fail. Diagnosing that is the entire job of this
+ * command.
+ *
+ * The binding name is read from the import rather than assumed, so an aliased
+ * import still counts as used; when the import shape is not one of the forms
+ * below, the import alone is accepted rather than risking a false alarm on a
+ * working project.
+ */
+export function analyzeConfigUsage(source: string): ConfigUsage {
+  const code = withoutComments(source);
+  const named = /import\s*\{([^}]*)\}\s*from\s*["']vitest-native["']/.exec(code);
+  const namespaced = /import\s*\*\s*as\s*([A-Za-z_$][\w$]*)\s*from\s*["']vitest-native["']/.exec(
+    code,
+  );
+  const required =
+    /(?:const|let|var)\s*\{([^}]*)\}\s*=\s*require\(\s*["']vitest-native["']\s*\)/.exec(code);
+
+  const bindingFrom = (clause: string): string | null => {
+    const entry = /\breactNative\b(?:\s*(?::|as)\s*([A-Za-z_$][\w$]*))?/.exec(clause);
+    return entry ? (entry[1] ?? "reactNative") : null;
+  };
+
+  if (named || required) {
+    const binding = bindingFrom((named ?? required)![1]);
+    // Imported something else from the package (helpers, presets) — not our call
+    // to judge; treat the import as use.
+    if (!binding) return { imports: true, invokes: true };
+    return { imports: true, invokes: new RegExp(`\\b${binding}\\s*\\(`).test(code) };
+  }
+  if (namespaced) {
+    return { imports: true, invokes: new RegExp(`\\b${namespaced[1]}\\.\\w+\\s*\\(`).test(code) };
+  }
+  // Any other import form (side-effect, dynamic) still counts as importing.
+  if (/from\s*["']vitest-native["']|require\(\s*["']vitest-native["']\s*\)/.test(code)) {
+    return { imports: true, invokes: true };
+  }
+  return { imports: false, invokes: false };
 }
 
 export function runDoctor(root: string, nodeVersion: string = process.versions.node): DoctorResult {
@@ -162,10 +237,20 @@ export function runDoctor(root: string, nodeVersion: string = process.versions.n
     warn("no vitest.config.* found — run `vitest-native init` to create one.");
   } else {
     const content = fs.readFileSync(path.join(root, configFile), "utf8");
-    if (content.includes("vitest-native") || content.includes("reactNative(")) {
+    const usage = analyzeConfigUsage(content);
+    if (usage.imports && usage.invokes) {
       pass(`${configFile} uses vitest-native.`);
+    } else if (usage.imports) {
+      warn(
+        `${configFile} imports vitest-native but never calls reactNative() — ` +
+          "the plugin is not in `plugins: [...]`, so React Native imports will not resolve.",
+      );
     } else {
-      warn(`${configFile} exists but does not reference vitest-native.`);
+      warn(
+        `${configFile} exists but does not import vitest-native` +
+          (content.includes("vitest-native") ? " (it is only mentioned in a comment)" : "") +
+          " — add `reactNative()` to `plugins: [...]`, or run `vitest-native init`.",
+      );
     }
   }
 

--- a/packages/vitest-native/tests/doctor-config-detection.test.ts
+++ b/packages/vitest-native/tests/doctor-config-detection.test.ts
@@ -1,0 +1,152 @@
+/**
+ * `doctor` exists to diagnose broken projects, so a false "No blocking problems
+ * found" is its worst possible failure. Two of them, both from the config check
+ * being the substring test `content.includes("vitest-native")`:
+ *
+ *   - A config whose only mention was `// TODO: migrate to vitest-native` reported
+ *     "uses vitest-native", on a project where every React Native import fails.
+ *   - The file list omitted `vite.config.*`, which Vitest reads when there is no
+ *     `vitest.config.*`. A correct setup was told to run `vitest-native init` —
+ *     advice that creates a second config which then TAKES PRECEDENCE over the
+ *     working one, so following it would have broken the project.
+ *
+ * Known limitation, deliberately not covered: a config that references the plugin
+ * but cannot be parsed still reports as used. Establishing that would mean parsing
+ * TypeScript, and esbuild is not resolvable from a project root under the current
+ * Vite. An unparseable config fails loudly on the first `vitest` run, unlike the
+ * two above, which fail silently.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { analyzeConfigUsage, runDoctor } from "../src/cli/doctor.js";
+
+const roots: string[] = [];
+afterAll(() => {
+  for (const r of roots) fs.rmSync(r, { recursive: true, force: true });
+});
+
+/** A throwaway project root containing the given config files. */
+function project(files: Record<string, string>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vn-doctor-"));
+  roots.push(root);
+  fs.writeFileSync(path.join(root, "package.json"), '{ "name": "p", "version": "1.0.0" }');
+  for (const [name, content] of Object.entries(files)) {
+    fs.writeFileSync(path.join(root, name), content);
+  }
+  return root;
+}
+
+/** The Config section of the report. */
+function configLines(root: string): string {
+  const { lines } = runDoctor(root, "22.13.0");
+  return lines.slice(lines.lastIndexOf("Config")).join("\n");
+}
+
+describe("analyzeConfigUsage", () => {
+  it("does not count a mention inside a line comment", () => {
+    expect(analyzeConfigUsage("// TODO: migrate to vitest-native\nexport default {}")).toEqual({
+      imports: false,
+      invokes: false,
+    });
+  });
+
+  it("does not count a mention inside a block comment", () => {
+    expect(analyzeConfigUsage("/* uses vitest-native one day */\nexport default {}")).toEqual({
+      imports: false,
+      invokes: false,
+    });
+  });
+
+  it("does not count an import that has been commented out", () => {
+    // The case comment-stripping actually exists for. A bare mention is already
+    // excluded by requiring an import statement; a commented-OUT import matches
+    // that pattern textually, so without stripping this reports a plugin that is
+    // switched off — which is exactly what someone debugging has just done.
+    const source = `// import { reactNative } from "vitest-native";
+export default { plugins: [] };`;
+    expect(analyzeConfigUsage(source)).toEqual({ imports: false, invokes: false });
+  });
+
+  it("does not count an invocation that has been commented out", () => {
+    const source = `import { reactNative } from "vitest-native";
+export default { plugins: [/* reactNative() */] };`;
+    expect(analyzeConfigUsage(source)).toEqual({ imports: true, invokes: false });
+  });
+
+  it("counts a real import that is invoked", () => {
+    const source = `import { reactNative } from "vitest-native";
+export default { plugins: [reactNative()] };`;
+    expect(analyzeConfigUsage(source)).toEqual({ imports: true, invokes: true });
+  });
+
+  it("counts an aliased import invoked under its alias", () => {
+    const source = `import { reactNative as rn } from "vitest-native";
+export default { plugins: [rn({ engine: "mock" })] };`;
+    expect(analyzeConfigUsage(source)).toEqual({ imports: true, invokes: true });
+  });
+
+  it("reports an import that is never invoked", () => {
+    const source = `import { reactNative } from "vitest-native";
+export default { plugins: [] };`;
+    expect(analyzeConfigUsage(source)).toEqual({ imports: true, invokes: false });
+  });
+
+  it("handles the require form", () => {
+    const source = `const { reactNative } = require("vitest-native");
+module.exports = { plugins: [reactNative()] };`;
+    expect(analyzeConfigUsage(source)).toEqual({ imports: true, invokes: true });
+  });
+
+  it("handles a namespace import", () => {
+    const source = `import * as vn from "vitest-native";
+export default { plugins: [vn.reactNative()] };`;
+    expect(analyzeConfigUsage(source)).toEqual({ imports: true, invokes: true });
+  });
+
+  it("does not flag a config importing something else from the package", () => {
+    // Judging how helpers are used is not this check's job; a false alarm on a
+    // working project is worse than missing an exotic misuse.
+    const source = `import { presets } from "vitest-native";
+export default { plugins: [presets.reanimated()] };`;
+    expect(analyzeConfigUsage(source).imports).toBe(true);
+    expect(analyzeConfigUsage(source).invokes).toBe(true);
+  });
+
+  it("is not fooled by a URL containing a double slash", () => {
+    const source = `// see https://example.com/vitest-native
+import { reactNative } from "vitest-native";
+export default { plugins: [reactNative()] };`;
+    expect(analyzeConfigUsage(source)).toEqual({ imports: true, invokes: true });
+  });
+});
+
+describe("doctor config discovery", () => {
+  const WORKING = `import { reactNative } from "vitest-native";
+export default { plugins: [reactNative()] };`;
+
+  it("recognises a working setup configured from vite.config.ts", () => {
+    const report = configLines(project({ "vite.config.ts": WORKING }));
+    expect(report).toContain("vite.config.ts uses vitest-native");
+    expect(report).not.toContain("run `vitest-native init`");
+  });
+
+  it("prefers vitest.config.* over vite.config.*, as Vitest does", () => {
+    const report = configLines(project({ "vite.config.ts": WORKING, "vitest.config.ts": WORKING }));
+    expect(report).toContain("vitest.config.ts uses vitest-native");
+    expect(report).not.toContain("vite.config.ts uses");
+  });
+
+  it("does not claim a comment-only config uses the plugin", () => {
+    const report = configLines(
+      project({ "vitest.config.ts": "// TODO: migrate to vitest-native\nexport default {}" }),
+    );
+    expect(report).not.toContain("uses vitest-native.");
+    expect(report).toContain("only mentioned in a comment");
+  });
+
+  it("still reports a missing config", () => {
+    expect(configLines(project({}))).toContain("no vitest.config.* found");
+  });
+});


### PR DESCRIPTION
`doctor` exists to diagnose broken projects, so reporting **"✓ No blocking problems found"** on one that cannot run a single test is its worst failure mode. Found by running it against real broken projects rather than reading it.

The config check was `content.includes("vitest-native")`.

## False "OK" on projects that cannot run

**A config mentioning the plugin only in a comment.** The plugin is never imported or used:

```ts
import { defineConfig } from "vitest/config";
// TODO: migrate to vitest-native at some point
export default defineConfig({ test: { globals: true } });
```
```
Config
  ✓ vitest.config.ts uses vitest-native.
✓ No blocking problems found.
```

Every React Native import in that project fails. Same result for a config that imports the plugin but never puts it in `plugins: [...]`, and for one where the import has been commented out while debugging.

## False alarm whose fix breaks the project

The file list omitted `vite.config.*`, which Vitest reads when there's no `vitest.config.*`. A **correct, working** setup:

```
Config
  ⚠ no vitest.config.* found — run `vitest-native init` to create one.
```

Following that writes a second config which then **takes precedence** over the working one. The report wasn't just wrong — it pointed at something that would break the project.

## Fix

The check now reads the import (comments removed first), takes the binding name from it so an alias still counts, and confirms that binding is called:

| Project | Before | After |
| --- | --- | --- |
| comment-only mention | ✓ uses vitest-native | ⚠ does not import it (only mentioned in a comment) |
| imported, never invoked | ✓ uses vitest-native | ⚠ never calls `reactNative()` — not in `plugins: [...]` |
| correct, via `vite.config.ts` | ⚠ run `init` | ✓ uses vitest-native |
| correct, aliased `reactNative as rn` | ✓ | ✓ (no false alarm) |

Unrecognised import forms are accepted rather than risking a false alarm on a working project, and importing something other than the plugin factory is left alone.

## Not addressed

A config that references the plugin but **cannot be parsed** still reports as used. Establishing that means parsing TypeScript, and esbuild doesn't resolve from a project root under the current Vite. That failure is loud on the first `vitest` run, unlike the ones above, which are silent.

## Verification

15 tests. **Controls**: dropping `vite.config.ts` from the list fails 1; assuming any import means invoked fails 1; disabling comment-stripping fails 2.

That last control initially **passed** — the structural import regex already rejects a bare mention, so stripping only matters for a *commented-out* import or invocation. Two tests were added for those cases, which is what makes it load-bearing.

Mock suite 1473 passed / 3 skipped; lint + typecheck + format:check clean.