### PR TITLE
feat(native): report a package that resolves to two different files

### DIFF
--- a/.changeset/resolver-agreement-warning.md
+++ b/.changeset/resolver-agreement-warning.md
@@ -1,0 +1,24 @@
+---
+"vitest-native": patch
+---
+
+Report when a package resolves to two different files across the two module systems
+
+The native engine runs two resolvers: Vite resolves the test graph, and Node's CJS
+resolver serves everything externalized. The plugin points Vite at React Native's
+fields — `react-native`, `module`, `jsnext:main`, `jsnext` — and `main`, which is all
+Node's resolver consults, is not among them.
+
+Any package publishing a `react-native` field, which is ordinary across the ecosystem,
+or a `module` field, which is ordinary for anything dual-format, therefore resolves to
+a different file on each side. When both graphs load it the package exists twice, with
+separate module-level state, and nothing says so: a store written through one copy
+reads back unset through the other, so values arrive empty and the failure surfaces far
+from its cause.
+
+The Node-side resolver now compares each package it resolves against the file Vite's
+field order would choose, and reports the pair once per package when they differ,
+naming the field responsible and what diverging state means. It does not fire on a
+suite where the two agree.
+
+This is a diagnostic, not a fix: making the two resolvers agree is a separate change.

--- a/packages/vitest-native/src/native/hooks.mjs
+++ b/packages/vitest-native/src/native/hooks.mjs
@@ -20,6 +20,78 @@ const NODE_MODULES = /[\\/]node_modules[\\/]/;
 // can be evaluated twice in one worker (once by the worker entry through Node's
 // loader, once through Vitest's module runner when the setup file is inlined),
 // and the hooks must still install exactly once per worker.
+/**
+ * Packages Vite executes itself (see ecosystem.ts). If Node also resolves one of
+ * these, the module exists TWICE in the process — once in Vite's graph, once in
+ * Node's — and module-level state does not cross between them.
+ *
+ * This is silent by construction: nothing fails, nothing is logged, the second
+ * copy simply starts empty. A store configured through one copy reads back
+ * unset through the other, so a translated label renders as "" and the test
+ * compares empty output against expected output with nothing pointing at the
+ * cause. Reported once per package, with both files, because the two paths are
+ * what makes it recognisable.
+ */
+// The fields Vite is configured with for React Native (see plugin.ts), in order.
+// Node's CJS resolver uses `main`, which is not in this list at all.
+const VITE_MAIN_FIELDS = ["react-native", "module", "jsnext:main", "jsnext"];
+
+const reportedDuplicates = new Set();
+
+/** Test seam: the warning is once per package for the life of the worker. */
+export function _resetDuplicateReports() {
+  reportedDuplicates.clear();
+}
+function reportDuplicateInstance(pkg, nodeFile, viteFile, field) {
+  reportedDuplicates.add(pkg);
+  console.warn(
+    `[vitest-native] '${pkg}' resolves to two different files.\n` +
+      `  Node (require) ->  ${nodeFile}\n` +
+      `  Vite ("${field}") ->  ${viteFile}\n` +
+      "  If both module systems load it, the package exists twice and module-level state —\n" +
+      "  stores, React contexts, event emitters, registries — is not shared between the copies.\n" +
+      "  Nothing throws: writes through one are simply invisible to the other, so values read\n" +
+      "  back unset. Set `resolve.mainFields` so both resolvers agree, or import the package\n" +
+      "  from one side only.",
+  );
+}
+
+/**
+ * Compare what Node just resolved against what Vite's field order would pick for
+ * the same package. A difference means the two module systems have different
+ * files for one package id, so anything importing it from both sides gets two
+ * copies with separate state.
+ */
+export function checkResolverAgreement(request, resolved) {
+  const pkg = packageOf(request);
+  if (!pkg || typeof resolved !== "string") return;
+  if (reportedDuplicates.has(pkg)) return;
+  const marker = `${path.sep}node_modules${path.sep}`;
+  const at = resolved.lastIndexOf(marker + pkg.split("/").join(path.sep) + path.sep);
+  if (at === -1) return;
+  const dir = resolved.slice(0, at + marker.length + pkg.length);
+  let manifest;
+  try {
+    manifest = JSON.parse(fs.readFileSync(path.join(dir, "package.json"), "utf8"));
+  } catch {
+    return;
+  }
+  const field = VITE_MAIN_FIELDS.find((f) => typeof manifest[f] === "string");
+  if (!field) return;
+  const viteFile = path.resolve(dir, manifest[field]);
+  if (viteFile === resolved) return;
+  reportDuplicateInstance(pkg, resolved, viteFile, field);
+}
+
+/** The npm package a bare specifier belongs to, or null for relative/absolute ones. */
+function packageOf(request) {
+  if (!request || request.startsWith(".") || request.startsWith("/") || request.startsWith("\\")) {
+    return null;
+  }
+  const parts = request.split("/");
+  return request.startsWith("@") ? (parts[1] ? `${parts[0]}/${parts[1]}` : null) : parts[0];
+}
+
 export function installRequireHooks(
   projectRoot,
   transformPkgs = [],
@@ -137,7 +209,9 @@ export function installRequireHooks(
       );
       if (hit) return hit;
     }
