### PR TITLE
fix(cli): report the real Node floor, and catch RNTL 14's missing peer

### DIFF
--- a/.changeset/doctor-floor-and-peers.md
+++ b/.changeset/doctor-floor-and-peers.md
@@ -1,0 +1,20 @@
+---
+"vitest-native": patch
+---
+
+`doctor` reports the real Node floor, and catches RNTL 14's missing peer
+
+Two cases where `doctor` said a project was fine while it was not.
+
+**The Node floor was hardcoded and compared on the major only.** It printed
+"floor: 20" and passed any Node 20.x, but the real floor moved to 20.19 — the version
+that added `require(esm)`, which the root entry point now depends on. Node 20.0 through
+20.18 were reported as supported. The floor is now read from this package's own
+`engines.node`, and compared as major and minor.
+
+**RNTL 14 declares `test-renderer` as a non-optional peer** and reconciles through it.
+Installing RNTL 14 without it is easy — npm only warns, and any `--legacy-peer-deps`
+install is silent — and the result is that every `render()` throws `Cannot find module
+'test-renderer'`, naming no file and no package. `doctor` reported no blocking problems
+for exactly that project. It now fails with the install command. RNTL 13 is unaffected
+and is not asked for the package it does not use.

--- a/packages/vitest-native/src/cli/doctor.ts
+++ b/packages/vitest-native/src/cli/doctor.ts
@@ -26,6 +26,26 @@ function packageVersion(root: string, name: string): string | null {
 }
 
 /**
+ * The supported Node floor, as [major, minor], read from this package's own
+ * `engines.node`. Single source: the manifest is what a package manager enforces
+ * at install time, so a diagnostic must not carry its own copy of the number.
+ */
+export function nodeFloor(): [number, number] {
+  const fallback: [number, number] = [20, 19];
+  try {
+    const manifest = JSON.parse(
+      fs.readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
+    ) as { engines?: { node?: string } };
+    const match = /(\d+)\.(\d+)/.exec(manifest.engines?.node ?? "");
+    return match ? [Number(match[1]), Number(match[2])] : fallback;
+  } catch {
+    // Bundled layouts can put the manifest elsewhere; a stale-but-close floor is
+    // better than a diagnostic that throws.
+    return fallback;
+  }
+}
+
+/**
  * In Vitest's own precedence order: a `vitest.config.*` wins, and `vite.config.*`
  * is used when there is none.
  *
@@ -203,8 +223,22 @@ export function runDoctor(root: string, nodeVersion: string = process.versions.n
   // --- Runtime ---
   lines.push("", "Runtime");
   const nodeMajorMinor = nodeVersion.split(".").slice(0, 2).map(Number);
-  if (nodeMajorMinor[0] >= 20) pass(`Node ${nodeVersion} (floor: 20)`);
-  else fail(`Node ${nodeVersion} — vitest-native requires Node >= 20.`);
+  // The floor is read from this package's own `engines.node` rather than written
+  // out here. It was hardcoded as 20, and compared on the MAJOR only, so when the
+  // real floor moved to 20.19 — the version that added require(esm), which the
+  // root entry point now depends on — doctor kept passing Node 20.0 and kept
+  // printing "floor: 20". A number a user reads off a diagnostic has to come from
+  // the same place the runtime enforces it.
+  const [floorMajor, floorMinor] = nodeFloor();
+  const floorText = `${floorMajor}.${floorMinor}`;
+  if (
+    nodeMajorMinor[0] > floorMajor ||
+    (nodeMajorMinor[0] === floorMajor && nodeMajorMinor[1] >= floorMinor)
+  ) {
+    pass(`Node ${nodeVersion} (floor: ${floorText})`);
+  } else {
+    fail(`Node ${nodeVersion} — vitest-native requires Node >= ${floorText}.`);
+  }
 
   // --- Required peers ---
   lines.push("", "Peer dependencies");
@@ -277,6 +311,19 @@ export function runDoctor(root: string, nodeVersion: string = process.versions.n
       fail(
         `@testing-library/react-native ${rntl} requires Node >= 22.13, but this is Node ${nodeVersion}. ` +
           `Upgrade Node or pin @testing-library/react-native@13.`,
+      );
+    } else if (rntlMajor >= 14 && !packageVersion(rootFor("test-renderer"), "test-renderer")) {
+      // RNTL 14 declares `test-renderer` as a NON-optional peer and reconciles
+      // through it. Without it every render throws "Cannot find module
+      // 'test-renderer'" — no file, no package, nothing pointing at the cause —
+      // while doctor reported no blocking problems. Installing RNTL 14 without its
+      // peer is easy: npm only warns, and any `--legacy-peer-deps` install is
+      // silent. This is blocking rather than a warning: RNTL itself is optional,
+      // but once RNTL 14 is present every render() in the project fails.
+      fail(
+        `@testing-library/react-native ${rntl} requires the 'test-renderer' package, which is not installed. ` +
+          `Every render() will fail with "Cannot find module 'test-renderer'". ` +
+          `Install it:\n\n  npm install -D test-renderer\n`,
       );
     } else {
       pass(

--- a/packages/vitest-native/tests/doctor-floor-and-peers.test.ts
+++ b/packages/vitest-native/tests/doctor-floor-and-peers.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Two things doctor got wrong, both found by running it against a project that was
+ * actually broken and watching it report no blocking problems.
+ *
+ * 1. The Node floor was hardcoded as 20 and compared on the MAJOR only. When the real
+ *    floor moved to 20.19 — the version that added require(esm), which the root entry
+ *    point depends on — doctor kept passing Node 20.0 and kept printing "floor: 20".
+ * 2. RNTL 14 declares `test-renderer` as a non-optional peer and reconciles through it.
+ *    Without it every render throws "Cannot find module 'test-renderer'", naming no
+ *    file and no package, while doctor said the project was fine.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { nodeFloor, runDoctor } from "../src/cli/doctor.js";
+
+const roots: string[] = [];
+afterAll(() => {
+  for (const r of roots) fs.rmSync(r, { recursive: true, force: true });
+});
+
+/** A project root with the given packages installed at the given versions. */
+function project(installed: Record<string, string>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vn-doctor-floor-"));
+  roots.push(root);
+  fs.writeFileSync(path.join(root, "package.json"), JSON.stringify({ name: "app" }));
+  for (const [name, version] of Object.entries(installed)) {
+    const dir = path.join(root, "node_modules", ...name.split("/"));
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, "package.json"),
+      JSON.stringify({ name, version, main: "index.js" }),
+    );
+    fs.writeFileSync(path.join(dir, "index.js"), "module.exports = {};");
+  }
+  return root;
+}
+
+const runtimeLine = (root: string, node: string) =>
+  runDoctor(root, node).lines.find((l) => l.includes("Node ")) ?? "";
+
+const testingLine = (root: string) => {
+  const { lines } = runDoctor(root, "22.13.0");
+  const start = lines.indexOf("Testing library");
+  return lines.slice(start + 1, start + 2).join(" ");
+};
+
+describe("doctor: the Node floor comes from engines.node", () => {
+  it("matches this package's own manifest", () => {
+    const manifest = JSON.parse(
+      fs.readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+    ) as { engines: { node: string } };
+    const [major, minor] = nodeFloor();
+    expect(manifest.engines.node).toContain(`${major}.${minor}`);
+  });
+
+  it("prints the floor it actually enforces", () => {
+    const [major, minor] = nodeFloor();
+    expect(runtimeLine(project({}), "24.0.0")).toContain(`floor: ${major}.${minor}`);
+  });
+
+  it("fails a Node below the floor even when the major matches", () => {
+    const [major, minor] = nodeFloor();
+    // The bug: 20.18 has the right major, and passed.
+    expect(minor).toBeGreaterThan(0);
+    const line = runtimeLine(project({}), `${major}.${minor - 1}.0`);
+    expect(line).toContain("✗");
+    expect(line).toContain(`requires Node >= ${major}.${minor}`);
+  });
+
+  it("passes exactly at the floor", () => {
+    const [major, minor] = nodeFloor();
+    expect(runtimeLine(project({}), `${major}.${minor}.0`)).toContain("✓");
+  });
+});
+
+describe("doctor: RNTL 14 needs test-renderer", () => {
+  it("fails when RNTL 14 is installed without it", () => {
+    const root = project({ "@testing-library/react-native": "14.0.1" });
+    const line = testingLine(root);
+    expect(line).toContain("✗");
+    expect(line).toContain("test-renderer");
+    expect(runDoctor(root, "22.13.0").ok).toBe(false);
+  });
+
+  it("passes when it is installed", () => {
+    const line = testingLine(
+      project({ "@testing-library/react-native": "14.0.1", "test-renderer": "1.2.0" }),
+    );
+    expect(line).toContain("✓");
+    expect(line).not.toContain("test-renderer");
+  });
+
+  it("does not demand it for RNTL 13, which does not use it", () => {
+    // A control: without this, requiring test-renderer unconditionally would pass
+    // both assertions above while breaking every RNTL 13 project.
+    const line = testingLine(project({ "@testing-library/react-native": "13.2.0" }));
+    expect(line).not.toContain("test-renderer");
+  });
+});


