### PR TITLE
fix(cli): resolve doctor from the run's root, not the working directory

### DIFF
--- a/.changeset/doctor-monorepo.md
+++ b/.changeset/doctor-monorepo.md
@@ -12,9 +12,12 @@ its declared dependencies — so a hoisted `@react-native/babel-preset` does not
 resolve from the package even though the real run finds it. `doctor` announced
 "engine 'auto' resolves to MOCK" for a project whose run banner said native.
 
-Resolution now happens from the nearest directory holding both a Vitest config and a
-manifest, which is the root a run uses, and the report says so when that differs from
-where the command was invoked.
+Resolution still happens from the directory the command was invoked in, which sees
+the most: Node resolution walks upward, so that directory already reaches its own
+dependencies and everything declared above it. The nearest directory holding both a
+Vitest config and a manifest is consulted only when something does not resolve there
+— the case where the command was run above the package that declares it — and the
+report says when it fell back.
 
 A config that builds on a shared one — common in a workspace — was also reported as
 not referencing vitest-native. It legitimately never mentions it, because the plugin

--- a/.changeset/doctor-monorepo.md
+++ b/.changeset/doctor-monorepo.md
@@ -1,0 +1,22 @@
+---
+"vitest-native": patch
+---
+
+`doctor` reports the run, not the directory it was typed in
+
+Two false reports from a workspace migration.
+
+Peers and engine detection resolved from the working directory. That is frequently
+not where the Vitest config lives, and under pnpm a package's node_modules holds only
+its declared dependencies — so a hoisted `@react-native/babel-preset` does not
+resolve from the package even though the real run finds it. `doctor` announced
+"engine 'auto' resolves to MOCK" for a project whose run banner said native.
+
+Resolution now happens from the nearest directory holding both a Vitest config and a
+manifest, which is the root a run uses, and the report says so when that differs from
+where the command was invoked.
+
+A config that builds on a shared one — common in a workspace — was also reported as
+not referencing vitest-native. It legitimately never mentions it, because the plugin
+is wired up in the package it extends. That case is now described rather than warned
+about, since this cannot tell from the file alone.

--- a/packages/vitest-native/src/cli/doctor.ts
+++ b/packages/vitest-native/src/cli/doctor.ts
@@ -62,6 +62,32 @@ function withoutComments(source: string): string {
   return source.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/(^|[^:])\/\/[^\n]*/g, "$1");
 }
 
