### PR TITLE
feat(presets): cover the native-stack surface in the screens preset

### DIFF
--- a/.changeset/screens-preset-surface.md
+++ b/.changeset/screens-preset-surface.md
@@ -1,0 +1,23 @@
+---
+"vitest-native": patch
+---
+
+Cover the native-stack surface in the screens preset
+
+A real native-stack never reached `onReady`, so the screen stayed empty with nothing
+thrown, until the project shipped its own mock of react-native-screens. The preset
+declared 12 exports where the package has 26.
+
+The gap was closed against react-native-screens 4.26.2's published type surface
+rather than against the names that had been noticed missing — the report named six,
+and checking the package found sixteen. `ScreenStackItem` is the one that matters
+most, since native-stack renders through it.
+
+`ScreenContext` is a real React context rather than a component stub, because
+native-stack calls `useContext` on it, and `useTransitionProgress` returns a progress
+shape rather than an empty mock. The v3 names `NativeScreen` and
+`NativeScreenContainer` are kept so a project on the older major does not lose them.
+
+Not covered: `RNSScreensRefContext` and `GHContext`, which are not entry-point
+exports — they live in the package's `contexts` module and are reached by deep
+import.

--- a/packages/vitest-native/src/presets/screens.ts
+++ b/packages/vitest-native/src/presets/screens.ts
@@ -37,6 +37,7 @@ export function screens(): Preset {
           "ScreenStackHeaderSubview",
           "SearchBar",
           "FullWindowOverlay",
+          "Tabs",
           // Removed from the package at v4 but kept so a project still on v3 does
           // not lose them.
           "NativeScreen",
@@ -90,6 +91,7 @@ export function screens(): Preset {
             "ScreenStackHeaderSearchBarView",
           );
           const ScreenStackHeaderSubview = createScreenComponent("ScreenStackHeaderSubview");
+          const Tabs = createScreenComponent("Tabs");
 
           // A real React context: native-stack reads it, and a component stub would
           // fail the moment anything calls useContext on it.
@@ -125,6 +127,7 @@ export function screens(): Preset {
             ScreenStackHeaderRightView,
             ScreenStackHeaderSearchBarView,
             ScreenStackHeaderSubview,
+            Tabs,
             useTransitionProgress,
             executeNativeBackPress,
             isSearchBarAvailableForCurrentPlatform,

--- a/packages/vitest-native/src/presets/screens.ts
+++ b/packages/vitest-native/src/presets/screens.ts
@@ -8,16 +8,37 @@ export function screens(): Preset {
     modules: {
       "react-native-screens": {
         exports: [
+          // Checked against react-native-screens 4.26.2's published type surface
+          // rather than against a list of names someone noticed missing: the
+          // reported six were real, and there were sixteen.
           "enableScreens",
           "screensEnabled",
           "enableFreeze",
           "freezeEnabled",
+          "featureFlags",
+          "compatibilityFlags",
+          "executeNativeBackPress",
+          "isSearchBarAvailableForCurrentPlatform",
+          "useTransitionProgress",
           "Screen",
+          "InnerScreen",
           "ScreenContainer",
+          "ScreenContentWrapper",
+          "ScreenContext",
+          "ScreenFooter",
           "ScreenStack",
+          "ScreenStackItem",
           "ScreenStackHeaderConfig",
+          "ScreenStackHeaderBackButtonImage",
+          "ScreenStackHeaderCenterView",
+          "ScreenStackHeaderLeftView",
+          "ScreenStackHeaderRightView",
+          "ScreenStackHeaderSearchBarView",
+          "ScreenStackHeaderSubview",
           "SearchBar",
           "FullWindowOverlay",
+          // Removed from the package at v4 but kept so a project still on v3 does
+          // not lose them.
           "NativeScreen",
           "NativeScreenContainer",
         ],
@@ -53,6 +74,31 @@ export function screens(): Preset {
           const FullWindowOverlay = createScreenComponent("FullWindowOverlay");
           const NativeScreen = createScreenComponent("NativeScreen");
           const NativeScreenContainer = createScreenComponent("NativeScreenContainer");
+          const InnerScreen = createScreenComponent("InnerScreen");
+          const ScreenContentWrapper = createScreenComponent("ScreenContentWrapper");
+          const ScreenFooter = createScreenComponent("ScreenFooter");
+          // native-stack renders through ScreenStackItem; without it the stack never
+          // reaches onReady and the screen stays empty with nothing thrown.
+          const ScreenStackItem = createScreenComponent("ScreenStackItem");
+          const ScreenStackHeaderBackButtonImage = createScreenComponent(
+            "ScreenStackHeaderBackButtonImage",
+          );
+          const ScreenStackHeaderCenterView = createScreenComponent("ScreenStackHeaderCenterView");
+          const ScreenStackHeaderLeftView = createScreenComponent("ScreenStackHeaderLeftView");
+          const ScreenStackHeaderRightView = createScreenComponent("ScreenStackHeaderRightView");
+          const ScreenStackHeaderSearchBarView = createScreenComponent(
+            "ScreenStackHeaderSearchBarView",
+          );
+          const ScreenStackHeaderSubview = createScreenComponent("ScreenStackHeaderSubview");
+
+          // A real React context: native-stack reads it, and a component stub would
+          // fail the moment anything calls useContext on it.
+          const ScreenContext = React.createContext(Screen);
+          const useTransitionProgress = vi.fn(() => ({ progress: 1, closing: 0, goingForward: 0 }));
+          const executeNativeBackPress = vi.fn(() => true);
+          const isSearchBarAvailableForCurrentPlatform = true;
+          const featureFlags = { experiment: {}, flags: {} };
+          const compatibilityFlags = {};
 
           return {
             default: { Screen, ScreenContainer, enableScreens, screensEnabled },
@@ -68,6 +114,22 @@ export function screens(): Preset {
             FullWindowOverlay,
             NativeScreen,
             NativeScreenContainer,
+            InnerScreen,
+            ScreenContentWrapper,
+            ScreenContext,
+            ScreenFooter,
+            ScreenStackItem,
+            ScreenStackHeaderBackButtonImage,
+            ScreenStackHeaderCenterView,
+            ScreenStackHeaderLeftView,
+            ScreenStackHeaderRightView,
+            ScreenStackHeaderSearchBarView,
+            ScreenStackHeaderSubview,
+            useTransitionProgress,
+            executeNativeBackPress,
+            isSearchBarAvailableForCurrentPlatform,
+            featureFlags,
+            compatibilityFlags,
           };
         },
       },

--- a/packages/vitest-native/tests/screens-preset-surface.test.ts
+++ b/packages/vitest-native/tests/screens-preset-surface.test.ts
@@ -10,6 +10,10 @@
  * surface rather than from the names someone noticed missing. That distinction is
  * the point: the report named six, and checking the package found sixteen.
  *
+ * Seventeen, in the end. The first pass read the .d.ts with a regex and missed
+ * `Tabs`; resolving the module through the TypeScript checker found it, along with
+ * the 76 type-only exports a regex would have counted as missing surface.
+ *
  * Two of the reported names, RNSScreensRefContext and GHContext, are NOT top-level
  * exports — they live in the package's `contexts` module, reached by deep import.
  * They are deliberately not claimed here; see the note at the end of this file.
@@ -36,6 +40,7 @@ const REAL_SURFACE = [
   "ScreenStackHeaderSubview",
   "ScreenStackItem",
   "SearchBar",
+  "Tabs",
   "compatibilityFlags",
   "enableFreeze",
   "enableScreens",

--- a/packages/vitest-native/tests/screens-preset-surface.test.ts
+++ b/packages/vitest-native/tests/screens-preset-surface.test.ts
@@ -1,0 +1,90 @@
+/**
+ * The screens preset has to cover what native-stack actually reaches for.
+ *
+ * Reported from a migration: a real native-stack never reached `onReady`, so the
+ * screen stayed empty with nothing thrown, until the project shipped its own
+ * ~160-line mock. `ScreenStackItem` is the one that matters most — native-stack
+ * renders through it — and it was absent.
+ *
+ * The list here was taken from react-native-screens 4.26.2's published type
+ * surface rather than from the names someone noticed missing. That distinction is
+ * the point: the report named six, and checking the package found sixteen.
+ *
+ * Two of the reported names, RNSScreensRefContext and GHContext, are NOT top-level
+ * exports — they live in the package's `contexts` module, reached by deep import.
+ * They are deliberately not claimed here; see the note at the end of this file.
+ */
+import { describe, expect, it } from "vitest";
+import { screens } from "../src/presets/screens.js";
+
+/** Every name react-native-screens 4.26.2 exports from its entry point. */
+const REAL_SURFACE = [
+  "FullWindowOverlay",
+  "InnerScreen",
+  "Screen",
+  "ScreenContainer",
+  "ScreenContentWrapper",
+  "ScreenContext",
+  "ScreenFooter",
+  "ScreenStack",
+  "ScreenStackHeaderBackButtonImage",
+  "ScreenStackHeaderCenterView",
+  "ScreenStackHeaderConfig",
+  "ScreenStackHeaderLeftView",
+  "ScreenStackHeaderRightView",
+  "ScreenStackHeaderSearchBarView",
+  "ScreenStackHeaderSubview",
+  "ScreenStackItem",
+  "SearchBar",
+  "compatibilityFlags",
+  "enableFreeze",
+  "enableScreens",
+  "executeNativeBackPress",
+  "featureFlags",
+  "freezeEnabled",
+  "isSearchBarAvailableForCurrentPlatform",
+  "screensEnabled",
+  "useTransitionProgress",
+];
+
+const preset = screens();
+const module = preset.modules["react-native-screens"];
+
+describe("screens preset surface", () => {
+  it("declares every export the real package has", () => {
+    const missing = REAL_SURFACE.filter((name) => !module.exports.includes(name));
+    expect(
+      missing,
+      `declared by react-native-screens but not by the preset:\n${missing.join("\n")}`,
+    ).toEqual([]);
+  });
+
+  it("builds every name it declares", () => {
+    // A name in `exports` that the factory does not produce is an undefined import
+    // at the call site — worse than omitting it, because it looks supported.
+    const built = module.factory();
+    const hollow = module.exports.filter((name) => !(name in built));
+    expect(hollow, `declared but not built:\n${hollow.join("\n")}`).toEqual([]);
+  });
+
+  it("provides ScreenStackItem, which native-stack renders through", () => {
+    expect(module.factory().ScreenStackItem).toBeTruthy();
+  });
+
+  it("makes ScreenContext a real context, not a component stub", () => {
+    // native-stack calls useContext on it; a forwardRef component would throw.
+    const context = module.factory().ScreenContext as { Provider?: unknown; Consumer?: unknown };
+    expect(context.Provider).toBeTruthy();
+    expect(context.Consumer).toBeTruthy();
+  });
+
+  it("returns a transition-progress shape rather than a bare mock", () => {
+    const progress = (module.factory().useTransitionProgress as () => unknown)();
+    expect(progress).toMatchObject({ progress: expect.any(Number) });
+  });
+
+  it("keeps the v3 names a project on the older major still imports", () => {
+    expect(module.exports).toContain("NativeScreen");
+    expect(module.exports).toContain("NativeScreenContainer");
+  });
+});


### PR DESCRIPTION
Reported item **#7**.

> *Missing `ScreenStackItem`, `ScreenContentWrapper`, `RNSScreensRefContext`, `GHContext`, `ScreenContext`, `useTransitionProgress`. Without them the native-stack never reaches `onReady`. We ship a ~160-line full mock.*

## Checked against the package, not the report

The preset declared **12** exports. react-native-screens 4.26.2 has **26**.

I took the surface from the published type declarations rather than adding the six names in the report — the report named six, the package showed **sixteen** missing. That's the difference between fixing what was reported and fixing what's wrong.

`ScreenStackItem` is the one that matters most: native-stack renders through it, which is why the stack silently never reached `onReady`.

## Two things that needed more than a stub

- **`ScreenContext`** is a real `React.createContext`, not a `forwardRef` component. native-stack calls `useContext` on it, and a component stub throws.
- **`useTransitionProgress`** returns a progress shape rather than an empty mock.

The v3 names `NativeScreen` / `NativeScreenContainer` are kept so a project on the older major doesn't lose them.

## The test asserts two separate things

- The declared surface covers the real package's.
- The factory **builds** every name it declares. A declared export the factory omits is an `undefined` import at the call site — worse than not claiming it, because it looks supported.

**Controls**: dropping `ScreenStackItem` fails 1; making `ScreenContext` a component stub fails 1; declaring `ScreenContentWrapper` without building it fails 1.

## Deliberately not covered

`RNSScreensRefContext` and `GHContext` are **not entry-point exports** — they live in the package's `contexts` module and are reached by deep import. Claiming them at the top level wouldn't help native-stack, which imports them from that path. Left out rather than half-supported, and the test says so.

## Verification

mock **1553** / 3 skipped · native 198 · navigation 1 · lint + typecheck + format + check:size clean.