### PR TITLE
fix(jest-compat): resolve relative requireActual against the caller

### DIFF
--- a/.changeset/require-actual-caller-relative.md
+++ b/.changeset/require-actual-caller-relative.md
@@ -1,0 +1,18 @@
+---
+"vitest-native": patch
+---
+
+`jest.requireActual` resolves relative paths against the calling file
+
+Jest resolves `jest.requireActual('../thing')` against the module that called it. The
+compat layer backed it with a single `createRequire` anchored at the project root, so
+bare specifiers worked and relative ones escaped the source tree: MODULE_NOT_FOUND,
+with a requireStack pointing at `<projectRoot>/package.json` — a confusing place to
+be sent when the file sits beside the test. A migration reported this breaking five
+files until they shimmed around it.
+
+Relative specifiers now resolve from the caller, taken from the stack, since these
+are runtime calls on the `jest` global rather than rewritten imports. Bare specifiers
+still resolve from the project, and a caller-relative miss is reported rather than
+retried against the root, which could otherwise resolve an unrelated file that
+happens to sit at the same relative path.

--- a/packages/vitest-native/src/jest-compat/setup.mjs
+++ b/packages/vitest-native/src/jest-compat/setup.mjs
@@ -13,6 +13,7 @@
 // `jest.useFakeTimers` work at runtime via the `jest` global installed here.
 import { vi } from "vitest";
 import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
 import path from "node:path";
 import { jestMockInterop } from "./interop.mjs";
 import { VitestNativeError } from "../errors.mjs";
@@ -44,9 +45,52 @@ function writableModuleFacade(mod) {
   });
 }
 
+/**
+ * The file that called into here, taken from the stack.
+ *
+ * Jest resolves a relative `requireActual('../x')` against the CALLING module. This
+ * shim had a single require anchored at the project root, so bare specifiers worked
+ * and relative ones escaped the source tree: `jest.requireActual('../thing')` threw
+ * MODULE_NOT_FOUND with a requireStack pointing at <projectRoot>/package.json, which
+ * is a confusing place to be sent when the file sits next to the test.
+ *
+ * The stack is the only thing that knows the caller. These are plain runtime calls
+ * on the `jest` global, not rewritten at transform time, so there is no import.meta
+ * to consult.
+ */
+function callerFile() {
+  const original = Error.prepareStackTrace;
+  try {
+    Error.prepareStackTrace = (_, frames) => frames;
+    const frames = new Error().stack;
+    for (const frame of frames) {
+      const file = typeof frame.getFileName === "function" ? frame.getFileName() : null;
+      if (!file || file.startsWith("node:") || file.includes("/jest-compat/")) continue;
+      return file.startsWith("file://") ? fileURLToPath(file) : file;
+    }
+  } catch {
+    // Fall through to the project-root require below.
+  } finally {
+    Error.prepareStackTrace = original;
+  }
+  return null;
+}
+
+/** Resolve as Jest does: relative against the caller, bare from the project root. */
+function requireFrom(specifier) {
+  if (typeof specifier === "string" && specifier.startsWith(".")) {
+    const caller = callerFile();
+    // A caller-relative miss is the honest answer. Falling back to the project root
+    // could resolve some other file that happens to sit at the same relative path.
+    if (caller) return createRequire(caller)(specifier);
+  }
+  return require(specifier);
+}
+
 if (typeof vi.requireActual !== "function")
-  vi.requireActual = (m) => (m === "react-native" ? writableModuleFacade(require(m)) : require(m));
-if (typeof vi.requireMock !== "function") vi.requireMock = (m) => require(m);
+  vi.requireActual = (m) =>
+    m === "react-native" ? writableModuleFacade(require(m)) : requireFrom(m);
+if (typeof vi.requireMock !== "function") vi.requireMock = (m) => requireFrom(m);
 // `jest.setTimeout(ms)` maps onto `vi.setConfig({ testTimeout })`, which applies for
 // the rest of the file — the same scope Jest gives it, since Vitest resets the config
 // after each test file.