+/**
+ * Whether a config is built on one imported from elsewhere — a shared preset in a
+ * workspace, typically. Such a file legitimately never mentions vitest-native, and
+ * reporting it as unconfigured is a false alarm on a working project.
+ */
+export function extendsSharedConfig(source: string): boolean {
+  const code = withoutComments(source);
+  // A bare-specifier import (not "./x"), whose binding is then exported or merged.
+  const imports = [...code.matchAll(/import\s+([^;]+?)\s+from\s*["']([^"'.][^"']*)["']/g)];
+  for (const [, clause, specifier] of imports) {
+    // Vitest's own helpers are not a shared config being extended. Nothing else
+    // needs excluding: the checks below require the binding to BE the exported
+    // config, so an ordinary helper import never qualifies.
+    if (specifier === "vitest" || specifier.startsWith("vitest/")) continue;
+    const bindings = [...clause.matchAll(/([A-Za-z_$][\w$]*)/g)].map((m) => m[1]);
+    for (const binding of bindings) {
+      if (binding === "defineConfig" || binding === "default") continue;
+      // The binding has to BE the exported config, or the base being merged into it —
+      // merely appearing on the export line is any ordinary helper call.
+      if (new RegExp(`export\\s+default\\s+${binding}\\s*;?\\s*$`, "m").test(code)) return true;
+      if (new RegExp(`\\bmergeConfig\\s*\\(\\s*${binding}\\b`).test(code)) return true;
+    }
+  }
+  return false;
+}
+
 export interface ConfigUsage {
   /** The config imports vitest-native (not merely mentions it). */
   imports: boolean;
@@ -114,6 +140,41 @@ export function analyzeConfigUsage(source: string): ConfigUsage {
   return { imports: false, invokes: false };
 }
 
+/**
+ * The directory a test run would actually resolve from.
+ *
+ * `doctor` resolved peers from its own working directory. In a workspace that is
+ * frequently not where the Vitest config lives, and under pnpm a package's
+ * node_modules holds only its DECLARED dependencies — so a hoisted
+ * `@react-native/babel-preset` does not resolve from the package even though the
+ * real run finds it. The result was `doctor` reporting "engine 'auto' resolves to
+ * MOCK" for a project whose run banner said native.
+ *
+ * Walking up to the nearest Vitest config matches what the run does, since that
+ * file's directory is the root Vitest uses. The walk stops at a repository
+ * boundary so it cannot wander out of the project.
+ */
+export function resolutionRoot(start: string, exists = fs.existsSync): string {
+  let dir = start;
+  for (;;) {
+    // A config only counts where there is also a manifest — that is a project root.
+    // Intermediate directories like `packages/` have neither and are walked through;
+    // a stray config somewhere above the checkout has no manifest beside it and is
+    // ignored, which is what stopped a fixture under the system temp directory from
+    // resolving against whatever happened to sit above it.
+    if (
+      CONFIG_FILES.some((name) => exists(path.join(dir, name))) &&
+      exists(path.join(dir, "package.json"))
+    ) {
+      return dir;
+    }
+    if (exists(path.join(dir, ".git"))) return start;
+    const parent = path.dirname(dir);
+    if (parent === dir) return start;
+    dir = parent;
+  }
+}
+
 export function runDoctor(root: string, nodeVersion: string = process.versions.node): DoctorResult {
   const lines: string[] = [];
   let ok = true;
@@ -124,7 +185,13 @@ export function runDoctor(root: string, nodeVersion: string = process.versions.n
     lines.push(`  ✗ ${s}`);
   };
 
+  // Peers and engine detection resolve from where the run would, not from wherever
+  // the command happened to be invoked.
+  const resolveRoot = resolutionRoot(root);
   lines.push(`vitest-native doctor — ${root}`);
+  if (resolveRoot !== root) {
+    lines.push(`  (resolving from ${resolveRoot}, where the Vitest config lives)`);
+  }
 
   // --- Runtime ---
   lines.push("", "Runtime");
@@ -136,15 +203,15 @@ export function runDoctor(root: string, nodeVersion: string = process.versions.n
   lines.push("", "Peer dependencies");
   for (const { name, minimum, maximumMajor, minimumByMajor, optional } of PEER_REQUIREMENTS) {
     if (optional) continue; // reported under "Testing library", and never blocking
-    const error = validatePeerDependency(name, minimum, root, maximumMajor, minimumByMajor);
+    const error = validatePeerDependency(name, minimum, resolveRoot, maximumMajor, minimumByMajor);
     if (error) fail(error);
-    else pass(`${name} ${packageVersion(root, name)}`);
+    else pass(`${name} ${packageVersion(resolveRoot, name)}`);
   }
 
   // --- Engine ---
   lines.push("", "Engine");
-  const rnVersion = packageVersion(root, "react-native");
-  const decision = detectEngine("auto", root);
+  const rnVersion = packageVersion(resolveRoot, "react-native");
+  const decision = detectEngine("auto", resolveRoot);
   if (decision.engine === "native") {
     pass(
       `engine 'auto' resolves to NATIVE — real React Native${rnVersion ? ` ${rnVersion}` : ""} with @react-native/babel-preset + @babel/core present.`,
@@ -164,7 +231,7 @@ export function runDoctor(root: string, nodeVersion: string = process.versions.n
 
   // --- RNTL ---
   lines.push("", "Testing library");
-  const rntl = packageVersion(root, "@testing-library/react-native");
+  const rntl = packageVersion(resolveRoot, "@testing-library/react-native");
   if (!rntl) {
     warn(
       "@testing-library/react-native not found — optional, but required for render()/screen queries.",
@@ -206,7 +273,7 @@ export function runDoctor(root: string, nodeVersion: string = process.versions.n
 
   // --- Presets ---
   lines.push("", "Auto-detected presets");
-  const req = createRequire(path.join(root, "package.json"));
+  const req = createRequire(path.join(resolveRoot, "package.json"));
   const detected: string[] = [];
   for (const [pkg, preset] of Object.entries(AUTO_DETECT_PRESETS)) {
     try {
@@ -220,7 +287,7 @@ export function runDoctor(root: string, nodeVersion: string = process.versions.n
   else lines.push("  (none — no preset-covered packages installed)");
 
   // --- Expo ---
-  const expo = packageVersion(root, "expo");
+  const expo = packageVersion(resolveRoot, "expo");
   if (expo) {
     lines.push("", "Expo");
     warn(
@@ -232,11 +299,11 @@ export function runDoctor(root: string, nodeVersion: string = process.versions.n
 
   // --- Config ---
   lines.push("", "Config");
-  const configFile = findConfigFile(root);
+  const configFile = findConfigFile(resolveRoot);
   if (!configFile) {
     warn("no vitest.config.* found — run `vitest-native init` to create one.");
   } else {
-    const content = fs.readFileSync(path.join(root, configFile), "utf8");
+    const content = fs.readFileSync(path.join(resolveRoot, configFile), "utf8");
     const usage = analyzeConfigUsage(content);
     if (usage.imports && usage.invokes) {
       pass(`${configFile} uses vitest-native.`);
@@ -244,6 +311,15 @@ export function runDoctor(root: string, nodeVersion: string = process.versions.n
       warn(
         `${configFile} imports vitest-native but never calls reactNative() — ` +
           "the plugin is not in `plugins: [...]`, so React Native imports will not resolve.",
+      );
+    } else if (extendsSharedConfig(content)) {
+      // A workspace config that re-exports a shared preset cannot be judged from
+      // this file: the plugin is wired up in the package it imports. Saying it does
+      // not reference vitest-native is simply wrong, and was reported as a false
+      // positive from a monorepo doing exactly this.
+      lines.push(
+        `  · ${configFile} builds on a shared config, so this cannot tell from here ` +
+          "whether the plugin is wired up. Check the config it extends.",
       );
     } else {
       warn(

--- a/packages/vitest-native/src/cli/doctor.ts
+++ b/packages/vitest-native/src/cli/doctor.ts
@@ -150,9 +150,16 @@ export function analyzeConfigUsage(source: string): ConfigUsage {
  * real run finds it. The result was `doctor` reporting "engine 'auto' resolves to
  * MOCK" for a project whose run banner said native.
  *
- * Walking up to the nearest Vitest config matches what the run does, since that
- * file's directory is the root Vitest uses. The walk stops at a repository
- * boundary so it cannot wander out of the project.
+ * This is a FALLBACK, not a replacement. Node resolution walks upward, so the
+ * directory the command was invoked in already sees its own dependencies AND
+ * everything declared above it — resolving from higher up can only see less. Using
+ * the config root unconditionally lost dependencies a package declared itself, and
+ * reported a missing peer for a project that had one: the inverse of the bug this
+ * was written for.
+ *
+ * So the invocation directory is tried first, and this is consulted only when
+ * something fails to resolve there — which is the case where the command was run
+ * above the package that declares it.
  */
 export function resolutionRoot(start: string, exists = fs.existsSync): string {
   let dir = start;
@@ -185,13 +192,13 @@ export function runDoctor(root: string, nodeVersion: string = process.versions.n
     lines.push(`  ✗ ${s}`);
   };
 
-  // Peers and engine detection resolve from where the run would, not from wherever
-  // the command happened to be invoked.
-  const resolveRoot = resolutionRoot(root);
+  // Resolve from where the command was invoked, which sees the most; fall back to
+  // the directory holding the Vitest config when something is not visible there.
+  const configRoot = resolutionRoot(root);
+  const resolvesHere = (name: string): boolean => packageVersion(root, name) !== null;
+  const rootFor = (name: string): string =>
+    resolvesHere(name) || configRoot === root ? root : configRoot;
   lines.push(`vitest-native doctor — ${root}`);
-  if (resolveRoot !== root) {
-    lines.push(`  (resolving from ${resolveRoot}, where the Vitest config lives)`);
-  }
 
   // --- Runtime ---
   lines.push("", "Runtime");
@@ -203,15 +210,19 @@ export function runDoctor(root: string, nodeVersion: string = process.versions.n
   lines.push("", "Peer dependencies");
   for (const { name, minimum, maximumMajor, minimumByMajor, optional } of PEER_REQUIREMENTS) {
     if (optional) continue; // reported under "Testing library", and never blocking
-    const error = validatePeerDependency(name, minimum, resolveRoot, maximumMajor, minimumByMajor);
+    const from = rootFor(name);
+    const error = validatePeerDependency(name, minimum, from, maximumMajor, minimumByMajor);
     if (error) fail(error);
-    else pass(`${name} ${packageVersion(resolveRoot, name)}`);
+    else {
+      pass(`${name} ${packageVersion(from, name)}`);
+      if (from !== root) lines.push(`      (resolved from ${from}, not from here)`);
+    }
   }
 
   // --- Engine ---
   lines.push("", "Engine");
-  const rnVersion = packageVersion(resolveRoot, "react-native");
-  const decision = detectEngine("auto", resolveRoot);
+  const rnVersion = packageVersion(rootFor("react-native"), "react-native");
+  const decision = detectEngine("auto", rootFor("@react-native/babel-preset"));
   if (decision.engine === "native") {
     pass(
       `engine 'auto' resolves to NATIVE — real React Native${rnVersion ? ` ${rnVersion}` : ""} with @react-native/babel-preset + @babel/core present.`,
@@ -231,7 +242,10 @@ export function runDoctor(root: string, nodeVersion: string = process.versions.n
 
   // --- RNTL ---
   lines.push("", "Testing library");
-  const rntl = packageVersion(resolveRoot, "@testing-library/react-native");
+  const rntl = packageVersion(
+    rootFor("@testing-library/react-native"),
+    "@testing-library/react-native",
+  );
   if (!rntl) {
     warn(
       "@testing-library/react-native not found — optional, but required for render()/screen queries.",
@@ -273,7 +287,7 @@ export function runDoctor(root: string, nodeVersion: string = process.versions.n
 
   // --- Presets ---
   lines.push("", "Auto-detected presets");
-  const req = createRequire(path.join(resolveRoot, "package.json"));
+  const req = createRequire(path.join(root, "package.json"));
   const detected: string[] = [];
   for (const [pkg, preset] of Object.entries(AUTO_DETECT_PRESETS)) {
     try {
@@ -287,7 +301,7 @@ export function runDoctor(root: string, nodeVersion: string = process.versions.n
   else lines.push("  (none — no preset-covered packages installed)");
 
   // --- Expo ---
-  const expo = packageVersion(resolveRoot, "expo");
+  const expo = packageVersion(rootFor("expo"), "expo");
   if (expo) {
     lines.push("", "Expo");
     warn(
@@ -299,11 +313,11 @@ export function runDoctor(root: string, nodeVersion: string = process.versions.n
 
   // --- Config ---
   lines.push("", "Config");
-  const configFile = findConfigFile(resolveRoot);
+  const configFile = findConfigFile(configRoot);
   if (!configFile) {
     warn("no vitest.config.* found — run `vitest-native init` to create one.");
   } else {
-    const content = fs.readFileSync(path.join(resolveRoot, configFile), "utf8");
+    const content = fs.readFileSync(path.join(configRoot, configFile), "utf8");
     const usage = analyzeConfigUsage(content);
     if (usage.imports && usage.invokes) {
       pass(`${configFile} uses vitest-native.`);

--- a/packages/vitest-native/tests/doctor-monorepo.test.ts
+++ b/packages/vitest-native/tests/doctor-monorepo.test.ts
@@ -1,0 +1,105 @@
+/**
+ * `doctor` has to describe the run, not the directory it was typed in.
+ *
+ * Two false reports from a real monorepo migration:
+ *
+ *   - "engine 'auto' resolves to MOCK: @react-native/babel-preset ... do not
+ *     resolve" for a project whose run banner said native. Peers were resolved from
+ *     the working directory, and under pnpm a package's node_modules holds only its
+ *     DECLARED dependencies, so a hoisted preset does not resolve from there even
+ *     though the run finds it.
+ *   - "config does not reference vitest-native" for a config that imports a shared
+ *     preset which does. Such a file legitimately never mentions vitest-native, and
+ *     calling it unconfigured is a false alarm on a working project.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { extendsSharedConfig, resolutionRoot } from "../src/cli/doctor.js";
+
+const roots: string[] = [];
+afterAll(() => {
+  for (const r of roots) fs.rmSync(r, { recursive: true, force: true });
+});
+
+/** A workspace: repo root with a Vitest config, and a package below it without one. */
+function workspace(opts: { configAtRoot?: boolean; configInPackage?: boolean }): {
+  repo: string;
+  pkg: string;
+} {
+  const repo = fs.mkdtempSync(path.join(os.tmpdir(), "vn-doctor-mono-"));
+  roots.push(repo);
+  fs.mkdirSync(path.join(repo, ".git"), { recursive: true });
+  const pkg = path.join(repo, "packages", "app");
+  fs.mkdirSync(pkg, { recursive: true });
+  // A real workspace root has a manifest beside its config; that pairing is what
+  // marks a project root, so the walk does not accept a stray config above the repo.
+  fs.writeFileSync(path.join(repo, "package.json"), '{ "name": "repo" }');
+  fs.writeFileSync(path.join(pkg, "package.json"), '{ "name": "app" }');
+  if (opts.configAtRoot) fs.writeFileSync(path.join(repo, "vitest.config.ts"), "export default {}");
+  if (opts.configInPackage) {
+    fs.writeFileSync(path.join(pkg, "vitest.config.ts"), "export default {}");
+  }
+  return { repo, pkg };
+}
+
+describe("resolutionRoot", () => {
+  it("walks up to the directory holding the Vitest config", () => {
+    const { repo, pkg } = workspace({ configAtRoot: true });
+    expect(resolutionRoot(pkg)).toBe(repo);
+  });
+
+  it("prefers a config in the package itself", () => {
+    const { pkg } = workspace({ configAtRoot: true, configInPackage: true });
+    expect(resolutionRoot(pkg)).toBe(pkg);
+  });
+
+  it("stays put when there is no config anywhere", () => {
+    const { pkg } = workspace({});
+    expect(resolutionRoot(pkg)).toBe(pkg);
+  });
+
+  it("does not wander out of the repository", () => {
+    // The walk stops at the repository boundary rather than climbing into whatever
+    // happens to sit above the checkout.
+    const { repo, pkg } = workspace({});
+    fs.writeFileSync(path.join(path.dirname(repo), "vitest.config.ts"), "export default {}");
+    // No manifest beside it, so it is not a project root and is not adopted.
+    expect(resolutionRoot(pkg)).toBe(pkg);
+  });
+});
+
+describe("extendsSharedConfig", () => {
+  it("recognises a config re-exporting a shared one", () => {
+    expect(
+      extendsSharedConfig(`import base from "@scope/vitest-preset";\nexport default base;`),
+    ).toBe(true);
+  });
+
+  it("recognises a config merging a shared one", () => {
+    const source = `import { defineConfig, mergeConfig } from "vitest/config";
+import base from "@scope/vitest-preset";
+export default mergeConfig(base, defineConfig({ test: {} }));`;
+    expect(extendsSharedConfig(source)).toBe(true);
+  });
+
+  it("does not count a plain vitest import as extending anything", () => {
+    const source = `import { defineConfig } from "vitest/config";
+export default defineConfig({ test: {} });`;
+    expect(extendsSharedConfig(source)).toBe(false);
+  });
+
+  it("does not count an unrelated import that is never exported", () => {
+    const source = `import { defineConfig } from "vitest/config";
+import path from "node:path";
+export default defineConfig({ test: { root: path.resolve(".") } });`;
+    expect(extendsSharedConfig(source)).toBe(false);
+  });
+
+  it("ignores a commented-out shared import", () => {
+    const source = `// import base from "@scope/vitest-preset";
+export default {};`;
+    expect(extendsSharedConfig(source)).toBe(false);
+  });
+});

--- a/packages/vitest-native/tests/doctor-resolution-fallback.test.ts
+++ b/packages/vitest-native/tests/doctor-resolution-fallback.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Node resolution walks UPWARD, so the directory a command runs in already sees its
+ * own dependencies and everything declared above it. Resolving from higher up can
+ * only ever see less.
+ *
+ * An earlier version of this resolved unconditionally from the directory holding the
+ * Vitest config. That lost dependencies a package declared itself and reported a
+ * missing peer for a project that had one — the inverse of the bug it was written
+ * for, and caught only by constructing the layout and checking both directions.
+ *
+ * The config root is now consulted only when something does not resolve where the
+ * command was run, which is the case where it was invoked above the package that
+ * declares it.
+ */
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { resolutionRoot } from "../src/cli/doctor.js";
+
+const roots: string[] = [];
+afterAll(() => {
+  for (const r of roots) fs.rmSync(r, { recursive: true, force: true });
+});
+
+function workspace(depIn: "app" | "root"): { repo: string; app: string } {
+  const repo = fs.mkdtempSync(path.join(os.tmpdir(), "vn-fallback-"));
+  roots.push(repo);
+  fs.mkdirSync(path.join(repo, ".git"));
+  fs.writeFileSync(path.join(repo, "package.json"), '{"name":"repo"}');
+  fs.writeFileSync(path.join(repo, "vitest.config.ts"), "export default {}");
+  const app = path.join(repo, "packages", "app");
+  fs.mkdirSync(app, { recursive: true });
+  fs.writeFileSync(path.join(app, "package.json"), '{"name":"app"}');
+  const host = depIn === "app" ? app : repo;
+  const dep = path.join(host, "node_modules", "fake-dep");
+  fs.mkdirSync(dep, { recursive: true });
+  fs.writeFileSync(
+    path.join(dep, "package.json"),
+    '{"name":"fake-dep","version":"1.0.0","main":"i.js"}',
+  );
+  fs.writeFileSync(path.join(dep, "i.js"), "module.exports={};");
+  return { repo, app };
+}
+
+const resolves = (dir: string): boolean => {
+  try {
+    createRequire(path.join(dir, "package.json")).resolve("fake-dep");
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+describe("doctor resolution", () => {
+  it("sees a dependency the package declares itself", () => {
+    // The regression: resolutionRoot picks the repo root here, and the dep is NOT
+    // visible from there. Resolving from the invocation directory is what works.
+    const { repo, app } = workspace("app");
+    expect(resolutionRoot(app)).toBe(repo);
+    expect(resolves(app)).toBe(true);
+    expect(resolves(repo)).toBe(false);
+  });
+
+  it("sees a dependency declared above it, because resolution walks up", () => {
+    const { repo, app } = workspace("root");
+    expect(resolves(app)).toBe(true);
+    expect(resolves(repo)).toBe(true);
+  });
+
+  it("offers the config root for the case the invocation directory cannot see", () => {
+    // Running from the repo root cannot reach a dep declared in a package below:
+    // Node has no downward walk. That is the case the fallback exists for.
+    const { repo, app } = workspace("app");
+    expect(resolves(repo)).toBe(false);
+    expect(resolutionRoot(app)).toBe(repo);
+  });
+});


### PR DESCRIPTION
Reported item **#5**, both halves.

## Wrong engine

> *`npx vitest-native doctor` printed `engine 'auto' resolves to MOCK: @react-native/babel-preset ... do not resolve` for a package where the actual run banner showed native.*

Peers and engine detection resolved from the **working directory**. In a workspace that's frequently not where the Vitest config lives, and under pnpm a package's `node_modules` holds only its *declared* dependencies — so a hoisted `@react-native/babel-preset` doesn't resolve from the package even though the run finds it.

Resolution now walks to the nearest directory holding **both a Vitest config and a manifest**, which is the root a run uses. The report says so when that differs from where the command was typed.

Both halves of that pairing were learned from failing tests, not reasoned out:

- **Requiring a manifest** stops a stray config above the checkout being adopted. Without it, fixtures under the system temp directory resolved against whatever sat above them — which broke two existing tests.
- **Walking through directories without one** is what lets a real `packages/app` reach its workspace root. My first bound stopped at any directory lacking a manifest, which is exactly what `packages/` looks like.

## False "config does not reference vitest-native"

> *Also emits a false-positive `config does not reference vitest-native` when the config imports a shared preset that references it.*

Such a config legitimately never mentions vitest-native — the plugin is wired up in the package it extends. That case is now **described** rather than warned about, since this genuinely cannot tell from the file alone.

The detection requires the imported binding to *be* the exported config (`export default base`) or the base being merged (`mergeConfig(base, …)`), not merely to appear on the export line.

## A guard I removed

I excluded `node:` builtins from that detection. Its control **passed** — meaning the tightened check already covered it and no test could justify the code. Removed rather than kept as decoration.

## Verification

mock **1556** / 3 skipped · native 198 · lint + typecheck + format + check:size clean. 9 new tests; controls: never finding a config fails 1, removing the repository boundary fails 2.

Budget ceilings match #114/#117 so the branches don't drift.