### PR TITLE
fix(native): pin the registry's external dependencies, not just React

### DIFF
--- a/.changeset/registry-external-manifest.md
+++ b/.changeset/registry-external-manifest.md
@@ -1,0 +1,24 @@
+---
+"vitest-native": patch
+---
+
+Invalidate the React Native registry when any baked-in dependency changes, not just React
+
+The precompiled registry inlines React Native's own graph and leaves everything else —
+`react`, `invariant`, `nullthrows`, `@babel/runtime`, `stacktrace-parser` and others —
+as a normal `require` at a **pre-resolved absolute path** compiled into the emitted
+file. Those paths are only correct while the packages they point at stay where they
+were, but only React Native's own files were pinned against change.
+
+A previous fix named `react` in the cache key after upgrading React produced a null
+React dispatcher and React Native singletons that no longer compared equal. That fixed
+one package out of eleven. Naming the rest in the key one at a time would be a list
+that rots — the next dependency added to React Native's graph would not be on it.
+
+The resolved external targets are now recorded in the registry's manifest alongside
+React Native's own files, so the existing size-and-mtime check covers them. That works
+for both `node_modules` layouts: under bun and pnpm a version change moves the path, so
+the stat fails; under a flat npm or yarn tree the path survives but the file changes.
+
+Eleven packages are pinned in this repository's build. Verified by changing `invariant`
+under a warm cache: the registry rebuilds, where before it was reused unchanged.

--- a/packages/vitest-native/src/native/registry.mjs
+++ b/packages/vitest-native/src/native/registry.mjs
@@ -421,6 +421,11 @@ export function buildRegistry({
   const options = { projectRoot, platform, reactNativeVersion, assetExtSet };
   const modules = new Map();
   const manifest = [];
+  // Targets the registry does NOT inline but DOES bake in as pre-resolved absolute
+  // paths. They belong in the manifest for the same reason React Native's own files
+  // do: if one moves or changes, the paths compiled into the registry are wrong.
+  // See the note above the manifest write below.
+  const externals = new Set();
   try {
     const entry = createRequire(path.join(projectRoot, "package.json")).resolve("react-native");
     const queue = [entry];
@@ -444,11 +449,34 @@ export function buildRegistry({
             !PASSTHROUGH_EXT.has(path.extname(target).toLowerCase());
           deps[request] = target;
           if (internal) queue.push(target);
+          else if (target !== null) externals.add(target);
         }
       }
       modules.set(file, { code, deps });
       const st = fs.statSync(file);
       manifest.push([file, st.mtimeMs, st.size]);
+    }
+
+    // Externals are require()d through pre-resolved absolute paths baked into the
+    // emitted registry, so the registry is only valid while those paths still point
+    // at what they pointed at when it was built. Nothing noticed when they did not:
+    // upgrading React served a registry whose baked path was a react directory that
+    // no longer existed, and the fallback produced a second React — a null dispatcher
+    // and React Native singletons that stopped comparing equal.
+    //
+    // Naming the packages in the cache key instead would work only for the ones
+    // somebody remembered to name. Statting the resolved targets covers every
+    // external there is, and covers both node_modules layouts: under bun and pnpm a
+    // version change moves the path, so the stat fails; under a flat npm or yarn tree
+    // the path survives but the file's size and mtime change.
+    for (const target of externals) {
+      try {
+        const st = fs.statSync(target);
+        manifest.push([target, st.mtimeMs, st.size]);
+      } catch {
+        // Not a real file on disk (a native addon resolved elsewhere, a virtual
+        // target). Nothing to pin; the runtime require still decides.
+      }
     }
 
     const files = [...modules.keys()];

--- a/packages/vitest-native/tests-native/registry.test.ts
+++ b/packages/vitest-native/tests-native/registry.test.ts
@@ -229,3 +229,62 @@ describe("precompiled RN registry: module semantics", () => {
     expect(typeof real).toBe("function");
   });
 });
