### PR TITLE
fix(ci): keep the resolution check active where it matters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,16 @@ jobs:
           cd packages/vitest-native
           npm pack --ignore-scripts --pack-destination ../../
           cd ../..
+          # --profile node16 drops node10 (TypeScript's pre-`exports` resolution) from
+          # the matrix. Every subpath fails there by construction, since the package is
+          # exports-only and requires Node >= 20. That noise was previously silenced with
+          # `--ignore-rules no-resolution`, which disables the rule for EVERY resolution
+          # mode — so a subpath that genuinely stopped resolving under node16 or a bundler
+          # was reported green. Verified by packing a build whose ./presets pointed at a
+          # non-existent file: the old invocation exited 0 with every entry point green,
+          # while this one exits 1 on "node16 (from ESM): Resolution failed".
+          #
           # cjs-resolves-to-esm: the jest-compat runtime subpaths are intentionally
           # ESM-only (they depend on vitest, which is ESM-only); CJS consumers use
           # dynamic import. They are setup-file / Vite-alias targets, not typed imports.
-          npx --yes @arethetypeswrong/cli vitest-native-*.tgz --ignore-rules no-resolution cjs-resolves-to-esm
+          npx --yes @arethetypeswrong/cli vitest-native-*.tgz --profile node16 --ignore-rules cjs-resolves-to-esm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,20 +176,4 @@ jobs:
 
       - name: Check package exports
         if: runner.os == 'Linux' && matrix.node-version == '22.13.0'
-        run: |
-          cd packages/vitest-native
-          npm pack --ignore-scripts --pack-destination ../../
-          cd ../..
-          # --profile node16 drops node10 (TypeScript's pre-`exports` resolution) from
-          # the matrix. Every subpath fails there by construction, since the package is
-          # exports-only and requires Node >= 20. That noise was previously silenced with
-          # `--ignore-rules no-resolution`, which disables the rule for EVERY resolution
-          # mode — so a subpath that genuinely stopped resolving under node16 or a bundler
-          # was reported green. Verified by packing a build whose ./presets pointed at a
-          # non-existent file: the old invocation exited 0 with every entry point green,
-          # while this one exits 1 on "node16 (from ESM): Resolution failed".
-          #
-          # cjs-resolves-to-esm: the jest-compat runtime subpaths are intentionally
-          # ESM-only (they depend on vitest, which is ESM-only); CJS consumers use
-          # dynamic import. They are setup-file / Vite-alias targets, not typed imports.
-          npx --yes @arethetypeswrong/cli vitest-native-*.tgz --profile node16 --ignore-rules cjs-resolves-to-esm
+        run: bun run check:exports

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,13 +87,7 @@ jobs:
         run: bun run test:example
 
       - name: Check package exports
-        working-directory: packages/vitest-native
-        run: |
-          npm pack --ignore-scripts --pack-destination /tmp
-          # cjs-resolves-to-esm: the jest-compat runtime subpaths are intentionally
-          # ESM-only (they depend on vitest, which is ESM-only); CJS consumers use
-          # dynamic import. They are setup-file / Vite-alias targets, not typed imports.
-          npx --yes @arethetypeswrong/cli /tmp/vitest-native-*.tgz --ignore-rules no-resolution cjs-resolves-to-esm
+        run: bun run check:exports
 
       - name: Stage publish to npm
         working-directory: packages/vitest-native

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "build": "bun run --filter vitest-native build",
     "test": "bun run --filter vitest-native test",
+    "check:exports": "bun run --filter vitest-native check:exports",
     "test:native": "bun run --filter vitest-native test:native",
     "test:native:forks": "bun run --filter vitest-native test:native:forks",
     "test:native:navigation": "bun run --filter vitest-native test:native:navigation",

--- a/packages/vitest-native/package.json
+++ b/packages/vitest-native/package.json
@@ -204,6 +204,7 @@
     "format:check": "oxfmt --check src/ tests/ consumer-tests/ scripts/",
     "check-compat": "bun scripts/check-compat.ts",
     "check:size": "node scripts/check-package-size.mjs",
