### PR TITLE
fix(build): give the package budget floors, and check the export map exactly

### DIFF
--- a/packages/vitest-native/package-budget.json
+++ b/packages/vitest-native/package-budget.json
@@ -1,9 +1,13 @@
 {
+  "minPackedBytes": 200000,
   "maxPackedBytes": 234000,
+  "minUnpackedBytes": 700000,
   "maxUnpackedBytes": 830000,
+  "minFiles": 70,
   "maxFiles": 85,
   "maxRuntimeDependencies": 2,
-  "maxExportPaths": 11,
-  "_maxExportPaths": "11 since ./rntl-matchers: a types-only entry that augments Vitest's Assertion with React Native Testing Library's matchers. It is separate rather than folded into the main types because RNTL is an optional peer, and an unresolvable type import inside a shipped .d.ts reports TS2307 for consumers using skipLibCheck: false without it.",
-  "_maxPackedBytes": "234000 since the Animated surface parity work: nine members React Native has and the mock lacked (Node, Event, Interpolation, attachNativeEvent, track, stopTracking, animate, hasListeners, toJSON), plus the unhoisted-jest.mock and duplicate-React detections. Headroom is deliberately thin \u2014 a few KB \u2014 so the next unintended growth still trips this."
+  "exportPaths": 11,
+  "_floors": "Floors exist because every limit here used to be a ceiling, so the check passed on an unbuilt tree (files: 8) and on a build missing the verbatim-copied native runtime (files: 60) — neither of which can run a test. They sit roughly 10% under the current artifact: far enough not to churn on ordinary changes, close enough that losing a build entry (four files: .mjs/.cjs/.d.mts/.d.cts) or the native runtime trips them.",
+  "_maxPackedBytes": "234000 since the Animated surface parity work: nine members React Native has and the mock lacked (Node, Event, Interpolation, attachNativeEvent, track, stopTracking, animate, hasListeners, toJSON), plus the unhoisted-jest.mock and duplicate-React detections. Headroom is deliberately thin — a few KB — so the next unintended growth still trips this.",
+  "_exportPaths": "Exact, not a ceiling. 11 since ./rntl-matchers: a types-only entry that augments Vitest's Assertion with React Native Testing Library's matchers. It is separate rather than folded into the main types because RNTL is an optional peer, and an unresolvable type import inside a shipped .d.ts reports TS2307 for consumers using skipLibCheck: false without it. Removing an entry is a breaking change for consumers and adding one is a support commitment, so both require editing this number."
 }

--- a/packages/vitest-native/package-budget.json
+++ b/packages/vitest-native/package-budget.json
@@ -1,13 +1,14 @@
 {
   "minPackedBytes": 200000,
-  "maxPackedBytes": 234000,
+  "maxPackedBytes": 236500,
   "minUnpackedBytes": 700000,
-  "maxUnpackedBytes": 830000,
+  "maxUnpackedBytes": 840000,
   "minFiles": 70,
   "maxFiles": 85,
   "maxRuntimeDependencies": 2,
   "exportPaths": 11,
   "_floors": "Floors exist because every limit here used to be a ceiling, so the check passed on an unbuilt tree (files: 8) and on a build missing the verbatim-copied native runtime (files: 60) — neither of which can run a test. They sit roughly 10% under the current artifact: far enough not to churn on ordinary changes, close enough that losing a build entry (four files: .mjs/.cjs/.d.mts/.d.cts) or the native runtime trips them.",
-  "_maxPackedBytes": "234000 since the Animated surface parity work: nine members React Native has and the mock lacked (Node, Event, Interpolation, attachNativeEvent, track, stopTracking, animate, hasListeners, toJSON), plus the unhoisted-jest.mock and duplicate-React detections. Headroom is deliberately thin — a few KB — so the next unintended growth still trips this.",
-  "_exportPaths": "Exact, not a ceiling. 11 since ./rntl-matchers: a types-only entry that augments Vitest's Assertion with React Native Testing Library's matchers. It is separate rather than folded into the main types because RNTL is an optional peer, and an unresolvable type import inside a shipped .d.ts reports TS2307 for consumers using skipLibCheck: false without it. Removing an entry is a breaking change for consumers and adding one is a support commitment, so both require editing this number."
+  "_maxPackedBytes": "236500 after the registry-fallback warning (#104) and the doctor config check (#106) landed together. Each passed against the previous 234000 on its own; combined they came to 234432, and main went red on the ceiling #96 had deliberately left thin. Raised once for both, keeping the same small headroom rather than buying room for changes not yet written.",
+  "_exportPaths": "Exact, not a ceiling. 11 since ./rntl-matchers: a types-only entry that augments Vitest's Assertion with React Native Testing Library's matchers. It is separate rather than folded into the main types because RNTL is an optional peer, and an unresolvable type import inside a shipped .d.ts reports TS2307 for consumers using skipLibCheck: false without it. Removing an entry is a breaking change for consumers and adding one is a support commitment, so both require editing this number.",
+  "_maxUnpackedBytes": "840000 for the same two changes: unpacked reached 828154 against a 830000 ceiling, close enough that the next edit of any size would have tripped it."
 }

