### PR TITLE
ci: check React Native API coverage on pull requests

### DIFF
--- a/.changeset/api-coverage-on-prs.md
+++ b/.changeset/api-coverage-on-prs.md
@@ -1,0 +1,21 @@
+---
+"vitest-native": patch
+---
+
+Check React Native API coverage on every pull request
+
+The mock engine is documented as covering every stable React Native export, and
+`check-compat` is the script that backs the claim: it parses the real `react-native`
+index and fails when a stable export has no mock.
+
+It ran only in the weekly compatibility workflow, and there against
+`react-native@latest`. The version actually pinned in the repository was never checked
+on a pull request. A change that moved the pinned React Native could add stable exports
+the mock did not cover and still go green, with the gap appearing days later as a
+canary failure against a different version.
+
+It now runs in the pull-request gate against the pinned React Native, on the one matrix
+leg where the React Native version is representative. The weekly canary keeps its own
+edge run — the two answer different questions.
+
+Currently 85 of 85 stable exports are covered.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,18 @@ jobs:
         if: runner.os == 'Linux' && matrix.node-version == '22.13.0' && !matrix.rntl
         run: bun run --filter vitest-native check:size
 
+      - name: React Native API coverage (pinned RN)
+        # The README claims the mock engine covers every stable React Native export.
+        # check-compat is what backs that claim, and it ran only in the weekly
+        # compat-check workflow — against react-native@latest, never against the
+        # version actually pinned here. So a pull request that moved the pinned RN
+        # could add stable exports the mock does not cover and still go green, with
+        # the gap surfacing days later as a canary failure against a different
+        # version. One leg is enough: RN is identical across the matrix, only RNTL
+        # varies. The canary keeps its own edge run.
+        if: runner.os == 'Linux' && matrix.node-version == '22.13.0' && !matrix.rntl
+        run: bun run --filter vitest-native check-compat
+
       - name: Test
         run: bun run test
 


### PR DESCRIPTION
## The gap

The README makes this claim:

> **100% public API coverage** (mock engine) — every stable React Native export is mocked.

`check-compat` is the script that backs it. It parses the real `react-native` index and fails when a stable export has no mock.

It ran in exactly one place — `compat-check.yml`, which is `schedule:` + `workflow_dispatch:` only, and which installs `react-native@latest` first.

So the React Native version **actually pinned in this repository** was never checked on a pull request. A change that moved the pinned RN could introduce stable exports the mock does not cover and go green; the gap would surface days later as a canary failure, against a different version than the one that caused it.

## Fix

`check-compat` now runs in the pull-request gate, against the pinned React Native.

It runs on one leg, guarded by the same condition as `check:size` — React Native is identical across the matrix, only RNTL varies, so a second run would prove nothing. The weekly canary keeps its edge run: the two answer different questions.

| | Question |
| --- | --- |
| PR gate (new) | does the version we ship against still hold? |
| Weekly canary | is upstream about to break us? |

## Verified load-bearing

Not assumed — mutated. Removing the `Vibration` mock from the registry:

```
To fix:
  1. Add a mock to src/mocks/ and register it in src/mocks/registry.ts
  2. Or add to KNOWN_SKIPPED in scripts/check-compat.ts if unstable/experimental
error: script "check-compat" exited with code 1
```

Restored: `OK — All stable exports covered (85/85, 100%); 14 of 99 total exports intentionally skipped`.

The workflow was also parsed with a real YAML parser to confirm the step lands in the right job with the intended condition.

## Note on the other schedule-only workflow

`compat-check.yml` staying schedule-only is **correct** and deliberate — it installs `react-native@latest`, so running it per-PR would fail pull requests for reasons unrelated to them. Only the pinned-version check belonged in the gate. Recording that so it does not get "fixed" later.