### PR TITLE
fix(native): rebuild the precompiled registry when React changes

### DIFF
--- a/.changeset/registry-cache-react-version.md
+++ b/.changeset/registry-cache-react-version.md
@@ -1,0 +1,27 @@
+---
+"vitest-native": patch
+---
+
+Rebuild the React Native registry when React changes
+
+Upgrading React while staying on the same React Native served a precompiled registry
+built against the previous React. The native engine then failed in ways that look
+nothing like a stale cache:
+
+```
+TypeError: Cannot read properties of null (reading 'useContext')
+AssertionError: expected [Function Dimensions] to be [Function Dimensions]
+```
+
+— a null React dispatcher and React Native singletons that no longer compare equal,
+which is the duplicate-instance failure the registry exists to prevent.
+
+The registry is disk-cached under `node_modules/.cache/vitest-native` and keyed on
+React Native, `@babel/core`, `@react-native/babel-preset`, the platform, and this
+package's own version. `react` was missing, and the manifest check could not stand in
+for it: that stats React Native's own files, which do not change when React alone is
+upgraded. The cache was therefore reused when it should not have been, and deleting
+the cache directory by hand was the only way out.
+
+`react` is now part of the key. Because the failure is self-clearing on a later run,
+it was easy to read as flakiness rather than as a stale cache.

