### PR TITLE
fix(native): detect the packages a workspace member declares

### DIFF
--- a/.changeset/workspace-member-detection.md
+++ b/.changeset/workspace-member-detection.md
@@ -1,0 +1,25 @@
+---
+"vitest-native": patch
+---
+
+Auto-detection sees workspace members, so running from a monorepo root works
+
+Package auto-detection walked manifests upwards from the run root. In a workspace the
+run root is frequently *above* the package under test — Nx invokes tasks from the
+workspace root, and Vitest's root follows the working directory — so the app's own
+dependencies live in a manifest that walking up never reaches.
+
+A workspace library therefore missed detection, stayed in Vite's graph while Node
+loaded it too, and came apart into two module instances with separate module-level
+state. Reproduced in a pnpm workspace: the same config and the same code passed from
+the app directory and failed from the workspace root, with state written through one
+graph reading back unset through the other.
+
+Detection now also reads the manifests of workspace members declared by any manifest
+it finds, including pnpm's separate `pnpm-workspace.yaml` list, and resolves each
+candidate from whichever of those directories can see it — necessary under pnpm,
+where a workspace package is linked only into the package that depends on it.
+
+The consumer gate now runs the monorepo fixture from the workspace root as well as
+from the app directory, so the invocation that exposed this is covered rather than
+assumed.