-    return origResolve.call(this, request, parent, ...rest);
+    const resolved = origResolve.call(this, request, parent, ...rest);
+    checkResolverAgreement(request, resolved);
+    return resolved;
   };
 
   const origJs = Module._extensions[".js"];

--- a/packages/vitest-native/tests/resolver-agreement.test.ts
+++ b/packages/vitest-native/tests/resolver-agreement.test.ts
@@ -1,0 +1,122 @@
+/**
+ * The native engine runs two module systems: Vite resolves the test graph, Node's
+ * CJS resolver serves everything externalized. The plugin points Vite at React
+ * Native's fields — `mainFields: ["react-native", "module", "jsnext:main", "jsnext"]`
+ * — and `main`, which is all Node's resolver looks at, is not among them.
+ *
+ * So any package publishing a `react-native` field (ordinary for the ecosystem) or a
+ * `module` field (ordinary for anything dual-format) resolves to a DIFFERENT FILE on
+ * each side. When both graphs load it, the package exists twice with separate
+ * module-level state, and nothing reports it: writes through one copy are simply
+ * invisible to the other.
+ *
+ * Reported from a real migration of a ~337-file monorepo suite: a store configured
+ * during setup read back unset inside a component, so every translated label
+ * rendered as "" and 44 tests failed comparing empty strings against expected text.
+ * It cost days to find, and the reporter's own conclusion was that one warning
+ * naming both paths would have surfaced it immediately.
+ *
+ * Reproduced here with no jest-compat involved, ruling out their shim as the cause.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { _resetDuplicateReports, checkResolverAgreement } from "../src/native/hooks.mjs";
+
+const roots: string[] = [];
+afterAll(() => {
+  for (const r of roots) fs.rmSync(r, { recursive: true, force: true });
+});
+
+/** A package directory under a node_modules, as the resolver would see it. */
+function pkg(name: string, manifest: Record<string, unknown>, files: string[]): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vn-resolver-"));
+  roots.push(root);
+  const dir = path.join(root, "node_modules", name);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "package.json"), JSON.stringify({ name, ...manifest }));
+  for (const f of files) {
+    fs.mkdirSync(path.dirname(path.join(dir, f)), { recursive: true });
+    fs.writeFileSync(path.join(dir, f), "module.exports = {};");
+  }
+  return dir;
+}
+
+describe("resolver agreement", () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    _resetDuplicateReports();
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warn.mockRestore();
+    _resetDuplicateReports();
+  });
+
+  it("reports a package whose react-native field points elsewhere than main", () => {
+    const dir = pkg("split-lib", { main: "./dist/index.cjs", "react-native": "./src/index.js" }, [
+      "dist/index.cjs",
+      "src/index.js",
+    ]);
+    checkResolverAgreement("split-lib", path.join(dir, "dist", "index.cjs"));
+    expect(warn).toHaveBeenCalledOnce();
+    const message = warn.mock.calls[0][0] as string;
+    expect(message).toContain("resolves to two different files");
+    // Both paths, because the pair is what makes it recognisable.
+    expect(message).toContain(path.join(dir, "dist", "index.cjs"));
+    expect(message).toContain(path.join(dir, "src", "index.js"));
+    // The field responsible, so the reader can see why they differ.
+    expect(message).toContain('"react-native"');
+  });
+
+  it("names the consequence, not just the paths", () => {
+    const dir = pkg("split-lib", { main: "./m.cjs", module: "./m.mjs" }, ["m.cjs", "m.mjs"]);
+    checkResolverAgreement("split-lib", path.join(dir, "m.cjs"));
+    const message = warn.mock.calls[0][0] as string;
+    expect(message).toMatch(/state/i);
+    expect(message).toMatch(/not shared|invisible/i);
+  });
+
+  it("stays quiet when both resolvers agree", () => {
+    const dir = pkg("agreed", { main: "./index.js", module: "./index.js" }, ["index.js"]);
+    checkResolverAgreement("agreed", path.join(dir, "index.js"));
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("stays quiet for a package declaring none of Vite's fields", () => {
+    const dir = pkg("plain", { main: "./index.js" }, ["index.js"]);
+    checkResolverAgreement("plain", path.join(dir, "index.js"));
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("reports each package once, however often it is resolved", () => {
+    const dir = pkg("noisy", { main: "./a.cjs", module: "./b.mjs" }, ["a.cjs", "b.mjs"]);
+    for (let i = 0; i < 5; i++) checkResolverAgreement("noisy", path.join(dir, "a.cjs"));
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it("ignores relative and absolute specifiers", () => {
+    const dir = pkg("rel", { main: "./a.cjs", module: "./b.mjs" }, ["a.cjs", "b.mjs"]);
+    checkResolverAgreement("./local", path.join(dir, "a.cjs"));
+    checkResolverAgreement("/abs/path", path.join(dir, "a.cjs"));
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("handles a scoped package and its subpath imports", () => {
+    const dir = pkg("@scope/lib", { main: "./dist/i.cjs", module: "./dist/i.mjs" }, [
+      "dist/i.cjs",
+      "dist/i.mjs",
+    ]);
+    checkResolverAgreement("@scope/lib/sub", path.join(dir, "dist", "i.cjs"));
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0][0]).toContain("@scope/lib");
+  });
+
+  it("does not throw on a package directory it cannot read", () => {
+    expect(() =>
+      checkResolverAgreement("ghost", path.join(os.tmpdir(), "node_modules", "ghost", "i.js")),
+    ).not.toThrow();
+    expect(warn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Addresses **Blocker #1** from the monorepo migration report — the reporter's own "single most valuable diagnostic to add".

## First: jest-compat is ruled out

Their shim redirected Node-side resolution to `src/`, so the obvious question was whether that caused the split. It doesn't. Reproduced with **no jest-compat anywhere** — no `jestCompatSetup`, no `jestMockTransform`, no `requireActual`, no shim — using a package that declares nothing unusual:

```json
{ "main": "./dist/index.cjs", "react-native": "./src/index.js" }
```

```
ESM loaded from: src | CJS loaded from: dist
value the component would read: ""
```

That is their symptom exactly: `configure()` wrote the translator into the **src** instance, the component read the **dist** instance, and got `''`.

## Cause

`plugin.ts` sets, for Vite only:

```
conditions: ["react-native"],
mainFields: ["react-native", "module", "jsnext:main", "jsnext"],
```

Node's CJS resolver consults `main`, which **is not in that list**. So a `react-native` field (ordinary across the ecosystem) or a `module` field (ordinary for anything dual-format) puts the two resolvers on different files by default. Their built workspace package is one instance of a much broader class.

## The diagnostic

The Node-side resolver compares what it resolved against the file Vite's field order would pick, and reports once per package:

```
[vitest-native] 'singleton-split' resolves to two different files.
  Node (require) ->  .../node_modules/singleton-split/dist/index.cjs
  Vite ("react-native") ->  .../node_modules/singleton-split/src/index.js
  If both module systems load it, the package exists twice and module-level state —
  stores, React contexts, event emitters, registries — is not shared between the copies.
  Nothing throws: writes through one are simply invisible to the other, so values read
  back unset. Set `resolve.mainFields` so both resolvers agree, or import the package
  from one side only.
```

## Measured, not assumed

| | |
| --- | --- |
| invocations in this package's native suite | **6022** across **135** distinct packages |
| warnings emitted on that healthy suite | **0** |
| fires on the reproduction | **yes** |

**Two earlier designs were discarded because measurement rejected them.** Keying on "package is Vite-inlined and also Node-resolved" looked precise (0 hits on a healthy repo) but missed the target case entirely — the reproducing package isn't a *declared dependency*, so `detectEcosystemPackages` never considers it. A static scan suggesting ~5 divergent packages also proved misleading: those aren't resolvable from this package at all.

**Controls**: reporting when the files agree fails 1; dropping once-per-package dedup fails 1; consulting none of Vite's fields fails 4.

## What I verified and rejected as advice

`transform: ['pkg']` does **not** collapse the duplicate — still `src` vs `dist`. It excludes a package from inlining, which is a different axis. That's why it isn't suggested in the message.

## Scope

This is a diagnostic. Making the two resolvers agree — most likely by having the Node-side `_resolveFilename` honour the same field order Vite uses — is a real behaviour change and belongs in its own PR, with the trade-offs put to you first.

## Verification

Mock suite 1547 passed / 3 skipped · native 198 passed · lint + typecheck + format clean · changeset included.