### PR TITLE
fix(build): run tsdown under bun's runtime so the build works on Node 20

### DIFF
--- a/.changeset/build-under-bun.md
+++ b/.changeset/build-under-bun.md
@@ -1,0 +1,19 @@
+---
+"vitest-native": patch
+---
+
+Build with tsdown under bun's runtime
+
+tsdown's bin declares a Node shebang, and from 0.22 it calls `Promise.withResolvers` —
+an API Node did not ship until 21. Building on Node 20 therefore failed with
+`TypeError: Promise.withResolvers is not a function`, which blocked the dev-dependency
+updates that carry tsdown forward.
+
+`build` now invokes `bunx --bun tsdown`, so the bundler runs under bun's runtime, which
+has the API. The emitted `dist` is byte-identical either way, verified by hashing it
+from both runtimes against tsdown 0.21 and 0.22.
+
+This is a change to what the build toolchain runs on, not to what the package requires.
+The published `engines` floor of Node >= 20.19 is unchanged, and the Node 20 CI legs —
+which prove that floor and pin RNTL 12 and 13 as the lower-bound back-compat corners —
+keep running everything they ran before.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,13 +31,27 @@ bun run test
 
 | Command | Description |
 |---|---|
-| `bun run build` | Build the package |
+| `bun run build` | Build the package (runs tsdown under bun's runtime — see below) |
 | `bun run test` | Run tests |
 | `bun run test:example` | Build and test the example app |
 | `bun run lint` | Lint with oxlint |
 | `bun run format` | Format with oxfmt |
 | `bun run format:check` | Check formatting (CI) |
 | `bun run typecheck` | Type-check with tsc |
+
+### Why the build runs tsdown under bun
+
+`build` invokes `bunx --bun tsdown` rather than `tsdown`. tsdown's bin declares a Node
+shebang, and from 0.22 it calls `Promise.withResolvers`, which Node did not ship until
+21 — so building on Node 20 fails with `TypeError: Promise.withResolvers is not a
+function`. Bun's runtime has it.
+
+The Node 20 CI legs exist to prove the package's *runtime* floor and to pin RNTL 12 and
+13 as the lower-bound back-compat corners. What toolchain the build itself runs under is
+a separate question from what Node a consumer needs, so the floor stays where it is.
+
+The output is identical either way — verified by hashing `dist` from both runtimes on
+tsdown 0.21 and 0.22.
 
 ## Releasing
 

--- a/packages/vitest-native/package.json
+++ b/packages/vitest-native/package.json
@@ -172,7 +172,7 @@
     "vitest": "4.1.9"
   },
   "scripts": {
-    "build": "tsdown && node scripts/copy-static-types.mjs",
+    "build": "bunx --bun tsdown && node scripts/copy-static-types.mjs",
     "test": "vitest run",
     "test:native": "vitest run --config tests-native/vitest.config.mts",
     "test:native:forks": "vitest run --config tests-native/vitest.forks.config.mts",


### PR DESCRIPTION
Unblocks #137, which has been red since the dev-dependency group picked up tsdown 0.22.

## The failure

tsdown's bin declares a Node shebang, and from 0.22 it calls `Promise.withResolvers` — an API Node did not ship until **21**. On the Node 20.19 CI legs:

```
ERROR TypeError: Promise.withResolvers is not a function
    at initBundleByPkg (…/tsdown/dist/build-D_enfyvD.mjs:302:41)
```

Reproduced locally against Node 20.19.4 rather than inferred from the CI log — it is tsdown's own code, not a transitive dependency.

## The fix

`build` now invokes `bunx --bun tsdown`, so the bundler runs under bun's runtime, which has the API. `node scripts/copy-static-types.mjs` still runs under real Node — only the bundler's runtime moves.

## The output is identical

Verified by hashing every file in `dist` from both runtimes, against **both** the current tsdown and the blocked bump:

| tsdown | node runtime | bun runtime |
| --- | --- | --- |
| 0.21.10 (current) | `6744e9ed…` | `6744e9ed…` |
| 0.22.14 (blocked bump) | *fails on Node 20* | `579ff2a8…` (matches the Node 24 node-runtime build) |

Same 66 files, same aggregate digest.

## Why not just drop Node 20

That was the tempting fix and I want to be explicit about rejecting it. Node 20 is end-of-life, and `docs/versioning.md` makes dropping an EOL version a minor — so it would have been defensible on paper.

But those legs are not decoration. Per the matrix comment in `ci.yml`, they prove the package's **runtime floor** and pin **RNTL 12 and 13** as the lower-bound back-compat corners, because RNTL 14 requires Node >= 22.13. Node 20 users are on Node 20 *precisely because* of that constraint — dropping them to make a dependency bump go green would be deciding a support question for the wrong reason.

What the build toolchain runs on is a separate question from what a consumer needs. `engines` is unchanged at Node >= 20.19.

The other option considered was building once on Node 22+ and sharing `dist` as an artifact. That is a reasonable shape, but it costs Windows and macOS build coverage, and it is a real CI restructure where this is one word.

## Verification

- build: 66 files, `check:size` within budget
- mock 75 files / 1635 passed; native 47 files / 217 passed
- lint, format, typecheck clean

CONTRIBUTING records why the indirection exists, so `bunx --bun` does not read as a stray incantation later.

After this lands, #137 should go green on a dependabot rebase.