--- a/packages/vitest-native/scripts/check-package-size.mjs
+++ b/packages/vitest-native/scripts/check-package-size.mjs
@@ -45,25 +45,70 @@ const actual = {
   runtimeDependencies: Object.keys(packageJson.dependencies ?? {}).length,
   exportPaths: Object.keys(packageJson.exports ?? {}).length,
 };
-const limits = {
-  packedBytes: budget.maxPackedBytes,
-  unpackedBytes: budget.maxUnpackedBytes,
-  files: budget.maxFiles,
-  runtimeDependencies: budget.maxRuntimeDependencies,
-  exportPaths: budget.maxExportPaths,
-};
+/**
+ * Ceilings AND floors.
+ *
+ * Every limit here used to be an upper bound, so the check only ever noticed the
+ * package growing. Measured against an unbuilt tree it reported "OK files: 8 / 85"
+ * and exited 0 — a budget that passes while measuring nothing. A build that lost
+ * the verbatim-copied native runtime reported "OK files: 60 / 85" just as happily,
+ * though nothing using the native engine can start without it.
+ *
+ * `exportPaths` is checked exactly rather than bounded. Deleting a public entry
+ * point is a breaking change for consumers, and it read as "OK exportPaths: 9 / 11"
+ * — a shrinking published surface, reported by the check whose job is to track the
+ * published surface. Adding one is a support commitment. Both should be a
+ * deliberate edit to this file, not a silent pass.
+ *
+ * `runtimeDependencies` keeps a ceiling only: shipping fewer dependencies is never
+ * the regression.
+ */
+const checks = [
+  { key: "packedBytes", min: budget.minPackedBytes, max: budget.maxPackedBytes },
+  { key: "unpackedBytes", min: budget.minUnpackedBytes, max: budget.maxUnpackedBytes },
+  { key: "files", min: budget.minFiles, max: budget.maxFiles },
+  { key: "runtimeDependencies", max: budget.maxRuntimeDependencies },
+  { key: "exportPaths", min: budget.exportPaths, max: budget.exportPaths },
+];
 
 let failed = false;
+const under = [];
 console.log("Published package budget:");