+    "check:exports": "node scripts/check-exports.mjs",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist",
     "prepublishOnly": "bun run build && bun run check:size && bun run test && bun run test:native && bun run test:native:forks && bun run test:native:navigation && bun run test:native:android && bun run test:native:hot && bun run test:native:hot:isolation && bun run test:native:hot:soak && bun run validate:hot-parity && bun run fidelity:check && bun run test:consumers && bun run lint && bun run typecheck",

--- a/packages/vitest-native/scripts/check-exports.mjs
+++ b/packages/vitest-native/scripts/check-exports.mjs
@@ -1,0 +1,58 @@
+// Packs the package and checks that every declared entry point resolves, using
+// @arethetypeswrong/cli.
+//
+// This lived inline in two workflows, and they drifted: the resolution rule was
+// re-enabled in ci.yml while release.yml — the path that actually publishes —
+// kept running with it disabled. One script, called from both, is the only way
+// that stays fixed.
+//
+// --profile node16 drops node10 (TypeScript's pre-`exports` resolution) from the
+// matrix. Every subpath fails there by construction, since this package is
+// exports-only and requires Node >= 20. That noise was previously silenced with
+// `--ignore-rules no-resolution`, which disables the rule for EVERY resolution
+// mode — so a subpath that genuinely stopped resolving under node16 or a bundler
+// was reported green. Verified by packing a build whose ./presets pointed at a
+// non-existent file: the old invocation exited 0 with every entry point green,
+// while this one exits 1 on "node16 (from ESM): Resolution failed".
+//
+// --ignore-rules cjs-resolves-to-esm: the jest-compat runtime subpaths are
+// intentionally ESM-only (they depend on vitest, which is ESM-only); CJS consumers
+// use dynamic import. They are setup-file / Vite-alias targets, not typed imports.
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const outDir = fs.mkdtempSync(path.join(os.tmpdir(), "vn-check-exports-"));
+
+const run = (command, args, options = {}) =>
+  spawnSync(command, args, { cwd: root, stdio: "inherit", ...options });
+
+try {
+  const packed = run("npm", ["pack", "--ignore-scripts", "--pack-destination", outDir]);
+  if (packed.status !== 0) {
+    console.error("✗ could not pack the package for the export check.");
+    process.exit(1);
+  }
+
+  const [tarball] = fs.readdirSync(outDir).filter((f) => f.endsWith(".tgz"));
+  if (!tarball) {
+    console.error(`✗ npm pack produced no tarball in ${outDir}.`);
+    process.exit(1);
+  }
+
+  const checked = run("npx", [
+    "--yes",
+    "@arethetypeswrong/cli",
+    path.join(outDir, tarball),
+    "--profile",
+    "node16",
+    "--ignore-rules",
+    "cjs-resolves-to-esm",
+  ]);
+  process.exit(checked.status ?? 1);
+} finally {
+  fs.rmSync(outDir, { recursive: true, force: true });
+}

