### PR TITLE
fix(jest-compat): apply mock interop to an async factory's resolved module

### DIFF
--- a/.changeset/jest-mock-async-factory.md
+++ b/.changeset/jest-mock-async-factory.md
@@ -1,0 +1,23 @@
+---
+"vitest-native": patch
+---
+
+`jest.mock` with an async factory keeps its named exports
+
+`jestMockTransform()` wraps each `jest.mock` factory so its return passes through
+Jest's CommonJS interop. The wrapper handled a synchronous return only. An async
+factory — or any factory returning a promise — handed the promise itself to the
+interop, where it matched the object branch: a promise has no own enumerable keys and
+no `default`, so the result was `{ default: Promise }`. Every named export
+disappeared, and the failure surfaced as
+
+    No "readSetting" export is defined on the "./settings-store" mock.
+    Did you forget to return it from "vi.mock"?
+
+naming a `vi.mock` the author never wrote.
+
+Interop now applies to the resolved module. The check is by object tag rather than for
+a `then` method: a module may legitimately export a function named `then`, and
+awaiting that calls it with `(resolve, reject)` and never settles, hanging the test
+file instead of failing it. `async` functions and `Promise.resolve` only ever produce
+native promises, which the tag identifies across realms.

--- a/packages/vitest-native/src/jest-compat/interop.mjs
+++ b/packages/vitest-native/src/jest-compat/interop.mjs
@@ -16,6 +16,21 @@
 // returns (those with `__esModule` or an explicit `default`) untouched.
 export function jestMockInterop(mod) {
   if (mod == null) return mod;
+  // An async factory — or any factory returning a promise — resolves to the module
+  // shape, so interop applies to the resolved value. Vitest awaits a factory result,
+  // so handing the promise back is enough. Without this the promise itself fell into
+  // the object branch below, where it has no own enumerable keys and no `default`,
+  // producing `{ default: Promise }`: every named export vanished and Vitest reported
+  // `No "x" export is defined on the mock` about a vi.mock the author never wrote.
+  //
+  // Tested by tag rather than by a `then` method: a module may legitimately export a
+  // function named `then`, and awaiting that calls it with (resolve, reject) and never
+  // settles — a hung test file, which is worse than the bug this fixes. The tag holds
+  // for native promises from any realm, and `async` functions and `Promise.resolve`
+  // only ever produce those.
+  if (Object.prototype.toString.call(mod) === "[object Promise]") {
+    return mod.then(jestMockInterop);
+  }
   const t = typeof mod;
   if (t === "object" || t === "function") {
     // Already ES-shaped — respect the author's/real module's default export.

--- a/packages/vitest-native/tests-native/fixtures/greeter2.ts
+++ b/packages/vitest-native/tests-native/fixtures/greeter2.ts
@@ -1,0 +1,2 @@
+// Fixture for the promise-returning jest.mock factory case.
+export const greet = () => "real-hello-2";

--- a/packages/vitest-native/tests-native/fixtures/settings-store.ts
+++ b/packages/vitest-native/tests-native/fixtures/settings-store.ts
@@ -1,0 +1,4 @@
+// Two named exports so an async-factory mock can keep one real and replace the
+// other — the shape a migrated suite reaches for when it needs requireActual.
+export const readSetting = () => "real-setting";
+export const writeSetting = () => "real-write";

--- a/packages/vitest-native/tests-native/jest-mock-hoist.test.tsx
+++ b/packages/vitest-native/tests-native/jest-mock-hoist.test.tsx
@@ -18,9 +18,30 @@ jest.mock("./fixtures/widget", () => () => "mocked-widget");
 // exports object the default; plain Vitest would give `undefined`.
 jest.mock("./fixtures/api", () => ({ get: () => "mocked-get" }));
 
+// (4) ASYNC factory. Not a Jest idiom — Jest never awaits a factory — but the shape a
+// partially-migrated suite reaches for, and one Vitest supports. The interop wrapper
+// received the promise itself, which has no own enumerable keys and no `default`, so
+// it produced `{ default: Promise }`: every named export disappeared and Vitest
+// reported `No "readSetting" export is defined on the mock`, naming a vi.mock the
+// author never wrote.
+// Deliberately no `jest.requireActual` here: relative requireActual resolution is a
+// separate change, and pairing the two would make this case untestable without it.
+// Worth revisiting once that lands — a hoisted factory's call stack need not contain
+// the test file, which is what caller-relative resolution depends on.
+jest.mock("./fixtures/settings-store", async () => ({
+  readSetting: () => "async-read",
+  writeSetting: () => "mocked-write",
+}));
+
+// (5) A factory that returns a promise without being declared async — the same
+// failure, undetectable from the AST, so the fix has to be at run time.
+jest.mock("./fixtures/greeter2", () => Promise.resolve({ greet: () => "promised-hello" }));
+
 import { greet } from "./fixtures/greeter";
 import Widget from "./fixtures/widget";
 import api from "./fixtures/api";
+import { readSetting, writeSetting } from "./fixtures/settings-store";
+import { greet as greet2 } from "./fixtures/greeter2";
 
 describe("jest.mock hoisting + CJS interop (jestMockTransform)", () => {
   it("applies a top-level jest.mock to a module imported below it", () => {
@@ -34,5 +55,14 @@ describe("jest.mock hoisting + CJS interop (jestMockTransform)", () => {
 
   it("a named-only factory return is usable via the default import (Jest CJS interop)", () => {
     expect((api as { get: () => string }).get()).toBe("mocked-get");
+  });
+
+  it("an async factory keeps its named exports", () => {
+    expect(writeSetting()).toBe("mocked-write");
+    expect(readSetting()).toBe("async-read");
+  });
+
+  it("a factory returning a promise resolves the same way", () => {
+    expect(greet2()).toBe("promised-hello");
   });
 });

--- a/packages/vitest-native/tests/jest-compat.test.ts
+++ b/packages/vitest-native/tests/jest-compat.test.ts
@@ -100,6 +100,32 @@ describe("jest-compat: jestMockInterop (CJS interop semantics)", () => {
     expect(jestMockInterop(null)).toBeNull();
     expect(jestMockInterop(undefined)).toBeUndefined();
   });
+
+  it("applies interop to a promised module rather than to the promise", async () => {
+    // A promise has no own enumerable keys and no `default`, so the object branch
+    // turned it into `{ default: Promise }` — the named exports disappeared and
+    // Vitest reported them missing from a vi.mock the author never wrote.
+    const exports = { a: 1 };
+    const ns = await jestMockInterop(Promise.resolve(exports));
+    expect(ns.a).toBe(1);
+    expect(ns.default).toBe(exports);
+  });
+
+  it("leaves an already-ES-shaped promised module alone", async () => {
+    const esm = { __esModule: true, default: "d", a: 1 };
+    expect(await jestMockInterop(Promise.resolve(esm))).toBe(esm);
+  });
+
+  it("does not mistake a module exporting `then` for a promise", () => {
+    // Both shapes matter, and the function one is the dangerous half: awaiting a
+    // thenable calls then(resolve, reject), which for an ordinary exported function
+    // never settles — the file would hang instead of failing.
+    for (const m of [{ then: 42 }, { then: () => "not a promise" }]) {
+      const ns = jestMockInterop(m);
+      expect(ns.then).toBe(m.then);
+      expect(ns.default).toBe(m);
+    }
+  });
 });
 
 describe("jest-compat: helper", () => {


### PR DESCRIPTION
## The bug

`jestMockTransform()` wraps every `jest.mock` factory so its return passes through Jest's CommonJS interop. The wrapper handled a synchronous return only.

An async factory — or any factory returning a promise — handed the **promise itself** to the interop. A promise has no own enumerable keys and no `default`, so it matched the plain-object branch and came out as `{ default: Promise }`. Every named export disappeared:

```
No "readSetting" export is defined on the "./settings-store" mock.
Did you forget to return it from "vi.mock"?
```

The message names a `vi.mock` the author never wrote, and points at the one thing that is not wrong.

Not a Jest idiom — Jest never awaits a factory — but it is the shape a partially-migrated suite reaches for, and one Vitest supports.

## The fix

Interop applies to the resolved module: `mod.then(jestMockInterop)`. Vitest awaits a factory result, so returning the promise is enough.

The promise check is **by object tag, not by the presence of a `then` method**. A module may legitimately export a function named `then`, and awaiting a thenable calls it with `(resolve, reject)` — for an ordinary exported function that never settles, so the test file would hang rather than fail. That is worse than the bug being fixed. `async` functions and `Promise.resolve` only ever produce native promises, which `Object.prototype.toString` identifies across realms.

## Coverage

Unit, on the interop helper: a promised module, an already-ES-shaped promised module, and both `then`-exporting shapes.

Integration, in the hoisting suite: a declared-`async` factory, and one returning a promise **without** being declared async — the second because it cannot be detected from the AST, which is why the fix belongs at run time rather than in the transform.

## Verification

| Injected | Result |
| --- | --- |
| promise branch removed | both integration cases fail with the original `No "x" export is defined` error |
| tag check loosened to `typeof mod.then === "function"` | the `then`-exporting unit case fails |

Suites: 1550 mock, 200 native. Lint, format, typecheck and the size budget pass.

## Note

The async case deliberately does **not** use `jest.requireActual`, though that is how a real migration would write it. Relative `requireActual` resolution is a separate open change, and pairing the two would make this case untestable without it. Worth revisiting once that lands: a hoisted factory's call stack need not contain the test file, which is what caller-relative resolution depends on.