-for (const key of Object.keys(limits)) {
-  const over = actual[key] > limits[key];
-  failed ||= over;
-  console.log(`  ${over ? "FAIL" : "OK  "} ${key}: ${actual[key]} / ${limits[key]}`);
+for (const { key, min, max } of checks) {
+  const value = actual[key];
+  const tooBig = typeof max === "number" && value > max;
+  const tooSmall = typeof min === "number" && value < min;
+  failed ||= tooBig || tooSmall;
+  if (tooSmall) under.push(key);
+  const range = typeof min === "number" ? `${min}..${max}` : `<= ${max}`;
+  console.log(`  ${tooBig || tooSmall ? "FAIL" : "OK  "} ${key}: ${value} / ${range}`);
 }
 
 if (failed) {
-  console.error(
-    "Package budget exceeded. Reduce the published surface or update the budget with an explicit justification.",
-  );
+  // A shrink in the artifact and a shrink in the export map are different
+  // problems: the first is nearly always an incomplete build, the second is a
+  // breaking change. Reporting a build hint for a deleted entry point would send
+  // the reader to look at dist/ for something that is not there.
+  const messages = [];
+  if (under.some((key) => key !== "exportPaths")) {
+    messages.push(
+      "The published artifact is SMALLER than expected. That is usually a build that did not run\n" +
+        "or did not finish — check dist/ before touching the floor. If the reduction is real,\n" +
+        "lower the floor in package-budget.json with a justification.",
+    );
+  }
+  if (under.includes("exportPaths")) {
+    messages.push(
+      "Fewer export paths than declared: a public entry point was removed, which is a BREAKING\n" +
+        "change for consumers. If that is intended, update `exportPaths` in package-budget.json\n" +
+        "and make sure the removal is in a changeset as a major.",
+    );
+  }
+  if (messages.length === 0) {
+    messages.push(
+      "Package budget exceeded. Reduce the published surface or update the budget with an explicit justification.",
+    );
+  }
+  console.error(messages.join("\n\n"));
   process.exit(1);
 }


### PR DESCRIPTION
Every limit in `package-budget.json` was an upper bound, so the check only ever noticed the package **growing**.

## A budget that passes while measuring nothing

Run against an unbuilt tree:

```
OK   packedBytes: 43594 / 230000
OK   files: 8 / 85
exit 0
```

A build that produced everything *except* the verbatim-copied native runtime (`dist/native/*.mjs`, which are not `exports` targets) passed just as happily:

```
OK   files: 60 / 85
```

Neither artifact can run a single test — the second fails with `Cannot find module dist/native/setup.mjs`.

## A breaking change reported as within budget

`maxExportPaths` caught *adding* an entry point but not removing one. Deleting two public exports:

```
OK   exportPaths: 9 / 11
```

Removing a public export is a **breaking change** for consumers, reported as comfortably within budget by the check whose stated job is tracking the published surface.

## Change

| metric | before | now |
| --- | --- | --- |
| packedBytes | `<= 230000` | `200000..230000` |
| unpackedBytes | `<= 830000` | `700000..830000` |
| files | `<= 85` | `70..85` |
| exportPaths | `<= 11` | **exactly 11** |
| runtimeDependencies | `<= 2` | unchanged — shipping fewer deps is never the regression |

Floors sit ~10% under the current artifact: far enough not to churn on ordinary changes, close enough that losing one build entry (four files: `.mjs`/`.cjs`/`.d.mts`/`.d.cts`) or the native runtime trips them.

An artifact shrink and an export-map shrink report **differently** — the first is nearly always an incomplete build, the second is a breaking change, and a build hint would send the reader looking in `dist/` for something that was never missing.

## Verification

Each case re-run against the fix:

| case | before | after |
| --- | --- | --- |
| unbuilt tree | OK, exit 0 | FAIL on packed/unpacked/files |
| native runtime missing | OK `60 / 85` | FAIL `60 / 70..85` |
| two exports removed | OK `9 / 11` | FAIL `9 / 11..11`, breaking-change message |
| healthy build | OK | OK — no false positive |

Mock suite 1458 passed / 3 skipped; lint + typecheck + format:check clean.

## Scope

No workflow can reach the unbuilt case today — CI and `prepublishOnly` both build first, and the native suite independently catches a missing runtime. This is the check standing on its own claiming a comfortable pass on nothing; the export-path asymmetry is reachable regardless of build order.