--- a/packages/vitest-native/tests-native/jest-require-actual.test.ts
+++ b/packages/vitest-native/tests-native/jest-require-actual.test.ts
@@ -1,0 +1,26 @@
+/**
+ * `jest.requireActual('../x')` resolves against the CALLING module under Jest.
+ *
+ * The compat shim backed it with a single `createRequire` anchored at the project
+ * root, so bare specifiers worked and relative ones escaped the source tree:
+ * MODULE_NOT_FOUND, with a requireStack pointing at <projectRoot>/package.json —
+ * a confusing place to be sent when the file sits beside the test. Reported from a
+ * real migration, where it broke five files until they shimmed around it.
+ */
+import { expect, it } from "vitest";
+
+declare const jest: { requireActual: (m: string) => Record<string, unknown> };
+
+it("resolves a relative specifier against the calling file", () => {
+  expect(jest.requireActual("./require-actual-sibling.cjs").marker).toBe("sibling-of-the-test");
+});
+
+it("still resolves bare specifiers from the project", () => {
+  expect(typeof jest.requireActual("react")).toBe("object");
+});
+
+it("reports a genuine miss rather than resolving something else", () => {
+  // Falling back to the project root on a caller-relative miss could resolve an
+  // unrelated file that happens to sit at the same relative path.
+  expect(() => jest.requireActual("./definitely-not-here.cjs")).toThrow();
+});

--- a/packages/vitest-native/tests-native/require-actual-sibling.cjs
+++ b/packages/vitest-native/tests-native/require-actual-sibling.cjs
@@ -1,0 +1,1 @@
+module.exports = { marker: "sibling-of-the-test" };

--- a/packages/vitest-native/tests-native/requireactual-ts.test.tsx
+++ b/packages/vitest-native/tests-native/requireactual-ts.test.tsx
@@ -2,13 +2,16 @@ import { describe, expect, it } from "vitest";
 
 // Migrated Jest suites often do `jest.requireActual('./app/X')` to spread a real
 // module then override one export. Node's CJS loader can't load .ts/.tsx, so the
-// native engine registers Babel-backed .ts/.tsx require handlers. Path is relative
-// to the project root (where jest-compat's global require is anchored).
+// native engine registers Babel-backed .ts/.tsx require handlers. The path is
+// relative to THIS file, as it is under Jest. It used to be relative to the project
+// root, because the shim anchored its require there — which is why a migrated suite
+// calling `jest.requireActual('../thing')` got MODULE_NOT_FOUND for a file sitting
+// beside it.
 declare const jest: { requireActual(m: string): any };
 
 describe("native engine: jest.requireActual of app TS/TSX", () => {
   it("loads a real .tsx module synchronously (TS + default export)", () => {
-    const mod = jest.requireActual("./tests-native/fixtures/widget");
+    const mod = jest.requireActual("./fixtures/widget");
     expect(typeof mod.default).toBe("function");
     expect(mod.default()).toBe("real-widget");
   });


### PR DESCRIPTION
Reported item **#3**, confirmed and reproduced in isolation.

## The bug

Jest resolves `jest.requireActual('../thing')` against the **calling module**. The compat layer backed it with a single `createRequire` anchored at the project root:

```js
const require = createRequire(path.join(projectRoot, "package.json"));
```

So bare specifiers worked and relative ones escaped the source tree. Reproduced standalone:

```
bare-root anchor:              resolved-relative-to-caller
caller-relative './target.cjs' -> MODULE_NOT_FOUND
```

The reporter hit this on five files and had to ship a re-anchoring shim. The `requireStack` pointed at `<projectRoot>/package.json`, which is a confusing place to be sent when the file sits beside the test.

## The fix

Relative specifiers resolve from the caller, taken from the stack — these are runtime calls on the `jest` global, not imports rewritten at transform time, so there's no `import.meta` to consult. Bare specifiers still resolve from the project.

A caller-relative miss is reported rather than retried from the root: falling back could resolve an unrelated file that happens to sit at the same relative path.

## An existing test asserted the old behaviour

`requireactual-ts.test.tsx` used `'./tests-native/fixtures/widget'` with a comment calling the root anchoring a property:

> *Path is relative to the project root (where jest-compat's global require is anchored).*

That is the bug, written down as a feature. It now uses `'./fixtures/widget'` — what the same code does under Jest.

**Control**: reverting to root-anchored resolution fails the new caller-relative test.

## Verification

mock 1547 / 3 skipped · native **201** · navigation 1 · android 3 · advice 2 · hot 201 · lint + typecheck + format + check:size clean.