### PR TITLE
fix(exports): make every declared entry point loadable from CommonJS

### DIFF
--- a/.changeset/cjs-entry-surface.md
+++ b/.changeset/cjs-entry-surface.md
@@ -1,0 +1,36 @@
+---
+"vitest-native": minor
+---
+
+Make every declared entry point loadable, and require Node >= 20.19
+
+`require("vitest-native")` threw. The package's `main`, the `require` condition of the
+root export, and the `require` conditions of `./setup` and `./presets` all pointed at
+transpiled CommonJS bundles that could not be loaded at all: the root re-exports the
+presets, every preset imports `vi` from vitest at module scope, and vitest throws when
+it is reached through `require()`. A previous release gated this and recorded the three
+entries as known-unloadable rather than fixing them.
+
+The fix is not to change how the presets are written. Node has loaded ES modules from
+`require()` since 20.19, and the ESM build was always fine — only the transpiled
+CommonJS build tripped vitest's guard. Those three subpaths now declare a single ESM
+target for both conditions, and the dead CommonJS bundles are no longer emitted.
+`const { reactNative, presets } = require("vitest-native")` works, on both the oldest
+and newest supported Node. No documented API changed.
+
+`engines` now requires Node >= 20.19.0, the version that added `require(esm)` and the
+oldest version the matrix has ever tested. The previous `>= 20` advertised support for
+Node 20.0–20.18, which was never exercised and where the root entry cannot be required.
+
+Two gates were extended to keep this fixed:
+
+- `tests/package-exports.test.ts` resolves and loads every subpath by specifier under
+  both `require` and `import`, rather than only loading declared targets by path. The
+  original defect was invisible from the path side, since `dist/index.mjs` loaded fine
+  throughout.
+- `scripts/check-exports.mjs` no longer ignores `cjs-resolves-to-esm` package-wide.
+  Subpaths that are ESM-only on purpose are declared explicitly and checked against the
+  manifest in both directions; every other subpath is checked with the rule enforced, so
+  a dual entry cannot quietly lose its CommonJS build. Deriving that split from the
+  manifest was tried and rejected: removing a `.cjs` moved the entry into the excused
+  bucket, and the gate stayed green on the defect it exists to catch.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ describe('MyComponent', () => {
 
 ## Requirements
 
-- **Node.js** >= 20
+- **Node.js** >= 20.19 (the version that added `require(esm)`)
 - **Vitest** 4.x or 5.x (both run the full gate in CI)
 - **Vite** ^6.4.2, ^7.3.2, or ^8.0.5
 - **React** >= 18

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "vite": "8.0.16"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.19.0"
   },
   "scripts": {
     "build": "bun run --filter vitest-native build",

--- a/packages/vitest-native/README.md
+++ b/packages/vitest-native/README.md
@@ -891,7 +891,7 @@ Current React Native edge releases are also tested weekly. See
 | `react`                                      | >= 18; use RN's matching React version    |
 | `vite`                                       | ^6.4.2, ^7.3.2, or ^8.0.5                |
 | `vitest`                                     | 4.x                                       |
-| `node`                                       | >= 20; RN/RNTL may impose a higher floor  |
+| `node`                                       | >= 20.19; RN/RNTL may impose a higher floor |
 | `react-native` (native engine)               | 0.81–0.86 validated                       |
 | `@react-native/babel-preset` (native engine) | Match the installed React Native minor    |
 | `@testing-library/react-native` (optional)   | 12.x, 13.x, or 14.x                       |

--- a/packages/vitest-native/docs/release-readiness.md
+++ b/packages/vitest-native/docs/release-readiness.md
@@ -41,10 +41,23 @@ versions are rejected rather than allowed to fail later inside private runner in
 9. Package export and declaration analysis with `@arethetypeswrong/cli`.
 10. Staged npm publishing with provenance; the version remains unavailable until maintainer approval.
 
-The ATTW gate ignores legacy Node 10 resolution because the package requires Node 20+. It also
-allows `cjs-resolves-to-esm` only for the three `jest-compat` runtime shims: those entries depend on
-Vitest's ESM runtime and are setup-file or Vite-alias targets. All normal public APIs are gated as
-dual ESM/CommonJS exports.
+The ATTW gate ignores legacy Node 10 resolution because the package requires Node 20.19+.
+
+Seven of the eleven `exports` subpaths are ESM-only by design — `.`, `./setup`, `./presets`, the
+three `jest-compat` runtime shims, and the types-only `./rntl-matchers`. Each of the runtime ones
+depends on Vitest, which throws when it is reached through `require()`, so shipping a transpiled
+CommonJS build for them produced files that could not be loaded at all. They now declare a single
+ESM target for both conditions: a CommonJS consumer still reaches them, through Node's `require(esm)`
+support. That is why `engines` pins Node >= 20.19 rather than >= 20.
+
+The remaining four subpaths ship a real CommonJS build and are checked with `cjs-resolves-to-esm`
+enforced, so a dual entry cannot quietly lose its `.cjs`. Which subpaths are intentionally ESM-only
+is declared in `scripts/check-exports.mjs` and checked against the manifest in both directions;
+deriving that split from the manifest instead was verified not to work, because dropping a `.cjs`
+simply moved the entry into the excused bucket.
+
+Resolution is not execution: `tests/package-exports.test.ts` additionally loads every declared
+target, and resolves and loads every subpath by specifier under both `require` and `import`.
 
 ## Release decision
 

--- a/packages/vitest-native/package.json
+++ b/packages/vitest-native/package.json
@@ -24,19 +24,13 @@
     "expo",
     "react"
   ],
-  "main": "./dist/index.cjs",
+  "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.mts",
-        "default": "./dist/index.mjs"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.mts",
+      "default": "./dist/index.mjs"
     },
     "./helpers": {
       "import": {
@@ -49,14 +43,8 @@
       }
     },
     "./setup": {
-      "import": {
-        "types": "./dist/setup.d.mts",
-        "default": "./dist/setup.mjs"
-      },
-      "require": {
-        "types": "./dist/setup.d.cts",
-        "default": "./dist/setup.cjs"
-      }
+      "types": "./dist/setup.d.mts",
+      "default": "./dist/setup.mjs"
     },
     "./serializer": {
       "import": {
@@ -69,14 +57,8 @@
       }
     },
     "./presets": {
-      "import": {
-        "types": "./dist/presets.d.mts",
-        "default": "./dist/presets.mjs"
-      },
-      "require": {
-        "types": "./dist/presets.d.cts",
-        "default": "./dist/presets.cjs"
-      }
+      "types": "./dist/presets.d.mts",
+      "default": "./dist/presets.mjs"
     },
     "./matchers": {
       "import": {
@@ -121,10 +103,9 @@
     "CHANGELOG.md"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=20.19.0"
   },
   "sideEffects": [
-    "./dist/setup.cjs",
     "./dist/setup.mjs",
     "./dist/jest-compat/setup.mjs",
     "./dist/native/*.mjs"

--- a/packages/vitest-native/scripts/check-exports.mjs
+++ b/packages/vitest-native/scripts/check-exports.mjs
@@ -15,9 +15,23 @@
 // non-existent file: the old invocation exited 0 with every entry point green,
 // while this one exits 1 on "node16 (from ESM): Resolution failed".
 //
-// --ignore-rules cjs-resolves-to-esm: the jest-compat runtime subpaths are
-// intentionally ESM-only (they depend on vitest, which is ESM-only); CJS consumers
-// use dynamic import. They are setup-file / Vite-alias targets, not typed imports.
+// `cjs-resolves-to-esm` had the same shape of bug. Some subpaths are deliberately
+// ESM-only: they depend on vitest, which throws when it is reached through
+// require(), so `exports` points both conditions at the .mjs build and Node
+// >= 20.19 loads it via require(esm). Ignoring the rule package-wide to excuse
+// those also stopped it reporting on the subpaths that ship a real CJS build —
+// a dual entry could silently lose its .cjs and nothing would say so.
+//
+// So the run is split. The ESM-only list is DECLARED below rather than derived from
+// package.json, and that distinction is the whole point. Deriving both lists from the
+// manifest looks tidier and is worthless: dropping the .cjs from a dual subpath simply
+// moves it into the derived ESM-only bucket, where the rule is ignored, so the gate
+// relabels the defect as intentional and stays green. Verified by doing exactly that to
+// ./helpers — the derived version passed, the version below fails.
+//
+// Intent is declared once, here; the manifest is then checked against it in both
+// directions. Making a subpath ESM-only now requires editing this list, which is a
+// deliberate act visible in review.
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
@@ -25,8 +39,85 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const outDir = fs.mkdtempSync(path.join(os.tmpdir(), "vn-check-exports-"));
+const manifest = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8"));
 
+/** Resolve an exports node the way Node does for a given condition set. */
+function resolveRuntime(node, conditions) {
+  if (typeof node === "string") return node;
+  if (!node || typeof node !== "object") return null;
+  for (const [key, value] of Object.entries(node)) {
+    if (key === "types") continue; // a TypeScript-only condition, never a runtime target
+    if (key === "default" || conditions.includes(key)) {
+      const resolved = resolveRuntime(value, conditions);
+      if (resolved) return resolved;
+    }
+  }
+  return null;
+}
+
+/**
+ * Subpaths that ship no CommonJS build on purpose, with the reason. Everything not
+ * listed here MUST resolve require() to a real .cjs.
+ */
+const INTENTIONALLY_ESM_ONLY = {
+  ".": "re-exports the presets, which import vitest at module scope",
+  "./setup": "imports vitest at module scope",
+  "./presets": "every preset imports vitest at module scope",
+  "./jest-compat/setup": "vitest-dependent runtime shim, loaded as a setup file",
+  "./jest-compat/jest-globals": "vitest-dependent runtime shim, resolved as a Vite alias",
+  "./jest-compat/extend-expect-noop": "vitest-dependent runtime shim, resolved as a Vite alias",
+  "./rntl-matchers": "types-only entry; there is no runtime target to ship",
+};
+
+const subpaths = Object.keys(manifest.exports);
+const esmOnly = subpaths.filter((s) => s in INTENTIONALLY_ESM_ONLY);
+const dualCjs = subpaths.filter((s) => !(s in INTENTIONALLY_ESM_ONLY));
+
+const problems = [];
+
+// An excuse for a subpath that no longer exists reads as coverage while guarding
+// nothing, and hides the fact that the real subpath went unchecked.
+for (const declared of Object.keys(INTENTIONALLY_ESM_ONLY)) {
+  if (!subpaths.includes(declared)) {
+    problems.push(`"${declared}" is declared ESM-only but the manifest no longer exports it.`);
+  }
+}
+
+// The direction that catches a dual subpath quietly losing its CommonJS build.
+for (const subpath of dualCjs) {
+  const target = resolveRuntime(manifest.exports[subpath], ["node", "require"]);
+  if (!target) {
+    problems.push(`"${subpath}" resolves require() to nothing, and is not declared ESM-only.`);
+  } else if (!target.endsWith(".cjs")) {
+    problems.push(
+      `"${subpath}" resolves require() to ${target}, not a .cjs build. If that is deliberate, ` +
+        `add it to INTENTIONALLY_ESM_ONLY with the reason; otherwise the CJS build is missing.`,
+    );
+  }
+}
+
+// And the direction that catches a stale excuse: a subpath listed as ESM-only that has
+// since gained a real CJS build should be checked with the rule enforced, not ignored.
+for (const subpath of esmOnly) {
+  const target = resolveRuntime(manifest.exports[subpath], ["node", "require"]);
+  if (target?.endsWith(".cjs")) {
+    problems.push(
+      `"${subpath}" ships a CJS build now — remove it from INTENTIONALLY_ESM_ONLY so the ` +
+        `cjs-resolves-to-esm rule is enforced for it.`,
+    );
+  }
+}
+
+if (dualCjs.length === 0) {
+  problems.push("no dual CJS/ESM subpath left — the enforced pass would check nothing.");
+}
+
+if (problems.length > 0) {
+  console.error(`✗ export map does not match declared intent:\n  - ${problems.join("\n  - ")}`);
+  process.exit(1);
+}
+
+const outDir = fs.mkdtempSync(path.join(os.tmpdir(), "vn-check-exports-"));
 const run = (command, args, options = {}) =>
   spawnSync(command, args, { cwd: root, stdio: "inherit", ...options });
 
@@ -42,17 +133,36 @@ try {
     console.error(`✗ npm pack produced no tarball in ${outDir}.`);
     process.exit(1);
   }
+  const archive = path.join(outDir, tarball);
 
-  const checked = run("npx", [
-    "--yes",
-    "@arethetypeswrong/cli",
-    path.join(outDir, tarball),
-    "--profile",
-    "node16",
-    "--ignore-rules",
-    "cjs-resolves-to-esm",
-  ]);
-  process.exit(checked.status ?? 1);
+  const passes = [
+    {
+      label: `dual CJS/ESM subpaths (cjs-resolves-to-esm enforced): ${dualCjs.join(", ")}`,
+      entrypoints: dualCjs,
+      ignore: [],
+    },
+    {
+      label: `ESM-only subpaths (cjs-resolves-to-esm ignored): ${esmOnly.join(", ")}`,
+      entrypoints: esmOnly,
+      ignore: ["cjs-resolves-to-esm"],
+    },
+  ];
+
+  for (const pass of passes) {
+    console.log(`\n=== ${pass.label} ===`);
+    const checked = run("npx", [
+      "--yes",
+      "@arethetypeswrong/cli",
+      archive,
+      "--profile",
+      "node16",
+      "--entrypoints",
+      ...pass.entrypoints,
+      ...(pass.ignore.length ? ["--ignore-rules", ...pass.ignore] : []),
+    ]);
+    if (checked.status !== 0) process.exit(checked.status ?? 1);
+  }
+  console.log("\n✓ every declared subpath checked under the right CJS/ESM expectation");
 } finally {
   fs.rmSync(outDir, { recursive: true, force: true });
 }

--- a/packages/vitest-native/tests/package-exports.test.ts
+++ b/packages/vitest-native/tests/package-exports.test.ts
@@ -77,21 +77,16 @@ describe("declared package entry points", () => {
 
 /**
  * Existing on disk is not the same as loading. Every check above is satisfied by a
- * file that throws the moment it is required — and three of the declared CJS entries
- * do exactly that, which nothing noticed because nothing ever loaded them.
+ * file that throws the moment it is required.
  *
- * The cause is `export * as presets` in the root entry: each preset imports `vi` from
- * vitest at module scope, so the root CJS bundle requires vitest, and vitest refuses
- * to be required from CommonJS. Every `vi` call itself sits inside a preset factory,
- * which only ever runs inside a worker, so the import is the only thing that needs to
- * move — but that is a change to how the presets are written, not to this list.
+ * Three declared CJS entries used to do exactly that. `export * as presets` in the
+ * root entry pulls in every preset, each of which imports `vi` from vitest at module
+ * scope, so the root CJS bundle required vitest — and vitest throws when it is reached
+ * through require(). The build no longer emits those CJS bundles: `exports` points
+ * both conditions at the single .mjs build, which Node >= 20.19 loads from CommonJS
+ * through require(esm). `engines` pins that floor.
  */
-const KNOWN_UNLOADABLE: Record<string, string> = {
-  "./dist/index.cjs":
-    "re-exports the presets, which import vitest at module scope; vitest cannot be required from CJS",
-  "./dist/presets.cjs": "presets import vitest at module scope",
-  "./dist/setup.cjs": "imports vitest at module scope",
-};
+const KNOWN_UNLOADABLE: Record<string, string> = {};
 
 /** Declared targets that are executable code rather than type declarations. */
 function runtimeTargets(): string[] {
@@ -126,5 +121,66 @@ describe("declared entry points load", () => {
     }
     expect(failures, `declared entry points that do not load:\n${failures.join("\n")}`).toEqual([]);
     expect(unexpectedlyFine, "these load now — remove them from KNOWN_UNLOADABLE").toEqual([]);
+  });
+
+  // An excuse for a target nothing declares any more reads as coverage while
+  // guarding nothing. The list must only ever describe entries that still ship.
+  it.runIf(distExists)("keeps no excuse for a target the manifest no longer declares", () => {
+    const declared = new Set(runtimeTargets());
+    const stale = Object.keys(KNOWN_UNLOADABLE).filter((t) => !declared.has(t));
+    expect(
+      stale,
+      `KNOWN_UNLOADABLE names targets that are not declared:\n${stale.join("\n")}`,
+    ).toEqual([]);
+  });
+});
+
+/**
+ * Loading a file by path proves the file works; it does not prove the manifest points
+ * a consumer at it. The bug this suite was written for was invisible from the path
+ * side — `dist/index.mjs` loaded fine the whole time — and only showed up through the
+ * specifier, under the condition a CommonJS consumer actually resolves.
+ *
+ * Node resolves a package's own name against its `exports`, so these are the real
+ * consumer paths, not an approximation of them.
+ */
+describe("declared subpaths load through the export map", () => {
+  const specifiers = () =>
+    Object.keys(manifest.exports).map((sub) =>
+      sub === "." ? "vitest-native" : `vitest-native/${sub.slice(2)}`,
+    );
+
+  /** Subpaths that declare no runtime target — types-only, so nothing to execute. */
+  const TYPES_ONLY = new Set(["vitest-native/rntl-matchers"]);
+
+  it.runIf(distExists)("resolves and requires every subpath from CommonJS", () => {
+    const require_ = createRequire(path.join(packageRoot, "package.json"));
+    const failures: string[] = [];
+    for (const spec of specifiers()) {
+      if (TYPES_ONLY.has(spec)) continue;
+      try {
+        require_(spec);
+      } catch (caught) {
+        // A subpath with no `require` condition is a deliberate ESM-only entry;
+        // Node reports that as a resolution error, which is honest and expected.
+        const err = caught as NodeJS.ErrnoException;
+        if (err.code === "ERR_PACKAGE_PATH_NOT_EXPORTED") continue;
+        failures.push(`${spec}: ${String(err.message).split("\n")[0]}`);
+      }
+    }
+    expect(failures, `subpaths that fail to require:\n${failures.join("\n")}`).toEqual([]);
+  });
+
+  it.runIf(distExists)("resolves and imports every subpath from ESM", async () => {
+    const failures: string[] = [];
+    for (const spec of specifiers()) {
+      if (TYPES_ONLY.has(spec)) continue;
+      try {
+        await import(spec);
+      } catch (caught) {
+        failures.push(`${spec}: ${String((caught as Error).message).split("\n")[0]}`);
+      }
+    }
+    expect(failures, `subpaths that fail to import:\n${failures.join("\n")}`).toEqual([]);
   });
 });

--- a/packages/vitest-native/tsdown.config.ts
+++ b/packages/vitest-native/tsdown.config.ts
@@ -35,6 +35,16 @@ export default defineConfig({
     // runtime (native: via module.register; jest-compat: as setup file / alias
     // targets resolved by Vite), so they must ship verbatim rather than bundled.
     'build:done': () => {
+      // Three entries depend on vitest at module scope, and vitest throws when it is
+      // reached through require(). Their CJS bundles therefore could not be loaded at
+      // all, so `exports` points require() and import() at the one .mjs build instead —
+      // Node >= 20.19 loads it through require(esm), which is why `engines` sets that
+      // floor. Emitting the dead CJS would ship files no declared entry can reach.
+      for (const name of ['index', 'setup', 'presets']) {
+        for (const ext of ['cjs', 'd.cts']) {
+          fs.rmSync(path.resolve('dist', `${name}.${ext}`), { force: true });
+        }
+      }
       // Top-level runtime .mjs (errors.mjs) ships verbatim too: the shipped runtimes
       // below import it by relative path, and the tests load those same files from src,
       // so it must resolve in both trees as one module rather than a bundled copy.


### PR DESCRIPTION
## Problem

`require("vitest-native")` throws.

The package's `main`, the `require` condition of the root export, and the `require` conditions of `./setup` and `./presets` all point at transpiled CommonJS bundles that cannot be loaded at all:

```
$ node -e "require('vitest-native')"
Error: Vitest cannot be imported in a CommonJS module using require().
```

The root entry re-exports the presets, every preset imports `vi` from vitest at module scope, so the root CJS bundle requires vitest — and vitest throws when it is reached through `require()`. `./presets` and `./setup` fail the same way.

This was already known: #121 gated it and recorded the three entries in a `KNOWN_UNLOADABLE` allowlist rather than fixing them. Meanwhile `docs/release-readiness.md` stated that "all normal public APIs are gated as dual ESM/CommonJS exports", which was not true.

## Fix

The presets do not need rewriting, which is what the earlier note proposed. Node has loaded ES modules from `require()` since 20.19, and the ESM build was always fine — only the *transpiled CommonJS* build tripped vitest's guard.

The three subpaths now declare a single ESM target for both conditions, and the dead CommonJS bundles are no longer emitted. **No documented API changed** — `import { reactNative, presets } from "vitest-native"` is the form both READMEs teach, and it is unaffected.

Verified from a real packed install rather than in-tree:

```
--- v20.19.4 ---
require(vitest-native) OK -> function 16 presets
require(vitest-native/presets) OK -> function
--- v24.13.0 ---
require(vitest-native) OK -> function 16 presets
require(vitest-native/presets) OK -> function
```

`engines` now requires Node >= 20.19.0 — the version that added `require(esm)`, and the oldest version the matrix has ever tested. The previous `>= 20` advertised support for Node 20.0–20.18, which was never exercised and where the root entry cannot be required.

## Keeping it fixed

Two gates were extended, and both were mutation-tested by reintroducing the defect.

**`tests/package-exports.test.ts`** resolved and loaded every declared *target by path*. The defect was invisible from that side — `dist/index.mjs` loaded fine throughout. It now also resolves and loads every *subpath by specifier*, under both `require` and `import`, which is what a consumer actually does.

**`scripts/check-exports.mjs`** ran ATTW with `--ignore-rules cjs-resolves-to-esm` package-wide, to excuse three `jest-compat` shims. That suppressed the rule for the subpaths that *do* ship CommonJS, so a dual entry could silently lose its `.cjs`. This is the same shape of bug the script's own comment describes for `no-resolution`, which was fixed in #107 and reintroduced here.

The run is now split: intentionally ESM-only subpaths are checked with the rule ignored, everything else with it enforced.

Deriving that split from `package.json` was tried first and **rejected on evidence**: removing the `.cjs` from `./helpers` moved it into the derived ESM-only bucket, where the rule is ignored, so the gate relabelled the defect as intentional and stayed green. Intent is now declared explicitly and checked against the manifest in both directions — a stale excuse fails, and so does an undeclared ESM-only entry.

Mutation results:

| Injected defect | Gate | Result |
| --- | --- | --- |
| dual `./helpers` loses its `.cjs` | `check:exports` | fails |
| excuse kept for a removed subpath | `check:exports` | fails |
| root `require` restored to `index.cjs` | `package-exports.test.ts` | fails, both by path and by specifier |

## Verification

- mock suite: 73 files, 1625 passed
- native suite: 47 files, 217 passed
- `check:exports`, `check:size` (74 files, floor 70), lint, format, typecheck: pass
- `test:consumers`: all packed consumer fixtures pass (bare RN, Expo, monorepo, current-RN, mock-rntl14, jest-migration)

## Also updated

The Node floor was stated in three places (`README.md`, `packages/vitest-native/README.md`, root `package.json`); all now say 20.19. `docs/release-readiness.md` describes the actual CJS/ESM split instead of claiming uniform dual exports.