### PR TITLE
ci: require a changeset when shipped source changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,26 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  changeset:
+    name: Changeset for shipped changes
+    # Pull requests only: the check compares against the base branch, and a push to
+    # main has already been through this on its way in.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Its own job with full history rather than fetch-depth: 0 on the matrix, which
+      # would make every leg clone the whole repository to serve one diff.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Require a changeset when shipped source changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node packages/vitest-native/scripts/check-changeset.mjs "$BASE_SHA" "$HEAD_SHA"
+
   check:
     name: Full gate (${{ matrix.os }}, Node ${{ matrix.node-version }})
     runs-on: ${{ matrix.os }}

--- a/packages/vitest-native/scripts/check-changeset.mjs
+++ b/packages/vitest-native/scripts/check-changeset.mjs
@@ -1,0 +1,62 @@
+// Fails a pull request that changes shipped source without recording a changeset.
+//
+// Releases are cut from the changeset queue, so a change to src/ with no entry
+// ships to users with no changelog line and contributes nothing to the version
+// bump. Nothing checked this: of thirteen pull requests opened in a single
+// session, the two that touched src/ — a new warning users would see, and a
+// change to what `doctor` reports — both had no changeset, and every gate was
+// green.
+//
+// Comment-only edits and internal refactors genuinely need no release note. They
+// need an explicit `bunx changeset --empty`, which records the decision rather
+// than leaving it to be inferred from an absence.
+import { spawnSync } from "node:child_process";
+
+const SHIPPED = "packages/vitest-native/src/";
+
+/**
+ * @param {string[]} changedFiles paths relative to the repository root
+ * @returns {{ shipped: string[], hasChangeset: boolean, ok: boolean }}
+ */
+export function assessChangeset(changedFiles) {
+  const shipped = changedFiles.filter((f) => f.startsWith(SHIPPED));
+  const hasChangeset = changedFiles.some(
+    (f) => f.startsWith(".changeset/") && f.endsWith(".md") && !f.endsWith("/README.md"),
+  );
+  return { shipped, hasChangeset, ok: shipped.length === 0 || hasChangeset };
+}
+
+function changedFilesBetween(base, head) {
+  const res = spawnSync("git", ["diff", "--name-only", `${base}...${head}`], { encoding: "utf8" });
+  if (res.status !== 0) {
+    console.error(`✗ could not diff ${base}...${head}:\n${res.stderr}`);
+    process.exit(1);
+  }
+  return res.stdout.split("\n").filter(Boolean);
+}
+
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].split("/").pop() ?? "")) {
+  const [base, head = "HEAD"] = process.argv.slice(2);
+  if (!base) {
+    console.error("usage: node scripts/check-changeset.mjs <base-ref> [head-ref]");
+    process.exit(1);
+  }
+  const { shipped, ok } = assessChangeset(changedFilesBetween(base, head));
+  if (ok) {
+    console.log(
+      shipped.length === 0
+        ? "✓ no shipped source changed — no changeset needed"
+        : `✓ ${shipped.length} shipped file(s) changed, and a changeset is present`,
+    );
+  } else {
+    console.error(
+      `✗ ${shipped.length} file(s) under ${SHIPPED} changed with no changeset:\n` +
+        shipped.map((f) => `    ${f}`).join("\n") +
+        "\n\n  Releases are cut from the changeset queue, so this would ship to users with no\n" +
+        "  changelog entry and no version bump.\n\n" +
+        "      bunx changeset            # user-visible change\n" +
+        "      bunx changeset --empty    # refactor or comments only — records the decision",
+    );
+    process.exit(1);
+  }
+}