--- a/packages/vitest-native/src/native/registry.mjs
+++ b/packages/vitest-native/src/native/registry.mjs
@@ -160,8 +160,10 @@ function ownVersion() {
  * This package's version is in the key for the same reason, covering everything
  * else it contributes — the transform's Babel options, platform resolution, the
  * emitted registry's own shape.
+ *
+ * Exported for tests. Not part of the public surface — see docs/versioning.md.
  */
-function registryKey({ projectRoot, platform, reactNativeVersion }) {
+export function registryKey({ projectRoot, platform, reactNativeVersion }) {
   const req = createRequire(path.join(projectRoot, "package.json"));
   const version = (name) => {
     try {
@@ -195,6 +197,17 @@ function registryKey({ projectRoot, platform, reactNativeVersion }) {
         platform,
         reactNativeVersion,
         version("react-native"),
+        // React Native's modules resolve `react` at runtime, so the registry is only
+        // valid for the React it was built against. This was missing, and the manifest
+        // check below could not cover it: it stats React Native's own files, which do
+        // not change when React alone is upgraded. Upgrading React while staying on the
+        // same React Native therefore served a registry built against the previous one,
+        // and the suite failed with a null React dispatcher ("Cannot read properties of
+        // null (reading 'useContext')") plus React Native singletons that no longer
+        // compared equal — the duplicate-instance failure this cache exists to avoid.
+        // Reproduced by switching between two trees differing only in React's version;
+        // clearing node_modules/.cache/vitest-native was the only way out.
+        version("react"),
         version("@react-native/babel-preset"),
         version("@babel/core"),
         process.env.BABEL_ENV || process.env.NODE_ENV || "none",

--- a/packages/vitest-native/tests/registry-key.test.ts
+++ b/packages/vitest-native/tests/registry-key.test.ts
@@ -1,0 +1,89 @@
+/**
+ * The precompiled React Native registry is disk-cached and reused across runs, so
+ * its key has to name every input that changes what the registry means.
+ *
+ * `react` was missing. React Native's modules resolve React at runtime, and the
+ * manifest check cannot cover it — that stats React Native's own files, which do
+ * not change when React alone is upgraded. So upgrading React on a fixed React
+ * Native served a registry built against the previous React, and the native suite
+ * failed with a null React dispatcher and React Native singletons that no longer
+ * compared equal. Deleting node_modules/.cache/vitest-native was the only cure.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+// @ts-expect-error — runtime .mjs, no types
+import { registryKey } from "../src/native/registry.mjs";
+
+const roots: string[] = [];
+afterAll(() => {
+  for (const dir of roots) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+/** A project root whose installed dependency versions are exactly as given. */
+function projectWith(versions: Record<string, string>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vn-registry-key-"));
+  roots.push(root);
+  fs.writeFileSync(path.join(root, "package.json"), JSON.stringify({ name: "fixture" }));
+  for (const [name, version] of Object.entries(versions)) {
+    const dir = path.join(root, "node_modules", ...name.split("/"));
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "package.json"), JSON.stringify({ name, version }));
+  }
+  return root;
+}
+
+const BASE = {
+  react: "19.2.3",
+  "react-native": "0.86.0",
+  "@babel/core": "7.28.0",
+  "@react-native/babel-preset": "0.86.0",
+};
+
+const keyFor = (versions: Record<string, string>) =>
+  registryKey({
+    projectRoot: projectWith(versions),
+    platform: "ios",
+    reactNativeVersion: versions["react-native"],
+  }) as string;
+
+describe("registry cache key", () => {
+  it("is stable for the same installed versions", () => {
+    // A control: without this, a key that changed on every call would make every
+    // assertion below pass while proving nothing.
+    expect(keyFor(BASE)).toBe(keyFor(BASE));
+  });
+
+  it("changes when react changes, with react-native held fixed", () => {
+    expect(keyFor({ ...BASE, react: "19.2.8" })).not.toBe(keyFor(BASE));
+  });
+
+  it.each([
+    ["react-native", "0.85.0"],
+    ["@babel/core", "7.29.0"],
+    ["@react-native/babel-preset", "0.85.0"],
+  ])("changes when %s changes", (name, version) => {
+    const changed = { ...BASE, [name]: version };
+    const key =
+      name === "react-native"
+        ? (registryKey({
+            projectRoot: projectWith(changed),
+            platform: "ios",
+            reactNativeVersion: version,
+          }) as string)
+        : keyFor(changed);
+    expect(key).not.toBe(keyFor(BASE));
+  });
+
+  it("changes with the platform", () => {
+    const root = projectWith(BASE);
+    const ios = registryKey({ projectRoot: root, platform: "ios", reactNativeVersion: "0.86.0" });
+    const android = registryKey({
+      projectRoot: root,
+      platform: "android",
+      reactNativeVersion: "0.86.0",
+    });
+    expect(ios).not.toBe(android);
+  });
+});


### PR DESCRIPTION
## Symptom

Upgrade React, stay on the same React Native, run the native suite. It fails like this:

```
TypeError: Cannot read properties of null (reading 'useContext')
TypeError: Cannot read properties of null (reading 'useMemo')
AssertionError: expected [Function Dimensions] to be [Function Dimensions]
```

A null React dispatcher and React Native singletons that no longer compare equal — the duplicate-instance failure the registry exists to prevent, and the invariant in `registry-identity.test.ts`.

Then it passes on the next run, and every run after that. Which reads as flakiness.

## Cause

The precompiled registry is disk-cached under `node_modules/.cache/vitest-native` and keyed on React Native's version, `@babel/core`, `@react-native/babel-preset`, the platform, this package's version, the transform version, and the boundary-mock sources.

**`react` was not in the key.** React Native's modules resolve React at runtime, so a registry is only valid for the React it was built against.

The manifest check could not stand in for it. It stats React Native's own files for size and mtime — and those do not change when React alone is upgraded. So the entry stayed valid, the stale registry was served, and deleting the cache directory by hand was the only way out.

## How it was isolated

It first appeared as a one-off: the first native run after a dependency bump failed with 17 errors, then nine consecutive runs passed. Three experiments separated the causes:

| Experiment | Result | Rules out |
| --- | --- | --- |
| Cold cache, changed tree | passes | absence of a cache |
| `touch` React Native's files (manifest invalid, key unchanged) | passes | manifest staleness, rebuild-in-place race |
| Change React only, warm cache | **fails** — 6 files, 15 tests | — |
| Change React only, warm cache, **our cache cleared first** | passes | anything outside this package's cache |

That places the fault in the key, not in the manifest, and not in a concurrent rebuild.

## Fix

`version("react")` joins the key, alongside the entries already there for `@babel/core` and the Babel preset.

## Verification

End to end: with a registry warmed against React 19.2.7 and React then upgraded to 19.2.8, the native suite passes **47/47 on the first run**. The same transition before this change failed 6 files and 15 tests.

`tests/registry-key.test.ts` pins the key's inputs — React, React Native, `@babel/core`, the Babel preset, and the platform — with a control asserting the key is stable for unchanged versions, so the rest cannot pass vacuously. Removing `version("react")` again fails it.

Suites: mock 74 files / 1628 passed, native 47 files / 217 passed, android 3 passed. Lint, format, typecheck clean.

## Impact

This affects users, not just CI. Upgrading React is routine, and the resulting failure is loud, looks like a bug in vitest-native or in the user's own code, and clears itself on a re-run — close to the worst possible shape for a caching bug.

`registryKey` is now exported so the test can reach it. It is not public API; `docs/versioning.md` (#135) states that only the declared `exports` subpaths are.
