### PR TITLE
docs(changeset): describe what the error classes actually give a consumer

### DIFF
--- a/.changeset/error-classes.md
+++ b/.changeset/error-classes.md
@@ -5,11 +5,18 @@
 Thrown errors now carry a class and a stable code
 
 Errors raised by the plugin were plain `Error` instances whose only identity was their
-message text, so a consumer catching one had nothing to match on but a string that is
-free to change. They are now `VitestNativeError` (or `VitestNativeTypeError`, where a
-`TypeError` is the right shape) with a `code` from a documented set, exported for
-typed use alongside an `isVitestNativeError` guard.
+message text. They are now `VitestNativeError`, or `VitestNativeTypeError` where a
+`TypeError` is the right shape, each carrying a `code` from a fixed set.
 
-Vitest serialises errors across the worker boundary by name, message and stack, so the
-guard checks the name and code rather than using `instanceof`, which does not survive
-that crossing.
+What this changes for a consumer is the `name` on the error: it reads
+`VitestNativeError` rather than `Error`, and that survives Vitest's serialisation of
+errors out of a worker, which keeps `name`, `message` and `stack`. The `code` is
+readable on errors thrown in the Vite main process — configuration and resolution
+failures — but is an own property, so it does not survive that same serialisation for
+errors raised inside a worker.
+
+The classes and an `isVitestNativeError` guard are not importable from the package:
+there is no `vitest-native/errors` entry point, and the main entry does not re-export
+them. Adding one is a separate decision, since it is a twelfth public export path to
+support, and it would also let the bundled entries self-reference `errors.mjs` instead
+of carrying a second copy of it.


### PR DESCRIPTION
The changeset for the error classes (added in #110, unreleased) describes an API that consumers cannot reach.

## What it claimed

> …with a `code` from a documented set, **exported for typed use alongside an `isVitestNativeError` guard**.

## What is actually on main

```
src/errors.mjs exports:  VitestNativeError, VitestNativeTypeError, isVitestNativeError
src/index.ts:            no reference
export paths:            ., ./helpers, ./setup, ./serializer, ./presets, ./matchers,
                         ./jest-compat, ./jest-compat/{setup,jest-globals,extend-expect-noop},
                         ./rntl-matchers        ← no ./errors
```

Nothing in that sentence is reachable from an installed package.

The entry also implied `code` is generally available. `errors.mjs` says otherwise in its own header comment: Vitest serialises errors out of a worker by `name`, `message` and `stack` — **`code` and every other own property is dropped**. So `code` is readable for errors thrown in the Vite main process (configuration and resolution failures) and not for anything raised in-worker.

## What consumers actually get

The error `name` reads `VitestNativeError` instead of `Error`, and that *does* survive serialisation. The classes are genuinely applied — `errors.mjs` is imported by nine source files — so the internal consistency is real. It's the public surface the entry described that isn't there.

The rewritten entry says that, and records the export as an open decision rather than a shipped feature.

## The decision I did not make

Adding a `vitest-native/errors` entry point would make the guard importable **and** let the bundled entries self-reference `errors.mjs` instead of shipping a second copy of it (~2KB, currently duplicated — `package-budget.json` already documents this as the intended follow-up). It costs a twelfth public export path, which `check:size` now enforces exactly, and a support commitment.

That's an API call, so it's yours. This PR only makes the changelog honest about the current state; nothing about the code changes.

## Scope

Changeset text only — no source, no tests, no gates touched.