+
+/**
+ * The registry inlines React Native's own graph and leaves everything else — react,
+ * invariant, nullthrows, @babel/runtime — as a normal require at a PRE-RESOLVED
+ * absolute path baked into the emitted file. Those paths are only correct while the
+ * packages they point at stay put, so they have to be pinned like React Native's own
+ * files are.
+ *
+ * They were not. Upgrading React served a registry whose baked path pointed at a
+ * react directory that no longer existed; the fallback produced a second React, and
+ * the suite failed with a null dispatcher and RN singletons that stopped comparing
+ * equal. `react` was then named in the cache key, which fixed that one package and
+ * left the rest — the manifest is what covers them all.
+ */
+describe("precompiled RN registry: external dependency pinning", () => {
+  const manifestOf = (registryFile: string): Array<[string, number, number]> =>
+    JSON.parse(fs.readFileSync(`${registryFile}.json`, "utf8")).manifest;
+
+  const isReactNative = (file: string) =>
+    /[\\/]node_modules[\\/](react-native|@react-native)[\\/]/.test(file);
+
+  it("pins React Native's own files", () => {
+    // Control: without this, the assertions below could pass on an empty manifest.
+    const own = manifestOf(build()).filter(([f]) => isReactNative(f));
+    expect(own.length).toBeGreaterThan(100);
+  });
+
+  it("pins the external packages whose resolved paths it bakes in", () => {
+    const external = manifestOf(build()).filter(([f]) => !isReactNative(f));
+    expect(
+      external.length,
+      "no non-React-Native entry is pinned, so upgrading react/invariant/etc cannot invalidate the cache",
+    ).toBeGreaterThan(0);
+
+    const packagesOf = (files: string[]) => {
+      const names = new Set<string>();
+      for (const file of files) {
+        const matches = [...file.matchAll(/node_modules[\\/](@[^\\/]+[\\/][^\\/]+|[^\\/]+)/g)];
+        const last = matches.at(-1);
+        if (last) names.add(last[1].replace(/\\/g, "/"));
+      }
+      return names;
+    };
+    // react is the one that caused a real failure; invariant stands for the rest,
+    // which naming packages in the cache key one at a time would keep missing.
+    const pinned = packagesOf(external.map(([f]) => f));
+    expect([...pinned]).toContain("react");
+    expect([...pinned]).toContain("invariant");
+  });
+
+  it("records each pinned file with the size and mtime the check compares", () => {
+    for (const entry of manifestOf(build()).filter(([f]) => !isReactNative(f))) {
+      const [file, mtimeMs, size] = entry;
+      expect(typeof mtimeMs, `${file} has no mtime`).toBe("number");
+      expect(typeof size, `${file} has no size`).toBe("number");
+      expect(fs.statSync(file).size).toBe(size);
+    }
+  });
+});


### PR DESCRIPTION
Follow-up to #134. That fix was correct but narrow — it closed one instance of a class.

## The class

The precompiled registry inlines React Native's own graph and leaves everything else as a normal `require` at a **pre-resolved absolute path** compiled into the emitted file. From `registry.mjs`:

> `__ext` is this file's own require: the escape hatch for targets outside the registry (react, invariant, JSON, anything computed). **Pre-resolved absolute paths** make those lookups exact rather than re-running Node resolution.

Those paths are correct only while the packages they point at stay where they were. But the manifest — the thing that invalidates the cache — stats **only React Native's own files**.

In this repository that leaves eleven packages unpinned:

```
@babel/runtime, anser, ansi-regex, base64-js, flow-enums-runtime,
invariant, memoize-one, nullthrows, react, stacktrace-parser, whatwg-fetch
```

#134 put `react` in the cache key because that is the one that bit. Naming the other ten there too would be a list that rots — the next dependency React Native's graph picks up would not be on it.

## Fix

Resolved external targets go into the manifest alongside React Native's own files, so the size-and-mtime check that already exists covers them. This works for both `node_modules` layouts:

- **bun / pnpm** — a version change moves the path, so the stat fails
- **flat npm / yarn** — the path survives but the file's size and mtime change

## Verification

Changing `invariant` under a warm cache:

| | Result |
| --- | --- |
| `main` | **stale registry reused** |
| this branch | **rebuilt** |

The new test in `tests-native/registry.test.ts` asserts the manifest pins non-React-Native packages, and specifically `react` and `invariant`. It fails without the fix (`expected 0 to be greater than 0`). A companion test asserts React Native's own files are still pinned, so the new assertions cannot pass on an empty manifest.

Suites: mock 75 files / 1635 passed, native 47 files / 220 passed, android 3 passed. Lint, format, typecheck clean.

## Two candidates checked and cleared

Auditing every cache the package writes turned up two more suspects. Both were **verified sound rather than changed**:

- **The transform cache.** Its disk key hashes platform, filename, and file *content*; its directory names the preset version, Babel version, and Babel env. Nothing missing.
- **`assetExts` is absent from the registry key**, which looks like exactly the same bug. It is not. Two fresh registries built with deliberately divergent asset extensions are **byte-identical** — React Native's own graph does not require user asset types, so the per-file hooks own that. Left alone.

## A misreading, corrected

Mid-investigation the registry appeared to rebuild on **every run**, which would have meant the disk cache never worked at all. It does not. The rewrite is the suite's own `registry.test.ts` calling `buildRegistry` directly against the real project root. With diagnostics on, the plugin reports:

```
[vitest-native] (native) reusing precompiled RN registry (439 modules)
```

No production defect there. Recording it because the symptom is convincing and someone will hit it again — and because the control that separated the two was running the same measurement on unmodified `main`.