### PR DESCRIPTION
Both of these were found the same way: by building a project that a real user would build, watching every test in it fail, and then watching `doctor` say this:

```
✓ No blocking problems found.
```

## 1. RNTL 14's missing peer

RNTL 14 declares `test-renderer` as a **non-optional** peer and reconciles through it:

```json
"peerDependencies": { "jest": ">=29.0.0", "react": ">=19.0.0",
                      "react-native": ">=0.78", "test-renderer": "^1.0.0" }
```

Installing RNTL 14 without it is easy — npm only warns, and any `--legacy-peer-deps` install is silent. Every `render()` then throws:

```
Error: Cannot find module 'test-renderer'
```

No file, no package, nothing pointing at the cause. In the probe project this took out **6 of 10 test files**, and `doctor` reported the project healthy.

It now fails with the fix, and only for RNTL >= 14 — 13 does not use the package and is not asked for it, which the third test pins so the check cannot regress into breaking every RNTL 13 project.

## 2. A Node floor that was neither current nor correctly compared

```
✓ Node 24.13.0 (floor: 20)
```

The floor was hardcoded as `20` and compared on the **major only**. The real floor moved to **20.19** in #132 — the version that added `require(esm)`, which the root entry point now depends on. So Node 20.0 through 20.18 were reported as supported, on a package that cannot be `require`d there.

It is now read from this package's own `engines.node` and compared as major *and* minor. A number a user reads off a diagnostic should come from the same place a package manager enforces it — this is the third time a version range in this repo has been written out in a second place and drifted.

```
✓ Node 24.13.0 (floor: 20.19)
```

## Verified

Against a real project rather than only in unit tests — with `test-renderer` removed, `doctor` exits **1** with:

```
✗ @testing-library/react-native 14.0.1 requires the 'test-renderer' package, which is
  not installed. Every render() will fail with "Cannot find module 'test-renderer'".
  Install it:

  npm install -D test-renderer
```

Mutation-tested: restoring the hardcoded major-only floor fails two tests; removing the peer check fails a third.

Suites: mock 76 files / 1642 passed, native 47 / 220, advice 2. Lint, format, typecheck clean.