--- a/packages/vitest-native/consumer-tests/monorepo/package.json
+++ b/packages/vitest-native/consumer-tests/monorepo/package.json
@@ -7,7 +7,8 @@
   ],
   "type": "module",
   "scripts": {
-    "test": "npm test --workspace @consumer/mobile"
+    "test": "npm test --workspace @consumer/mobile",
+    "test:from-root": "vitest run --config apps/mobile/vitest.config.mts"
   },
   "devDependencies": {
     "@babel/core": "7.29.7",

--- a/packages/vitest-native/scripts/test-consumers.mjs
+++ b/packages/vitest-native/scripts/test-consumers.mjs
@@ -50,6 +50,15 @@ try {
     addPackedDependency(fixtureRoot, tarball);
     run("npm", ["install"], fixtureRoot);
     run("npm", ["test"], fixtureRoot);
+    // The monorepo fixture is also run from the WORKSPACE ROOT, pointing at the
+    // app's config. That is how Nx invokes tasks, and Vitest's root follows the
+    // working directory, so the run root ends up above the package under test.
+    // Package detection walks manifests UPWARDS, so from there it saw none of the
+    // app's own dependencies: the workspace library missed auto-detection, stayed
+    // in Vite's graph while Node loaded it too, and came apart into two module
+    // instances — the reported blocker reproducing from nothing but a different
+    // working directory. Running only from the app directory could not see it.
+    if (fixture === "monorepo") run("npm", ["run", "test:from-root"], fixtureRoot);
   }
 
   // The CLI ships as the package bin — prove it dispatches from the packed

--- a/packages/vitest-native/src/native/ecosystem.ts
+++ b/packages/vitest-native/src/native/ecosystem.ts
@@ -39,13 +39,89 @@ function dependsOnReactNative(manifest: Record<string, unknown>): boolean {
  * never imported costs nothing, because inlining only applies to files that are
  * actually loaded.
  */
-function manifestsFrom(projectRoot: string): Record<string, unknown>[] {
-  const manifests: Record<string, unknown>[] = [];
+/**
+ * Directories of the workspace members a manifest declares, plus any listed in a
+ * sibling pnpm-workspace.yaml.
+ *
+ * Needed because `manifestsFrom` only walks UP. In a workspace the run root is
+ * frequently ABOVE the package under test — Nx invokes tasks from the workspace
+ * root, and Vitest's root defaults to the working directory — so the app's own
+ * dependencies are declared in a manifest that walking up never reaches. The
+ * package then misses auto-detection and stays in Vite's graph while Node loads it
+ * too, which is the dual-ownership failure reproducing from nothing but a different
+ * working directory.
+ *
+ * Only the two glob shapes workspace fields actually use are expanded (`dir/*` and a
+ * literal path). Over-collecting is safe here — an unimported package costs nothing —
+ * so a shape that is not understood is skipped rather than approximated.
+ */
+function workspaceMemberDirs(dir: string, manifest: Record<string, unknown>): string[] {
+  const patterns: string[] = [];
+  const declared = manifest.workspaces;
+  if (Array.isArray(declared)) {
+    patterns.push(...declared.filter((p): p is string => typeof p === "string"));
+  } else if (
+    declared &&
+    typeof declared === "object" &&
+    Array.isArray((declared as { packages?: unknown }).packages)
+  ) {
+    patterns.push(
+      ...(declared as { packages: unknown[] }).packages.filter(
+        (p): p is string => typeof p === "string",
+      ),
+    );
+  }
+  try {
+    // pnpm keeps its member list outside package.json, and pnpm workspaces are where
+    // this problem was reported. Read the lines rather than adding a YAML dependency:
+    // the file is a `packages:` list of quoted globs.
+    const yaml = fs.readFileSync(path.join(dir, "pnpm-workspace.yaml"), "utf8");
+    for (const line of yaml.split(/\r?\n/)) {
+      const entry = /^\s*-\s*["']?([^"'#]+?)["']?\s*$/.exec(line);
+      if (entry) patterns.push(entry[1]);
+    }
+  } catch {
+    // No pnpm workspace file — the manifest field above is the only source.
+  }
+
+  const dirs: string[] = [];
+  for (const pattern of patterns) {
+    if (pattern.endsWith("/*")) {
+      const parent = path.join(dir, pattern.slice(0, -2));
+      try {
+        for (const entry of fs.readdirSync(parent, { withFileTypes: true })) {
+          if (entry.isDirectory()) dirs.push(path.join(parent, entry.name));
+        }
+      } catch {
+        // Declared but absent — nothing to read.
+      }
+    } else if (!pattern.includes("*")) {
+      dirs.push(path.join(dir, pattern));
+    }
+  }
+  return dirs;
+}
+
+function manifestsFrom(projectRoot: string): { dir: string; manifest: Record<string, unknown> }[] {
+  const manifests: { dir: string; manifest: Record<string, unknown> }[] = [];
   let dir = path.resolve(projectRoot);
   for (;;) {
     try {
       const raw = fs.readFileSync(path.join(dir, "package.json"), "utf8");
-      manifests.push(JSON.parse(raw) as Record<string, unknown>);
+      const manifest = JSON.parse(raw) as Record<string, unknown>;
+      manifests.push({ dir, manifest });
+      for (const member of workspaceMemberDirs(dir, manifest)) {
+        try {
+          manifests.push({
+            dir: member,
+            manifest: JSON.parse(
+              fs.readFileSync(path.join(member, "package.json"), "utf8"),
+            ) as Record<string, unknown>,
+          });
+        } catch {
+          // A member directory without a readable manifest — skip it.
+        }
+      }
     } catch {
       // No manifest at this level, or an unreadable one — keep walking up.
     }
@@ -78,11 +154,30 @@ function manifestsFrom(projectRoot: string): Record<string, unknown>[] {
  * test infrastructure in NEVER_INLINE, and anything the consumer listed explicitly
  * in `transform` — that option keeps its existing meaning and takes precedence.
  */
-export function detectEcosystemPackages(projectRoot: string, explicit: string[] = []): string[] {
-  const req = createRequire(path.join(projectRoot, "package.json"));
+export function detectEcosystemPackages(
+  projectRoot: string | string[],
+  explicit: string[] = [],
+): string[] {
+  // More than one root because `manifestsFrom` only walks UP. In a workspace the
+  // run root is often above the package under test — Nx invokes tasks from the
+  // workspace root, and Vitest's root defaults to the working directory — and the
+  // app's own dependencies are declared below it, so walking up from the run root
+  // alone finds none of them. The package then misses auto-detection and stays in
+  // Vite's graph while Node loads it too: the dual-ownership failure again, this
+  // time triggered by nothing but the working directory. The config file's
+  // directory is the second root, since that is where the package under test lives.
+  const roots = (Array.isArray(projectRoot) ? projectRoot : [projectRoot]).filter(Boolean);
   const skip = new Set<string>([...NEVER_INLINE, ...Object.keys(AUTO_DETECT_PRESETS), ...explicit]);
   const candidates = new Set<string>();
-  for (const manifest of manifestsFrom(projectRoot)) {
+  const found = roots.flatMap((root) => manifestsFrom(root));
+  // One resolver per directory that declared something. Under pnpm a workspace
+  // package is linked only into the package that depends on it, so the run root
+  // often cannot resolve what the app can — resolving only from the run root is
+  // how a workspace library slips past detection when the run starts above it.
+  const requires = [...new Set(found.map((entry) => entry.dir))].map((dir) =>
+    createRequire(path.join(dir, "package.json")),
+  );
+  for (const { manifest } of found) {
     for (const field of ["dependencies", "devDependencies", "optionalDependencies"]) {
       const deps = manifest[field];
       if (deps && typeof deps === "object") {
@@ -95,11 +190,17 @@ export function detectEcosystemPackages(projectRoot: string, explicit: string[] 
   const detected: string[] = [];
   for (const name of candidates) {
     if (skip.has(name) || name.startsWith("@react-native/")) continue;
-    try {
-      const pkg = req(`${name}/package.json`) as Record<string, unknown>;
-      if (dependsOnReactNative(pkg)) detected.push(name);
-    } catch {
-      // Not installed, or no exported manifest — nothing to inline either way.
+    // Resolved from whichever root can see it. Under pnpm a workspace package is
+    // linked only into the package that depends on it, so the run root frequently
+    // cannot resolve what the app can.
+    for (const req of requires) {
+      try {
+        const pkg = req(`${name}/package.json`) as Record<string, unknown>;
+        if (dependsOnReactNative(pkg)) detected.push(name);
+        break;
+      } catch {
+        // Not resolvable from this root — try the next one.
+      }
     }
   }
   return detected.sort();

--- a/packages/vitest-native/tests/ecosystem-workspace-roots.test.ts
+++ b/packages/vitest-native/tests/ecosystem-workspace-roots.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Auto-detection must see the packages a WORKSPACE MEMBER declares, not only those
+ * on the path from the run root upwards.
+ *
+ * `manifestsFrom` walks up. In a workspace the run root is frequently above the
+ * package under test — Nx invokes tasks from the workspace root, and Vitest's root
+ * follows the working directory — so the app's own dependencies live in a manifest
+ * that walking up never reaches. The package then misses detection, stays in Vite's
+ * graph while Node loads it too, and comes apart into two module instances. That is
+ * the reported dual-ownership blocker, reproducing from nothing but a different
+ * working directory.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { detectEcosystemPackages } from "../src/native/ecosystem.js";
+
+const made: string[] = [];
+afterEach(() => {
+  for (const dir of made.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function write(root: string, rel: string, value: unknown) {
+  const file = path.join(root, rel);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, typeof value === "string" ? value : JSON.stringify(value));
+}
+
+/** A workspace whose member app depends on an RN library, installed only under it. */
+function workspace(declare: (root: string) => void): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vn-ws-"));
+  made.push(root);
+  declare(root);
+  write(root, "apps/mobile/package.json", {
+    name: "@w/mobile",
+    dependencies: { "@w/ui": "*" },
+  });
+  // Resolvable only from the member, as pnpm links a workspace package.
+  write(root, "apps/mobile/node_modules/@w/ui/package.json", {
+    name: "@w/ui",
+    version: "1.0.0",
+    peerDependencies: { "react-native": "*" },
+  });
+  return root;
+}
+
+describe("ecosystem detection across workspace members", () => {
+  it("detects a member's dependency when the run root is the workspace root", () => {
+    const root = workspace((r) => write(r, "package.json", { name: "w", workspaces: ["apps/*"] }));
+    expect(detectEcosystemPackages(root)).toContain("@w/ui");
+  });
+
+  it("reads pnpm's member list, which lives outside package.json", () => {
+    const root = workspace((r) => {
+      write(r, "package.json", { name: "w" });
+      write(r, "pnpm-workspace.yaml", 'packages:\n  - "apps/*"\n');
+    });
+    expect(detectEcosystemPackages(root)).toContain("@w/ui");
+  });
+
+  it("reads the object form of the workspaces field", () => {
+    const root = workspace((r) =>
+      write(r, "package.json", { name: "w", workspaces: { packages: ["apps/*"] } }),
+    );
+    expect(detectEcosystemPackages(root)).toContain("@w/ui");
+  });
+
+  it("still detects when the run root IS the member", () => {
+    const root = workspace((r) => write(r, "package.json", { name: "w", workspaces: ["apps/*"] }));
+    expect(detectEcosystemPackages(path.join(root, "apps", "mobile"))).toContain("@w/ui");
+  });
+
+  it("declares no members when none are configured", () => {
+    const root = workspace((r) => write(r, "package.json", { name: "w" }));
+    expect(detectEcosystemPackages(root)).not.toContain("@w/ui");
+  });
+});


### PR DESCRIPTION
Closes the last open item: enterprise blocker #1 reproducing in a monorepo shape the fixtures did not cover.

## The failure

Built a pnpm workspace, installed the packed tarball, and ran the same fixture two ways:

| invocation | result |
| --- | --- |
| `cd apps/mobile && vitest run` | 3 passed |
| `vitest run --config apps/mobile/vitest.config.mts` from the **workspace root** | **2 failed** |

```
a workspace library is ONE module across both module systems
AssertionError: expected '' to be 'translated:greeting'
```

Same config, same code — only the working directory differs. State written through one graph reads back unset through the other: two module instances, which is blocker #1 verbatim.

**This is how Nx invokes tasks**, and the original report was Nx + pnpm. So the fixes in #114/#115 held only when the working directory was the app package.

## Why

Auto-detection walks manifests **upwards** from the run root. From the workspace root, the app's own dependencies are declared *below* it, so walking up finds none of them. `@consumer/ui` missed detection, stayed in Vite's graph while Node loaded it too, and split.

## The fix

Detection also reads the manifests of workspace members declared by any manifest it finds — the `workspaces` array, its object form, and pnpm's separate `pnpm-workspace.yaml` list — and resolves each candidate from whichever of those directories can see it. That last part is necessary under pnpm, where a workspace package is linked only into the package that depends on it, so the run root genuinely cannot resolve what the app can.

Only the two glob shapes these fields actually use are expanded (`dir/*` and a literal path). Anything else is skipped rather than approximated: over-collecting is safe here — an unimported package costs nothing — but guessing a path is not.

## Gated at both levels

The **consumer harness now runs the monorepo fixture from the workspace root** as well as from the app directory. The invocation that exposed this is covered rather than assumed — running only from the app directory could not see it, which is why it survived #115.

Five unit tests: the `workspaces` array, its object form, pnpm's YAML list, the run root being the member itself, and a workspace with no members configured.

| Injected | Result |
| --- | --- |
| member expansion removed | 3 unit tests fail; both root-run fixture assertions fail |
| `pnpm-workspace.yaml` ignored | 1 unit test fails |

Verified end to end against a real pnpm workspace: 3/3 from the workspace root and 3/3 from the app directory, and the failure returns when the expansion is removed.

Suites: 1622 mock, 217 native, all consumer fixtures. Lint, format, typecheck and the budget pass.