### PR TITLE
test(native): make the ecosystem mock-scope test able to fail

### DIFF
--- a/packages/vitest-native/tests-native/ecosystem-inline.test.tsx
+++ b/packages/vitest-native/tests-native/ecosystem-inline.test.tsx
@@ -1,33 +1,46 @@
 import { describe, it, expect, vi } from "vitest";
-import { Banner, renderCount } from "rn-ecosystem-lib";
+import { Banner, renderCount, platformSeen } from "rn-ecosystem-lib";
 import { render, screen } from "@testing-library/react-native";
 
 // rn-ecosystem-lib is published the way most of the React Native ecosystem
 // publishes: untranspiled JSX in CommonJS, assuming Metro will compile it, with
 // react-native declared in its own manifest. Nothing in this project's config
-// mentions it — being auto-detected and inlined is the whole point.
+// mentions it — being auto-detected is the whole point.
 vi.mock("rn-ecosystem-lib", async (importOriginal) => {
   const actual = await importOriginal<typeof import("rn-ecosystem-lib")>();
   return { ...actual, renderCount: () => 4242 };
 });
 
+// React Native itself, mocked with a distinguishable Platform.OS. The test graph
+// reaches RN through a facade module the plugin owns, which is what makes this
+// interceptable at all; the library reaches it by require() and does not.
+vi.mock("react-native", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-native")>();
+  return { ...actual, Platform: { ...actual.Platform, OS: "mocked-os" } };
+});
+
 describe("auto-detected React Native packages", () => {
   it("compiles and runs untranspiled ecosystem source with no configuration", async () => {
     await render(<Banner label="hello" />);
-    // Real React Native rendered it — the package is inlined, not stubbed.
+    // Real React Native rendered it — the package is compiled, not stubbed.
     expect(screen.getByTestId("banner").type).toBe("RCTView");
     expect(screen.getByText("hello")).toBeTruthy();
   });
 
-  it("is reachable by vi.mock, which externalized packages are not", () => {
+  it("is reachable by vi.mock", () => {
     expect(renderCount()).toBe(4242);
   });
 
   it("still sees the real React Native even when the test mocks it", async () => {
     // Documented scope: mocking react-native rewrites what the TEST graph imports.
-    // An inlined package's own imports compile to require(), which reaches React
-    // Native directly — so a library never observes the test's mock.
+    // The library's own imports compile to require(), which reaches React Native
+    // directly — so a library never observes the test's mock.
+    //
+    // This assertion used to read `Platform.OS === "ios"` with nothing in the file
+    // mocking react-native at all, so it could not fail from the behaviour its own
+    // name describes. The two views are now distinguishable at run time.
     const { Platform } = await import("react-native");
-    expect(Platform.OS).toBe("ios");
+    expect(Platform.OS).toBe("mocked-os");
+    expect(platformSeen()).toBe("ios");
   });
 });

--- a/packages/vitest-native/tests-native/fixtures/rn-ecosystem-lib/index.js
+++ b/packages/vitest-native/tests-native/fixtures/rn-ecosystem-lib/index.js
@@ -4,7 +4,7 @@
 // what makes it auto-detectable.
 // eslint-disable-next-line no-unused-vars -- the JSX below compiles to React.createElement
 const React = require("react");
-const { View, Text } = require("react-native");
+const { View, Text, Platform } = require("react-native");
 
 let renders = 0;
 
@@ -18,4 +18,7 @@ module.exports = {
     );
   },
   renderCount: () => renders,
+  // Reports the Platform.OS this library sees, so a test can tell the library's own
+  // view of React Native apart from the test graph's.
+  platformSeen: () => Platform.OS,
 };


### PR DESCRIPTION
## The vacuous case

`tests-native/ecosystem-inline.test.tsx` contained:

```ts
it("still sees the real React Native even when the test mocks it", async () => {
  // Documented scope: mocking react-native rewrites what the TEST graph imports.
  // An inlined package's own imports compile to require(), which reaches React
  // Native directly — so a library never observes the test's mock.
  const { Platform } = await import("react-native");
  expect(Platform.OS).toBe("ios");
});
```

Nothing in the file mocked `react-native` — the only `vi.mock` targeted `rn-ecosystem-lib`. So the assertion read `Platform.OS === "ios"` with no mock in play, and could not fail from the behaviour its own name describes. It documented a scope boundary while testing nothing about it.

The file now mocks `react-native` with a distinguishable `Platform.OS`, and the fixture reports the value it sees, so the two views are separable at run time:

- the test graph reads `"mocked-os"` — it reaches RN through the facade module the plugin owns, which is what makes the mock interceptable at all
- the library reads `"ios"` — its own `require` bypasses the facade

## The false claim

A second case was titled `is reachable by vi.mock, which externalized packages are not`.

The parenthetical is not true. A test-graph `vi.mock` of an externalized, non-RN dependency **does** intercept — measured against an installed fixture that declares no `react-native` and is therefore neither auto-detected nor inlined. The mocked module arrived with all its keys.

What an externalized package does not observe is a mock of something **it** requires, which is exactly the distinction the third case now tests. The claim is dropped from the title rather than restated, since that case only establishes reachability.

## Verification

| Injected | Result |
| --- | --- |
| `vi.mock("react-native", …)` removed (the original state of the file) | fails: `expected 'ios' to be 'mocked-os'` |
| assert the library observes the test's mock | fails |

Suites: 1547 mock, 198 native. Lint, format and typecheck pass.

## Note

Editing a `file:` dependency fixture requires clearing bun's copy of it from the store and reinstalling — the installed copy is a snapshot, not a link, so an edit is otherwise invisible locally. CI is unaffected, since it installs fresh.