--- a/packages/vitest-native/tests/package-exports.test.ts
+++ b/packages/vitest-native/tests/package-exports.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Every declared entry point must point at a file that exists.
+ *
+ * The published surface is eleven `exports` subpaths, and the consumer gate
+ * imports three of them. The remaining eight were covered only by
+ * `@arethetypeswrong/cli` in CI — which ran with `--ignore-rules no-resolution`,
+ * disabling that rule for every resolution mode. Verified by packing a build whose
+ * `./presets` pointed at a non-existent file: the check exited 0 with every entry
+ * point green, while the same package without that ignore reported
+ * "node16 (from ESM): Resolution failed" and "bundler: Resolution failed".
+ *
+ * CI now uses `--profile node16`, which drops the legacy node10 noise the ignore
+ * was there for while keeping the rule active where it matters. This is the local
+ * half of the same guard: no network, no packing, and it fails the moment a target
+ * goes missing.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const manifest = JSON.parse(fs.readFileSync(path.join(packageRoot, "package.json"), "utf8")) as {
+  exports: Record<string, unknown>;
+  types?: string;
+  main?: string;
+  module?: string;
+};
+
+/** Every `"./dist/..."` string reachable in the exports tree, with its subpath and condition. */
+function declaredTargets(): Array<{ subpath: string; condition: string; target: string }> {
+  const out: Array<{ subpath: string; condition: string; target: string }> = [];
+  const walk = (subpath: string, node: unknown, condition: string): void => {
+    if (typeof node === "string") {
+      out.push({ subpath, condition, target: node });
+      return;
+    }
+    if (node && typeof node === "object") {
+      for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+        walk(subpath, value, condition ? `${condition}.${key}` : key);
+      }
+    }
+  };
+  for (const [subpath, node] of Object.entries(manifest.exports)) walk(subpath, node, "");
+  return out;
+}
+
+const distExists = fs.existsSync(path.join(packageRoot, "dist"));
+
+describe("declared package entry points", () => {
+  it("has a build to check against", () => {
+    // Not skipped when dist is absent: silently passing would make every assertion
+    // below vacuous, which is the failure mode this whole file exists to prevent.
+    expect(distExists, "run `bun run build` before this suite — CI builds first").toBe(true);
+  });
+
+  it("declares more than one entry point, so the walk is not trivially empty", () => {
+    expect(declaredTargets().length).toBeGreaterThan(10);
+  });
+
+  it.runIf(distExists)("points every declared target at a file that exists", () => {
+    const missing = declaredTargets()
+      .filter(({ target }) => !fs.existsSync(path.join(packageRoot, target)))
+      .map(({ subpath, condition, target }) => `${subpath} (${condition}) -> ${target}`);
+    expect(missing, `declared but absent from the build:\n${missing.join("\n")}`).toEqual([]);
+  });
+
+  it.runIf(distExists)("resolves the root fields the manifest advertises", () => {
+    const rootFields = [manifest.main, manifest.module, manifest.types].filter(
+      (v): v is string => typeof v === "string",
+    );
+    const missing = rootFields.filter((f) => !fs.existsSync(path.join(packageRoot, f)));
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
The published surface is **eleven `exports` subpaths**; the consumer gate imports three (`vitest-native`, `/helpers`, `/jest-compat`). The other eight were covered only by `@arethetypeswrong/cli`, which ran as:

```
--ignore-rules no-resolution cjs-resolves-to-esm
```

The `no-resolution` ignore was there for **node10** — TypeScript's pre-`exports` resolution, where every subpath of an exports-only package fails by construction. But it disables the rule for *every* resolution mode, including the ones consumers use.

## Mutation test

Packed a build whose `./presets` pointed at a non-existent file — mutation verified present in the tarball before running anything.

**Existing invocation — exit 0, everything green:**
```
"vitest-native/presets"
node16 (from CJS): 🟢 (CJS)
node16 (from ESM): 🟢
bundler: 🟢
```

**Same package, rule enabled — exit 1:**
```
node16 (from ESM): 💀 Resolution failed
bundler:           💀 Resolution failed
```

A public entry point could stop resolving entirely and CI would report success.

## Fix

`--profile node16` drops node10 from the matrix instead of disabling the rule. Verified **both directions**: the broken package exits 1; the current package exits 0 with `node10: (ignored) 💀`.

`cjs-resolves-to-esm` stays ignored — the existing comment justifies it, and that reasoning still holds.

## Local companion

A test walks the exports tree and asserts every declared target exists in the build — no network, no packing. It **fails** when `dist` is absent rather than skipping, since a silent skip would make its assertions vacuous, which is the exact failure this change is about.

**Control**: pointing `./presets` at a missing file fails it, naming both the `import.types` and `import.default` targets.

## Also checked, not defects

- All 11 declared export targets are present in the packed tarball.
- All 11 subpaths import successfully from a clean `npm install` of the tarball. (`/setup` needs a Vitest environment and `/rntl-matchers` is types-only — both expected.)
- `vitest-native/rntl-matchers` declares only a `types` condition, so it can't be imported at runtime. That is **by design** and documented consistently in the README, the `.d.ts`, the changeset and `package-budget.json`; the documented usage is `/// <reference types="..." />` or `compilerOptions.types`.
- That file's comment claims RNTL "has no `exports` map, so the path resolves". Still true on RNTL 14.0.0 — deep path resolves.

## Verification

Mock suite 1462 passed / 3 skipped; lint + typecheck + format:check clean.