### PR TITLE
feat(presets): switch one auto-detected preset off without listing the rest

### DIFF
--- a/.changeset/preset-opt-out.md
+++ b/.changeset/preset-opt-out.md
@@ -1,0 +1,15 @@
+---
+"vitest-native": patch
+---
+
+Switch a single auto-detected preset off with `presets: { name: false }`
+
+`presets` accepted only an array, and providing one replaced auto-detection entirely.
+A project that needed to drop one preset — for example the navigation preset, because
+its stub means a real `NavigationContainer` never fires `onReady` — had to enumerate
+every other detected preset by hand. That list then rots silently as dependencies
+change: add a library and its preset is not applied, because the hand-written array
+does not mention it.
+
+Passing an object keeps auto-detection and names only what to drop. The array form is
+unchanged.

--- a/packages/vitest-native/src/index.ts
+++ b/packages/vitest-native/src/index.ts
@@ -1,3 +1,3 @@
-export { reactNative } from "./plugin.js";
+export { reactNative, disabledPresetNames } from "./plugin.js";
 export * as presets from "./presets/index.js";
 export type { VitestNativeOptions, Preset, ReactNativeMock } from "./types.js";

--- a/packages/vitest-native/src/plugin.ts
+++ b/packages/vitest-native/src/plugin.ts
@@ -256,12 +256,15 @@ async function resolveOptions(
   const engine: "mock" | "native" = options.engine === "native" ? "native" : "mock";
   const userExts = (options.assetExts ?? []).map((e) => e.replace(/^\./, ""));
 
-  // If user provided presets explicitly, use those. Otherwise auto-detect.
+  // An array replaces auto-detection; an object keeps it and switches named presets
+  // off; omitting it auto-detects everything.
   let presets: Preset[];
-  if (options.presets) {
+  if (Array.isArray(options.presets)) {
     presets = options.presets;
   } else {
-    presets = await autoDetectPresets(diagnostics, projectRoot ?? process.cwd());
+    const detected = await autoDetectPresets(diagnostics, projectRoot ?? process.cwd());
+    const disabled = disabledPresetNames(options.presets);
+    presets = disabled.size > 0 ? detected.filter((p) => !disabled.has(p.name)) : detected;
   }
 
   return {
@@ -558,6 +561,23 @@ export function alignLegacyFieldsWithNode(
   return nodeFile;
 }
 
+/**
+ * Preset names switched off by the object form of the `presets` option.
+ *
+ * The array form replaces auto-detection wholesale, which meant that turning ONE
+ * preset off required listing every other detected preset by hand — tedious, and a
+ * list that silently rots as dependencies change. The object form keeps detection
+ * and names only what to drop.
+ */
+export function disabledPresetNames(presets: unknown): Set<string> {
+  if (!presets || Array.isArray(presets) || typeof presets !== "object") return new Set();
+  return new Set(
+    Object.entries(presets as Record<string, unknown>)
+      .filter(([, enabled]) => enabled === false)
+      .map(([name]) => name),
+  );
+}
+
 export function reactNative(options?: VitestNativeOptions): Plugin {
   // Per plugin INSTANCE, not module scope. A Vitest workspace calls reactNative() once
   // per project and they share this module, so module-level state means the last
@@ -822,16 +842,17 @@ export function reactNative(options?: VitestNativeOptions): Plugin {
         // resolve which presets are active here (sync) and hand the names to the
         // native setup file via env; it builds the mocks in-worker. The actual
         // import redirection happens in resolveId/load (virtual:preset modules).
-        const nativePresetNames = options?.presets
+        const disabledNative = disabledPresetNames(options?.presets);
+        const nativePresetNames = Array.isArray(options?.presets)
           ? options.presets.map((p) => p.name)
-          : autoDetectPresetNames(resolvedRoot, diagnostics);
+          : autoDetectPresetNames(resolvedRoot, diagnostics).filter((n) => !disabledNative.has(n));
         if (nativePresetNames.length > 0) {
           env.VITEST_NATIVE_PRESET_NAMES = JSON.stringify(nativePresetNames);
         }
         // Per-preset config (e.g. navigation({ defaultRouteParams })) must travel to
         // the worker, where presets are rebuilt from their name. Only explicitly
         // configured presets carry config; auto-detected ones use their defaults.
-        if (options?.presets) {
+        if (Array.isArray(options?.presets)) {
           const presetConfig: Record<string, Record<string, unknown>> = {};
           for (const p of options.presets) {
             if (p.config && Object.keys(p.config).length > 0) presetConfig[p.name] = p.config;
@@ -952,11 +973,17 @@ export function reactNative(options?: VitestNativeOptions): Plugin {
         env.VITEST_NATIVE_MOCKS = JSON.stringify(options.mocks);
       }
 
-      // If user explicitly provided presets, serialize their names so
-      // setup.ts knows not to auto-detect. If omitted, setup.ts will
-      // auto-detect from the worker context.
-      if (options?.presets) {
+      // An explicit ARRAY is the full list, so setup.ts must not auto-detect. The
+      // object form keeps detection — the worker does that itself — and only needs to
+      // know which names to drop. `resolved` is not assigned until configResolved,
+      // so neither branch can read it here.
+      if (Array.isArray(options?.presets)) {
         env.VITEST_NATIVE_PRESET_NAMES = JSON.stringify(options.presets.map((p) => p.name));
+      } else {
+        const disabled = disabledPresetNames(options?.presets);
+        if (disabled.size > 0) {
+          env.VITEST_NATIVE_PRESET_DISABLED = JSON.stringify([...disabled]);
+        }
       }
 
       return asCompatibleViteConfig({

--- a/packages/vitest-native/src/setup.ts
+++ b/packages/vitest-native/src/setup.ts
@@ -47,6 +47,17 @@ if (process.env.VITEST_NATIVE_MOCKS) {
 
 // Explicit preset names from plugin config, or null for auto-detect.
 let explicitPresetNames: string[] | null = null;
+// Names switched off by `presets: { name: false }`. Auto-detection still runs in the
+// worker; these are removed from what it finds.
+let disabledPresetNames: string[] = [];
+if (process.env.VITEST_NATIVE_PRESET_DISABLED) {
+  try {
+    disabledPresetNames = JSON.parse(process.env.VITEST_NATIVE_PRESET_DISABLED) as string[];
+  } catch {
+    disabledPresetNames = [];
+  }
+}
+
 if (process.env.VITEST_NATIVE_PRESET_NAMES) {
   try {
     explicitPresetNames = JSON.parse(process.env.VITEST_NATIVE_PRESET_NAMES);
@@ -185,7 +196,7 @@ function loadExplicitPresets(names: string[]): Preset[] {
 // Determine which presets to use.
 const presets = explicitPresetNames
   ? loadExplicitPresets(explicitPresetNames)
-  : autoDetectPresets();
+  : autoDetectPresets().filter((p) => !disabledPresetNames.includes(p.name));
 
 // Initialize a global store for preset mocks so that virtual modules
 // (served by the plugin's load() hook) can read them at runtime.

--- a/packages/vitest-native/src/types.ts
+++ b/packages/vitest-native/src/types.ts
@@ -250,9 +250,14 @@ export interface VitestNativeOptions {
   engine?: "auto" | "mock" | "native";
 
   /**
-   * Built-in third-party library presets. When provided, only these presets
-   * are used. When omitted, vitest-native auto-detects installed packages
-   * and enables matching presets automatically.
+   * Built-in third-party library presets.
+   *
+   * An ARRAY replaces auto-detection entirely: only those presets are used.
+   *
+   * An OBJECT keeps auto-detection and turns individual presets off by name —
+   * `{ navigation: false }` — which is what you want when one preset gets in the
+   * way. Listing every other detected preset back by hand just to drop one is
+   * both tedious and a thing that silently rots as dependencies change.
    *
    * Only built-in presets are supported (reanimated, gestureHandler,
    * safeAreaContext, navigation, asyncStorage, screens, expo). For custom
@@ -264,7 +269,7 @@ export interface VitestNativeOptions {
    * reactNative({ presets: [presets.reanimated(), presets.navigation()] })
    * ```
    */
-  presets?: Preset[];
+  presets?: Preset[] | Record<string, boolean>;
 
   /**
    * `engine: 'mock'` only. Plain-data overrides merged into the react-native

--- a/packages/vitest-native/src/validate.ts
+++ b/packages/vitest-native/src/validate.ts
@@ -59,8 +59,23 @@ export function validateOptions(options: Record<string, unknown>): void {
   }
   if (options.assetExts !== undefined) assertStringArray(options.assetExts, "assetExts");
   if (options.transform !== undefined) assertStringArray(options.transform, "transform");
+  // Two shapes: an array replaces auto-detection, an object of booleans keeps it and
+  // switches named presets off. Anything else is rejected with both spellings named,
+  // since "must be an array" would now be wrong advice.
   if (options.presets !== undefined && !Array.isArray(options.presets)) {
-    throw new VitestNativeTypeError("INVALID_OPTION", `"presets" must be an array.`);
+    const isPlainObject =
+      options.presets !== null &&
+      typeof options.presets === "object" &&
+      Object.values(options.presets as Record<string, unknown>).every(
+        (v) => typeof v === "boolean",
+      );
+    if (!isPlainObject) {
+      throw new VitestNativeTypeError(
+        "INVALID_OPTION",
+        `"presets" must be an array of presets, or an object of booleans to switch ` +
+          `auto-detected presets off (for example { navigation: false }).`,
+      );
+    }
   }
   if (
     options.mocks !== undefined &&

--- a/packages/vitest-native/tests/preset-opt-out.test.ts
+++ b/packages/vitest-native/tests/preset-opt-out.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Turning ONE auto-detected preset off should not mean listing every other one.
+ *
+ * `presets` accepted only an array, and providing it replaced auto-detection
+ * wholesale. A project that needed to drop the navigation preset — because it
+ * renders a real NavigationContainer and the stub means `onReady` never fires — had
+ * to enumerate every other detected preset by hand. That list then rots silently as
+ * dependencies change: add a library, and its preset is not applied because the
+ * hand-written array does not mention it.
+ *
+ * The object form keeps detection and names only what to drop.
+ */
+import { describe, expect, it } from "vitest";
+import { disabledPresetNames, reactNative } from "../src/index.js";
+
+type PluginLike = {
+  configResolved: (config: { root: string }) => Promise<void>;
+  config: (config: unknown, env: unknown) => Promise<{ test?: { env?: Record<string, string> } }>;
+};
+
+async function activePresets(options?: unknown): Promise<string[]> {
+  const plugin = reactNative(options as never) as unknown as PluginLike;
+  await plugin.configResolved({ root: process.cwd() });
+  const resolved = await plugin.config({ test: {} }, { command: "serve" });
+  const names = resolved?.test?.env?.VITEST_NATIVE_PRESET_NAMES;
+  return names ? (JSON.parse(names) as string[]) : [];
+}
+
+describe("disabledPresetNames", () => {
+  it("reads names switched off in the object form", () => {
+    expect(disabledPresetNames({ navigation: false, screens: true })).toEqual(
+      new Set(["navigation"]),
+    );
+  });
+
+  it("treats the array form as replacing detection, not disabling", () => {
+    expect(disabledPresetNames([{ name: "navigation", modules: {} }])).toEqual(new Set());
+  });
+
+  it("is empty for undefined", () => {
+    expect(disabledPresetNames(undefined)).toEqual(new Set());
+  });
+});
+
+describe("presets option", () => {
+  it("auto-detects when omitted", async () => {
+    const auto = await activePresets();
+    // Guards against the assertions below passing because nothing was detected.
+    expect(auto.length).toBeGreaterThan(1);
+    expect(auto).toContain("navigation");
+  });
+
+  it("drops a named preset and keeps the rest", async () => {
+    const auto = await activePresets();
+    const without = await activePresets({ presets: { navigation: false } });
+    expect(without).not.toContain("navigation");
+    for (const name of auto.filter((n) => n !== "navigation")) {
+      expect(without).toContain(name);
+    }
+  });
+
+  it("still lets an array replace detection entirely", async () => {
+    const only = await activePresets({ presets: [] });
+    expect(only).toEqual([]);
+  });
+
+  it("ignores names set to true, which is the default anyway", async () => {
+    const auto = await activePresets();
+    expect(await activePresets({ presets: { navigation: true } })).toEqual(auto);
+  });
+});

--- a/website/guide/plugin-options.md
+++ b/website/guide/plugin-options.md
@@ -36,11 +36,25 @@ Set to `true` to log plugin activity — useful when debugging resolution or whi
 
 An array of [third-party presets](/guide/presets). Presets are auto-detected from your installed dependencies, so listing them is usually optional:
 
-::: warning Providing this option replaces auto-detection
-When `presets` is present, **only** the presets in the array are used — auto-detection
-does not run. `presets: []` therefore disables every preset, including ones your app
-depends on. Omit the option entirely to keep auto-detection.
+::: warning An array replaces auto-detection
+When `presets` is an **array**, only those presets are used — auto-detection does not
+run. `presets: []` therefore disables every preset, including ones your app depends
+on. Omit the option entirely to keep auto-detection.
 :::
+
+To keep auto-detection and switch a single preset off, pass an **object** instead:
+
+```ts
+reactNative({
+  presets: { navigation: false },
+})
+```
+
+That is what you want when one preset gets in the way — for example when a suite
+renders a real `NavigationContainer` and the stubbed one never fires `onReady`.
+Listing every other detected preset back by hand to drop one also rots silently: add
+a library later and its preset is not applied, because the hand-written array does
+not mention it.
 
 ```ts
 import { reactNative, presets } from 'vitest-native'


### PR DESCRIPTION
Reported item **#6**.

## The ask

> *provide a single-preset opt-out (e.g. `presets: { navigation: false }`) instead of forcing users to re-list all auto-detected presets.*

## Why it matters

`presets` accepted only an array, and providing one **replaced auto-detection entirely**. To drop the navigation preset — which the reporter needed, because its stub means a real `NavigationContainer` never fires `onReady` — they had to enumerate every other detected preset by hand.

That list then rots silently: add a library later and its preset isn't applied, because the hand-written array doesn't mention it. #103 showed the same sharp edge from the other side, where a documented `presets: []` disabled ten presets without a word.

## The change

```ts
reactNative({ presets: { navigation: false } })   // keeps detection, drops one
reactNative({ presets: [presets.svg()] })          // unchanged: replaces detection
```

Validation now names both spellings — `"presets" must be an array` would be wrong advice.

## Two mistakes the suite caught

- The mock path read `resolved.presets` inside `config()`, where `resolved` isn't assigned until `configResolved`. That broke **eight** unrelated tests with `Cannot read properties of undefined`.
- Auto-detection happens in the **worker**, which had no way to know what was switched off. It now receives the disabled names and subtracts them.

Both were mine, and both were invisible until the suites ran — the first version type-checked cleanly.

## Verification

mock **1554** / 3 skipped · native 198 · navigation 1 · android 3 · advice 2 · lint + typecheck + format + check:size clean. 7 new tests, including a guard that auto-detection found something first so the assertions can't pass vacuously.

Docs updated; the #103 documented-config gate still passes.

Budget ceilings match #114's so the branches don't drift.