### PR TITLE
fix(ci): repair two upstream-drift failures on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,17 @@ jobs:
       - name: Test example app
         run: bun run test:example
 
+      # The consumer gate installs each fixture with npm. Node 22.13.0 bundles npm
+      # 10.9.2, whose arborist crashes with "Cannot read properties of null (reading
+      # 'edgesOut')" on these fixtures' dependency graphs. It is not this package:
+      # a fixture with vitest-native removed entirely crashes the same way, and the
+      # commit that passed on 2026-07-27 fails on re-run with no code change, so a
+      # republished transitive dependency started tripping the bug. npm 11 installs
+      # all of them.
+      - name: Use an npm without the arborist edgesOut bug
+        if: runner.os == 'Linux' && matrix.node-version == '22.13.0'
+        run: npm install -g npm@11
+
       - name: Test packed consumer projects
         if: runner.os == 'Linux' && matrix.node-version == '22.13.0'
         run: bun run test:consumers

--- a/packages/vitest-native/scripts/test-hot-soak.mjs
+++ b/packages/vitest-native/scripts/test-hot-soak.mjs
@@ -74,11 +74,22 @@ export default defineConfig({
 
 function runVitest(label, configName) {
   const startedAt = performance.now();
-  const result = spawnSync(process.execPath, [vitestEntry, "run", "--config", configName], {
-    cwd: generatedRoot,
-    encoding: "utf8",
-    env: process.env,
-  });
+  // Run FROM the package root, which is also the `root` the generated config sets.
+  // The two used to disagree — cwd was the generated directory — and the include
+  // globs are written relative to the package root, so they only matched because
+  // Vitest 4 resolved them against the configured `root`. Vitest 5.0.0-beta.7
+  // resolves them against the working directory instead, which made every generated
+  // file invisible: "No test files found", on a floating `vitest@beta` leg, with no
+  // change on our side. Keeping cwd and root the same is correct under both.
+  const result = spawnSync(
+    process.execPath,
+    [vitestEntry, "run", "--config", path.join(generatedName, configName)],
+    {
+      cwd: packageRoot,
+      encoding: "utf8",
+      env: process.env,
+    },
+  );
   const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
   process.stdout.write(output);
   if (result.error) throw result.error;


### PR DESCRIPTION
`main` is red on two unrelated counts. **Neither is caused by a change in this repository** — both were confirmed by re-running unchanged code.

## 1. Hot soak — `vitest@beta` moved

Both `native+hot — vitest v5` matrix legs fail with:

```
No test files found, exiting with code 1
include: .vitest-native-hot-soak-2514/long/*.test.ts
```

Those legs install `vitest@beta` unpinned. The last green matrix run used **5.0.0-beta.6**; the failing runs use **5.0.0-beta.7**.

The soak generates test files under the package root, writes configs that set `root` to the package root, and ran vitest with `cwd` set to the *generated* directory. The include globs are relative to the package root, so they matched only because Vitest 4 resolves them against the configured `root`. Beta.7 resolves them against the working directory. Vitest's own banner shows the switch:

```
RUN  v5.0.0-beta.7  .../packages/vitest-native/.vitest-native-hot-soak-69263   ← the package root under v4
```

The harness was depending on which of the two Vitest happened to pick. Running from the package root makes `cwd` and the declared `root` the same, which is unambiguous under either.

| Vitest | Result |
| --- | --- |
| 5.0.0-beta.7, before | `No test files found`, exit 1 |
| 5.0.0-beta.7, after | 100 files share one worker; recycling gives 12 boots; inert limit warns |
| 4.1.9, after | same three outcomes |

The leg stays floating on purpose. Catching a Vitest 5 behaviour change before release is its entire job, and it did that here — the defect it surfaced was ours. Pinning would have hidden a real incompatibility.

## 2. Consumer gate — npm's arborist

The Full gate fails at `test:consumers`:

```
npm error Cannot read properties of null (reading 'edgesOut')
```

Node 22.13.0 bundles npm 10.9.2, and that version now crashes on these fixtures' dependency graphs.

Two controls establish it is not this package:

- **A copy of the `bare` fixture with `vitest-native` removed entirely crashes identically** under npm 10.9.2. The gate's own subject is not involved.
- **The commit that passed on 2026-07-27 fails on re-run**, same SHA, no code change. So a republished transitive dependency started tripping a latent npm bug.

npm 11 installs every fixture (432 packages, no error), so the gate now uses it. Reproduced locally against 10.9.2 and confirmed against 11, both with and without the packed tarball.

## Why this matters beyond the fix

Both failures landed on `main` between a green run and the next push, from dependencies nothing in this repository pins: an unpinned prerelease and the npm bundled with a pinned Node. The first was worth having — that leg exists to find exactly this. The second was pure noise against a gate whose subject was not involved, which is why the diagnosis is recorded in the workflow next to the remedy.