### PR TITLE
docs: state the versioning contract, and check it against the build

### DIFF
--- a/.changeset/versioning-contract.md
+++ b/.changeset/versioning-contract.md
@@ -1,0 +1,17 @@
+---
+"vitest-native": patch
+---
+
+Document the versioning contract, and check it against the build
+
+The package shipped stability *labels* — which surfaces are release-supported, which
+are experimental — but never a semver contract: which exports and options are covered,
+what a major may break, how the peer ranges may move, and what a deprecation cycle
+looks like. `docs/versioning.md` states all of it, and ships with the package.
+
+The document enumerates the public surface, so it is checked rather than trusted.
+`tests/versioning-contract.test.ts` loads each documented entry point and asserts the
+export lists match exactly in both directions, that the stated preset-factory count is
+right, and that the documented plugin options are exactly the keys the validator
+accepts. A surface added without a contract update fails the suite, as does a contract
+naming something that does not exist.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ A fast pure-JS **mock** engine is available as an opt-in for RN-free unit tests.
 > on any divergence. Pinned external apps are also run as non-authoritative integration
 > observations; their custom migration setup and Jest-era shims do not define package support.
 > See the [validation model](https://danfry1.github.io/vitest-native/guide/validation-model).
-> Some APIs may still shift before 1.0.
+> Some APIs may still shift before 1.0 — what is covered, what is experimental, and what 1.0 will
+> mean are set out in
+> [versioning and stability](packages/vitest-native/docs/versioning.md).
 >
 > Maintained successor to
 > [`vitest-community/vitest-react-native`](https://github.com/vitest-community/vitest-react-native)

--- a/packages/vitest-native/README.md
+++ b/packages/vitest-native/README.md
@@ -882,6 +882,10 @@ Every release must pass:
 Current React Native edge releases are also tested weekly. See
 [the release-readiness policy](docs/release-readiness.md) for the exact gates and stability labels.
 
+For what is *promised* rather than what is tested — which exports and options are protected by
+semver, which are experimental, how the version ranges above may move, and what 1.0 will mean —
+see [versioning and stability](docs/versioning.md).
+
 ---
 
 ## Requirements

--- a/packages/vitest-native/docs/release-readiness.md
+++ b/packages/vitest-native/docs/release-readiness.md
@@ -4,12 +4,16 @@ This document defines what `vitest-native` means by release-supported. It is del
 than "the repository tests pass": published artifacts are installed into representative consumer
 projects, experimental surfaces are labeled, and upstream compatibility is bounded.
 
+It covers what is **tested** before a release ships. [`versioning.md`](./versioning.md) covers what
+is **promised** about the surface those tests cover — which exports and options are protected by
+semver, which are experimental, and how the peer ranges below are allowed to move.
+
 ## Stability labels
 
 | Surface | Status | Release promise |
 | --- | --- | --- |
 | Mock engine | Release-supported | Documented behavior and exports are gated on every pull request and release. |
-| Native engine | Release-supported beta | Real RN behavior, iOS/Android resolution, presets, helpers, assets, matchers, and isolation are blocking gates. Pre-1.0 APIs can still change with release notes. |
+| Native engine | Release-supported beta | Real RN behavior, iOS/Android resolution, presets, helpers, assets, matchers, and isolation are blocking gates. Until 1.0 the [versioning contract](./versioning.md) is honoured best-effort, and a breaking change is called out in release notes. |
 | Hot runtime | Experimental | Correctness is gated, but it depends on Vitest's experimental custom-pool API and can require adaptation between Vitest releases. |
 | Current RN edge | Canary | Tested weekly and in a pinned packed consumer once adopted; an edge failure opens a compatibility issue. |
 

--- a/packages/vitest-native/docs/versioning.md
+++ b/packages/vitest-native/docs/versioning.md
@@ -1,0 +1,133 @@
+# Versioning and stability
+
+This document is the semver contract: what a major, minor, or patch release is allowed to change.
+
+[`release-readiness.md`](./release-readiness.md) is the companion document. It defines what is
+*tested* before a release ships. This one defines what is *promised* about the surface those tests
+cover.
+
+Until 1.0, the contract below describes intent and is honoured on a best-effort basis; breaking
+changes are called out in release notes. **At 1.0 it becomes binding**, and everything in
+[Covered surface](#covered-surface) is protected by semver.
+
+## Covered surface
+
+These are the things a major release may break, a minor may only extend, and a patch may not change
+at all. Anything not listed here is not covered — see [Outside the contract](#outside-the-contract).
+
+### Entry points
+
+Only the subpaths declared in `exports` are public. Nothing under `dist/` is importable directly,
+and deep paths are not supported even when they happen to resolve.
+
+| Subpath | Covered exports |
+| --- | --- |
+| `vitest-native` | `reactNative`, `presets`, `disabledPresetNames` |
+| `vitest-native/helpers` | `setPlatform`, `setDimensions`, `setColorScheme`, `setInsets`, `mockNativeModule`, `resetAllMocks` |
+| `vitest-native/presets` | the 16 preset factories, by name |
+| `vitest-native/matchers` | `toHaveAnimatedStyle`, `toHaveAnimatedProps`, `animatedMatchers` |
+| `vitest-native/serializer` | `serializer` |
+| `vitest-native/jest-compat` | `jestMockTransform`, `jestCompatAliases`, `jestCompatSetup` |
+| `vitest-native/jest-compat/setup`, `/jest-globals`, `/extend-expect-noop` | loadable as setup-file and alias targets |
+| `vitest-native/rntl-matchers` | the RNTL matcher type augmentation |
+
+The module format of an entry point is part of the contract: an entry that is loadable from
+CommonJS stays loadable from CommonJS. Which entries those are is enforced by `check:exports`, and
+every subpath is loaded by specifier under both `require` and `import` in
+`tests/package-exports.test.ts`.
+
+### Plugin options
+
+The keys accepted by the plugin function are `engine`, `platform`, `presets`, `mocks`,
+`diagnostics`, `assetExts`, `transform`, `hotRuntime`. Their accepted types and their defaults are
+covered. An unknown key is rejected at configuration time, so adding a key is a minor and removing
+or renaming one is a major.
+
+`hotRuntime` is the exception — see [Experimental](#experimental).
+
+### Preset authoring
+
+The `Preset` and `PresetModule` types are a public extension point: third-party presets can be
+written and passed to `presets: [...]`. Covered: the shape `{ name, modules, config? }`, that
+`PresetModule.exports` is read at config time, and that `PresetModule.factory` is called only
+inside a Vitest worker.
+
+`factory` may gain optional parameters in a minor, since that does not break an existing
+zero-argument factory. Its return type and call site will not change without a major.
+
+### Error codes
+
+Thrown errors carry a stable `code`. The `code` values and the error classes are covered; the
+human-readable `message` text is not.
+
+### CLI
+
+The command names `doctor`, `init`, and `migrate`, their documented flags, and their exit codes.
+The wording and layout of what they print is not covered.
+
+## Outside the contract
+
+Changing any of these is a patch or minor, and never requires a major.
+
+- **The wording of any message** — diagnostics, warnings, `doctor`/`init`/`migrate` output, and
+  error `message` strings. Assert on error `code`, not on text.
+- **What a preset mocks.** Presets track upstream libraries. When `react-native-reanimated` adds an
+  export, the preset gains it in a minor; when upstream removes one, the preset drops it in a minor.
+  The preset's *existence and name* are covered; its mocked surface follows upstream.
+- **Mock-engine fidelity details.** The mock engine's job is to match real React Native. A change
+  that moves it *closer* to real RN is a fix, even if a test was relying on the divergence. The
+  cross-check corpus and `crosscheck/known-differences.json` record where the two intentionally
+  differ.
+- **Anything reachable only by deep import** into `dist/`.
+- **Internal cache layout** under `node_modules/.cache/vitest-native`.
+
+## Experimental
+
+Experimental surfaces are excluded from the contract at every version, including after 1.0. They
+are documented, tested, and gated in CI — they are simply not stable, and they say so.
+
+| Surface | Why |
+| --- | --- |
+| `hotRuntime` and its options | Built on Vitest's experimental custom-pool API, which can change between Vitest minors. Off by default. |
+
+A surface leaves this list by being promoted in a minor, and can change or be removed in a minor
+while it is on it.
+
+## Upstream support ranges
+
+`vitest-native` sits between several fast-moving projects — Node, Vite, Vitest, React, React
+Native, and React Native Testing Library. Treating every peer-range change as a major would make
+the package unable to keep up, which is the main way a tool like this dies. So peer ranges are
+handled explicitly:
+
+- **Adding support** for a new upstream version is a **minor**.
+- **Dropping a version that upstream has already end-of-lifed** is a **minor**, announced in the
+  release notes. The package does not promise to outlive its own dependencies.
+- **Dropping a version upstream still supports** is a **major**.
+- **Raising the Node floor** is a **minor** when the versions dropped are end-of-life, and a
+  **major** otherwise.
+
+The currently supported ranges are in [Requirements](../README.md#requirements) and the blocking
+matrix in [`release-readiness.md`](./release-readiness.md#blocking-compatibility-matrix). Those are
+the authoritative lists; this document only says how they may move.
+
+## Deprecation
+
+1. A deprecated surface keeps working and gains a runtime warning naming the replacement, plus a
+   note in the docs and release notes. This happens in a **minor**.
+2. It is removed no earlier than the **next major**.
+
+Something can only be removed without this cycle if it never worked — an entry point that always
+threw, for example, is a bug being fixed, not an API being removed.
+
+## What 1.0 means
+
+1.0 is not a statement that the code has stopped changing. It is a statement that:
+
+- the surface above is enumerated, deliberate, and protected by semver;
+- the parts that are not stable are labelled, rather than silently included;
+- the tests and gates in [`release-readiness.md`](./release-readiness.md) are what stand behind the
+  promise, and each one checks the thing it claims to check.
+
+Reaching it does not require new features. It requires the surface to be exactly what this document
+says it is.

--- a/packages/vitest-native/tests/versioning-contract.test.ts
+++ b/packages/vitest-native/tests/versioning-contract.test.ts
@@ -1,0 +1,131 @@
+/**
+ * The versioning contract enumerates the public surface. An enumeration in prose
+ * drifts the moment an export is added, and a stale contract is worse than none —
+ * it is a promise about a surface that no longer exists.
+ *
+ * This checks the document against the build: every export named in
+ * `docs/versioning.md` must exist, and every export that exists must be named.
+ * The same failure mode that put "all normal public APIs are gated as dual
+ * ESM/CommonJS exports" into the release-readiness policy, where it stayed wrong
+ * for two releases, applies to every table in that file.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const doc = fs.readFileSync(path.join(packageRoot, "docs", "versioning.md"), "utf8");
+const manifest = JSON.parse(fs.readFileSync(path.join(packageRoot, "package.json"), "utf8")) as {
+  exports: Record<string, unknown>;
+};
+const distExists = fs.existsSync(path.join(packageRoot, "dist"));
+
+/** Resolve a subpath's ESM target from the manifest, the way a bundler would. */
+function esmTarget(subpath: string): string | null {
+  const walk = (node: unknown): string | null => {
+    if (typeof node === "string") return node;
+    if (!node || typeof node !== "object") return null;
+    for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+      if (key === "types") continue;
+      if (key === "default" || key === "import" || key === "node") {
+        const found = walk(value);
+        if (found) return found;
+      }
+    }
+    return null;
+  };
+  return walk(manifest.exports[subpath]);
+}
+
+/**
+ * Rows of the entry-point table whose "covered exports" cell is a list of
+ * backticked identifiers. Rows written as prose (the preset factories, the
+ * jest-compat runtime shims, the types-only entry) are handled separately.
+ */
+function documentedEntryRows(): Array<{ subpath: string; exports: string[] }> {
+  const rows: Array<{ subpath: string; exports: string[] }> = [];
+  for (const line of doc.split("\n")) {
+    const match = /^\|\s*`(vitest-native[^`]*)`\s*\|\s*(.+?)\s*\|\s*$/.exec(line);
+    if (!match) continue;
+    const [, specifier, cell] = match;
+    // Only cells that are purely a comma-separated list of code spans.
+    if (!/^`[^`]+`(?:,\s*`[^`]+`)*$/.test(cell)) continue;
+    const subpath =
+      specifier === "vitest-native" ? "." : `./${specifier.split("/").slice(1).join("/")}`;
+    rows.push({ subpath, exports: [...cell.matchAll(/`([^`]+)`/g)].map((m) => m[1]).sort() });
+  }
+  return rows;
+}
+
+async function actualExports(subpath: string): Promise<string[]> {
+  const target = esmTarget(subpath);
+  if (!target) throw new Error(`no ESM target for ${subpath}`);
+  const mod = (await import(pathToFileURL(path.join(packageRoot, target)).href)) as Record<
+    string,
+    unknown
+  >;
+  return Object.keys(mod)
+    .filter((k) => k !== "default")
+    .sort();
+}
+
+describe("versioning contract matches the build", () => {
+  it("finds entry rows to check, so the assertions below are not vacuous", () => {
+    const rows = documentedEntryRows();
+    expect(rows.length).toBeGreaterThanOrEqual(5);
+    // Every listed subpath must actually be exported by the manifest.
+    const undeclared = rows.filter((r) => !(r.subpath in manifest.exports)).map((r) => r.subpath);
+    expect(undeclared, "documented but not in the exports map").toEqual([]);
+  });
+
+  it.runIf(distExists)("names exactly the exports each documented entry point has", async () => {
+    const mismatches: string[] = [];
+    for (const { subpath, exports: documented } of documentedEntryRows()) {
+      const actual = await actualExports(subpath);
+      const missing = actual.filter((e) => !documented.includes(e));
+      const extra = documented.filter((e) => !actual.includes(e));
+      if (missing.length > 0) {
+        mismatches.push(`${subpath}: exported but undocumented — ${missing.join(", ")}`);
+      }
+      if (extra.length > 0) {
+        mismatches.push(`${subpath}: documented but not exported — ${extra.join(", ")}`);
+      }
+    }
+    expect(mismatches, `docs/versioning.md is out of date:\n${mismatches.join("\n")}`).toEqual([]);
+  });
+
+  it.runIf(distExists)("states the right number of preset factories", async () => {
+    const stated = /the (\d+) preset factories/.exec(doc);
+    expect(stated, "the preset row no longer states a count").not.toBeNull();
+    const actual = await actualExports("./presets");
+    expect(Number(stated![1]), `docs say ${stated![1]}, build has ${actual.length}`).toBe(
+      actual.length,
+    );
+  });
+
+  it("names exactly the plugin options the validator accepts", async () => {
+    // The validator rejects unknown keys, so its list is the real option surface.
+    const validate = fs.readFileSync(path.join(packageRoot, "src", "validate.ts"), "utf8");
+    const block = /const KNOWN_OPTIONS = \[([\s\S]*?)\]/.exec(validate);
+    expect(block, "KNOWN_OPTIONS not found in validate.ts").not.toBeNull();
+    const accepted = [...block![1].matchAll(/"([^"]+)"/g)].map((m) => m[1]).sort();
+
+    const documentedLine = doc
+      .split("\n")
+      .find((l) => l.includes("keys accepted by the plugin function"));
+    expect(documentedLine, "the plugin-options sentence moved or lost its list").toBeDefined();
+    // The sentence continues onto following lines; take the whole paragraph.
+    const paragraph = doc.slice(doc.indexOf(documentedLine!)).split("\n\n")[0];
+    const documented = [...paragraph.matchAll(/`([^`]+)`/g)]
+      .map((m) => m[1])
+      // Option names are bare identifiers; anything with parentheses is a
+      // function being referred to in prose, not an option.
+      .filter((name) => !name.includes("("))
+      .sort();
+
+    expect(documented, "docs/versioning.md plugin options differ from KNOWN_OPTIONS").toEqual(
+      accepted,
+    );
+  });
+});


### PR DESCRIPTION
## Why

The package ships stability *labels* — which surfaces are release-supported, which are experimental — but has never had a **semver contract**. Nothing said which exports and options are covered, what a major is allowed to break, how the peer ranges may move as Node, Vite, Vitest, React Native and RNTL move, or what a deprecation looks like.

That is the thing 1.0 has to mean, and it did not exist in writing. `release-readiness.md` still says only "Pre-1.0 APIs can still change with release notes."

## What this adds

`docs/versioning.md`, which ships with the package (`files` includes `docs`):

- **Covered surface** — every entry point and its exports, the plugin options, the preset authoring contract, error `code` values, and the CLI command names and exit codes.
- **Outside the contract** — message wording, what a preset mocks (it tracks upstream), mock-engine fidelity details, deep imports into `dist/`, cache layout.
- **Experimental** — `hotRuntime`, excluded at every version including after 1.0, because it is built on Vitest's experimental custom-pool API.
- **Upstream support ranges** — adding support is a minor; dropping a version upstream has already end-of-lifed is a minor; dropping one upstream still supports is a major.
- **Deprecation** — warn in a minor, remove no earlier than the next major.
- **What 1.0 means.**

## The part that matters

The document enumerates the public surface, so it is **checked rather than trusted**.

This repository has already shipped a false claim of exactly this kind: "all normal public APIs are gated as dual ESM/CommonJS exports" sat in the release-readiness policy while three of them could not be `require`d at all (#132). A contract is a much larger claim, and prose drifts the moment an export is added.

`tests/versioning-contract.test.ts` loads each documented entry point and asserts:

- the export lists match **exactly, in both directions** — an export that exists but is undocumented fails, and so does a documented export that does not exist;
- the stated preset-factory count matches the build;
- the documented plugin options are exactly the keys `validate.ts` accepts.

Four injected mutations each fail it:

| Mutation | Caught by |
| --- | --- |
| drop `setInsets` from the documented list | export-set equality |
| document a `resetEverything` that does not exist | export-set equality |
| state 15 preset factories instead of 16 | count check |
| add an option to `KNOWN_OPTIONS`, not to the docs | option-set equality |

Plus a vacuity guard: the suite fails if fewer than five entry rows are found to check.

## Decisions worth confirming

These are product calls rather than facts, and are easy to change — flagging them explicitly:

1. **The `Preset` extension point is treated as stable.** Third parties can author presets, so `{ name, modules, config? }` is covered. `factory` may gain *optional* parameters in a minor, which keeps the door open to passing dependencies in without a breaking change.
2. **Dropping an end-of-life upstream version is a minor, not a major.** Treating every peer-range change as a major would leave the package unable to follow its own dependencies, which is the main way a tool in this position dies.
3. **`hotRuntime` stays experimental through 1.0**, rather than 1.0 waiting on it.

## Scope

Docs and one test. No source change. Also cross-links `release-readiness.md` (tested) and `versioning.md` (promised) so the two do not drift apart, and points both READMEs at it.