--- a/packages/vitest-native/tests/check-changeset.test.ts
+++ b/packages/vitest-native/tests/check-changeset.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Releases are cut from the changeset queue, so a change to shipped source with no
+ * entry reaches users with no changelog line and contributes nothing to the version
+ * bump. Nothing checked for it.
+ *
+ * The gap was measured rather than supposed: of thirteen pull requests opened in a
+ * single session, exactly two touched `packages/vitest-native/src/` — a new warning
+ * users would see when the precompiled registry cannot be built, and a change to
+ * what `doctor` reports about a project's config. Neither had a changeset, and every
+ * gate on both was green.
+ *
+ * Comment-only edits and internal refactors genuinely need no release note. They
+ * need `bunx changeset --empty`, which records that decision instead of leaving it
+ * to be inferred from an absence.
+ */
+import { describe, expect, it } from "vitest";
+import { assessChangeset } from "../scripts/check-changeset.mjs";
+
+const SRC = "packages/vitest-native/src/cli/doctor.ts";
+
+describe("assessChangeset", () => {
+  it("requires one when shipped source changes", () => {
+    const result = assessChangeset([SRC, "packages/vitest-native/tests/doctor.test.ts"]);
+    expect(result.ok).toBe(false);
+    expect(result.shipped).toEqual([SRC]);
+  });
+
+  it("is satisfied by a changeset alongside the change", () => {
+    expect(assessChangeset([SRC, ".changeset/some-fix.md"]).ok).toBe(true);
+  });
+
+  it("does not require one when no shipped source changed", () => {
+    const result = assessChangeset([
+      ".github/workflows/ci.yml",
+      "packages/vitest-native/scripts/check-package-size.mjs",
+      "packages/vitest-native/tests/a.test.ts",
+      "website/guide/plugin-options.md",
+    ]);
+    expect(result.ok).toBe(true);
+    expect(result.shipped).toEqual([]);
+  });
+
+  it("does not accept the changeset README as a changeset", () => {
+    // It is the only .md that lives there permanently, so counting it would make
+    // every check pass forever.
+    expect(assessChangeset([SRC, ".changeset/README.md"]).ok).toBe(false);
+  });
+
+  it("does not accept the changeset config as a changeset", () => {
+    expect(assessChangeset([SRC, ".changeset/config.json"]).ok).toBe(false);
+  });
+
+  it("reports every shipped file, not just the first", () => {
+    const files = [SRC, "packages/vitest-native/src/native/registry.mjs"];
+    expect(assessChangeset(files).shipped).toEqual(files);
+  });
+
+  it("does not mistake a similarly-named path for shipped source", () => {
+    // `scripts/` and `tests/` sit beside `src/` under the same package.
+    const result = assessChangeset([
+      "packages/vitest-native/src-notes/todo.md",
+      "packages/vitest-native/scripts/src/helper.mjs",
+    ]);
+    expect(result.shipped).toEqual([]);
+  });
+});


### PR DESCRIPTION
Releases are cut from the changeset queue, so a change under `packages/vitest-native/src/` with no entry reaches users with **no changelog line and no contribution to the version bump**. Nothing checked for it.

## Measured, not supposed

Of the thirteen PRs opened in one session, exactly **two** touched shipped source:

| PR | shipped file | changeset |
| --- | --- | --- |
| #104 | `src/native/registry.mjs` — a new warning users will see | **none** |
| #106 | `src/cli/doctor.ts` — changes what `doctor` reports | **none** |

Every gate on both was green. The other eleven touch no shipped source and correctly need nothing.

Run against those branches as they actually stood:

```
✗ 1 file(s) under packages/vitest-native/src/ changed with no changeset:
    packages/vitest-native/src/cli/doctor.ts
```

and after the changeset was added, `✓ 1 shipped file(s) changed, and a changeset is present`. Exit codes verified: 1, 0, and 0 for a PR touching no shipped source.

*(Changesets have since been added to #104 and #106 directly.)*

## Escape hatch

Comment-only edits and internal refactors genuinely need no release note. They need `bunx changeset --empty`, which records the decision rather than leaving it inferred from an absence. The failure message says exactly that.

## Shape

Its own small job on pull requests — comparing against the base needs full history, and `fetch-depth: 0` on the matrix would make every leg clone the whole repository to serve one diff.

The decision is a pure function over the changed-file list, so it's unit-tested (7 tests), including that neither `.changeset/README.md` nor `config.json` counts — both live there permanently and would otherwise satisfy the check forever.

## A note on policy

This is **blocking**, which is a judgement call rather than a technical necessity. If you'd rather it warned without failing, that's a one-line change (drop the non-zero exit). I made it blocking because a warning is what the current situation already amounts to — nothing was stopping the two PRs above.

## Verification

Mock suite 1465 passed / 3 skipped; lint + typecheck + format:check clean.