### PR TITLE
fix(native): compile a detected package's dependencies too

### DIFF
--- a/.changeset/ecosystem-closure.md
+++ b/.changeset/ecosystem-closure.md
@@ -1,0 +1,29 @@
+---
+"vitest-native": patch
+---
+
+Compile a detected package's dependencies too
+
+`react-native-modal` — and any package like it — failed to import under the native
+engine with a bare `SyntaxError: Unexpected token '<'`, naming no file and no package.
+
+Detection asks each package's own manifest whether it declares `react-native`. The
+untranspiled JSX was not in `react-native-modal`; it was in `react-native-animatable`,
+which that package depends on. Nothing in the project declares it, so it was never a
+candidate, and it names `react-native` in neither `dependencies` nor
+`peerDependencies`, so the manifest test would have rejected it anyway. The documented
+remedy, `transform: ['react-native-modal']`, does not help — only naming
+`react-native-animatable` does, and nothing told anyone that.
+
+A detected package's dependency closure is now compiled with it. Two exclusions keep
+that safe, and both compute themselves rather than being lists to maintain:
+
+- **React Native's own dependencies.** The precompiled registry reaches those through
+  pre-resolved absolute paths, so Node owns them; inlining one would give the same
+  package two owners and two instances.
+- **The transform's own toolchain closure.** The transform runs `@babel/core`, so
+  inlining anything Babel reaches means loading it re-enters the transform while Babel
+  is mid-load.
+
+Detection stays under a millisecond, and 120 isolated test files run in the same time
+as before.

--- a/packages/vitest-native/src/native/ecosystem.ts
+++ b/packages/vitest-native/src/native/ecosystem.ts
@@ -187,21 +187,90 @@ export function detectEcosystemPackages(
   }
   if (candidates.size === 0) return [];
 
-  const detected: string[] = [];
-  for (const name of candidates) {
-    if (skip.has(name) || name.startsWith("@react-native/")) continue;
-    // Resolved from whichever root can see it. Under pnpm a workspace package is
-    // linked only into the package that depends on it, so the run root frequently
-    // cannot resolve what the app can.
+  /** Resolve a package's manifest from whichever root can see it. */
+  const manifestOf = (name: string): Record<string, unknown> | null => {
     for (const req of requires) {
       try {
-        const pkg = req(`${name}/package.json`) as Record<string, unknown>;
-        if (dependsOnReactNative(pkg)) detected.push(name);
-        break;
+        return req(`${name}/package.json`) as Record<string, unknown>;
       } catch {
         // Not resolvable from this root — try the next one.
       }
     }
+    return null;
+  };
+
+  const detected: string[] = [];
+  for (const name of candidates) {
+    if (skip.has(name) || name.startsWith("@react-native/")) continue;
+    const pkg = manifestOf(name);
+    if (pkg && dependsOnReactNative(pkg)) detected.push(name);
   }
-  return detected.sort();
+
+  // A detected package's own runtime dependencies are React Native code too, and the
+  // manifest test cannot see them: they are transitive, so nothing in the project
+  // declares them, and the older ones frequently declare no `react-native` at all.
+  //
+  // react-native-modal is the case that made this concrete. It is detected, and it
+  // still failed with a bare `SyntaxError: Unexpected token '<'` naming no file,
+  // because the untranspiled JSX is in react-native-animatable — its dependency,
+  // which declares `react-native` in neither dependencies nor peerDependencies.
+  // `transform: ['react-native-modal']`, the documented remedy, does not help; only
+  // naming react-native-animatable does, and nothing tells a user that.
+  //
+  // Membership of a detected package's dependency closure is the signal that its
+  // own manifest does not carry. Runtime `dependencies` only: devDependencies are
+  // not shipped, and peerDependencies are supplied by the project and reached
+  // through the normal candidate set.
+  //
+  // React Native's OWN dependencies are excluded. The precompiled registry compiles
+  // React Native's graph and reaches everything outside it — invariant, nullthrows,
+  // scheduler, @babel/runtime — through a pre-resolved absolute path, i.e. Node owns
+  // them. Inlining one of those into Vite as well would hand the same package two
+  // owners and two instances, which is the failure the registry exists to prevent.
+  // Walking react-native-modal's closure reaches `invariant` for exactly this reason,
+  // and it is the one package in that closure React Native also owns.
+  const rnOwned = new Set<string>(Object.keys(manifestOf("react-native")?.dependencies ?? {}));
+
+  /** Every package reachable from `roots` through runtime dependencies. */
+  const closureOf = (starts: string[]): Set<string> => {
+    const seen = new Set<string>();
+    const pending = [...starts];
+    while (pending.length > 0) {
+      const name = pending.pop() as string;
+      if (seen.has(name)) continue;
+      seen.add(name);
+      const deps = manifestOf(name)?.dependencies;
+      if (deps && typeof deps === "object") pending.push(...Object.keys(deps as object));
+    }
+    return seen;
+  };
+
+  // The transform loads @babel/core to do its work. Inlining anything Babel itself
+  // reaches means loading that package re-enters the transform, which needs Babel,
+  // which is mid-load — so it fails as `_babel.transformSync is not a function` or
+  // `Cannot read properties of undefined (reading 'transformSync')`.
+  //
+  // `expo` declares @babel/core as a runtime dependency, so walking its closure
+  // reached Babel and then Babel's own dependencies (chalk among them). Both blew up
+  // the packed Expo consumer, and neither reproduced in a synthetic fixture. Excluding
+  // the toolchain by name would be a list that rots; its closure computes itself.
+  const toolchain = closureOf(["@babel/core", "@react-native/babel-preset"]);
+
+  const inClosure = new Set(detected);
+  const queue = [...detected];
+  while (queue.length > 0) {
+    const pkg = manifestOf(queue.pop() as string);
+    const deps = pkg?.dependencies;
+    if (!deps || typeof deps !== "object") continue;
+    for (const dep of Object.keys(deps as object)) {
+      if (inClosure.has(dep) || skip.has(dep) || dep.startsWith("@react-native/")) continue;
+      if (rnOwned.has(dep)) continue;
+      if (toolchain.has(dep)) continue;
+      if (!manifestOf(dep)) continue; // declared but not installed
+      inClosure.add(dep);
+      queue.push(dep);
+    }
+  }
+
+  return [...inClosure].sort();
 }

--- a/packages/vitest-native/tests/ecosystem-closure.test.ts
+++ b/packages/vitest-native/tests/ecosystem-closure.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Detection reads manifests: a package is React Native ecosystem code when its own
+ * manifest declares `react-native`. That misses a whole class, and the miss is silent.
+ *
+ * react-native-modal is the case. It is detected, and importing it still failed with a
+ * bare `SyntaxError: Unexpected token '<'` naming no file, because the untranspiled
+ * JSX is in react-native-animatable — its dependency, which is transitive (so nothing
+ * in the project declares it) and declares `react-native` in neither dependencies nor
+ * peerDependencies (so the manifest test rejects it). `transform: ['react-native-modal']`,
+ * the documented remedy, does not help.
+ *
+ * A detected package's dependency closure is the signal its members' own manifests do
+ * not carry. React Native's own dependencies are excluded from it: the precompiled
+ * registry reaches those through a pre-resolved absolute path, so Node owns them, and
+ * inlining one into Vite as well would give the same package two owners.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { detectEcosystemPackages } from "../src/native/ecosystem.js";
+
+const roots: string[] = [];
+afterAll(() => {
+  for (const r of roots) fs.rmSync(r, { recursive: true, force: true });
+});
+
+type Pkg = { deps?: string[]; peerDeps?: string[] };
+
+/** A project root with `installed` packages, and the project depending on `declares`. */
+function project(declares: string[], installed: Record<string, Pkg>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vn-closure-"));
+  roots.push(root);
+  fs.writeFileSync(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      name: "app",
+      dependencies: Object.fromEntries(declares.map((d) => [d, "*"])),
+    }),
+  );
+  for (const [name, pkg] of Object.entries(installed)) {
+    const dir = path.join(root, "node_modules", ...name.split("/"));
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, "package.json"),
+      JSON.stringify({
+        name,
+        version: "1.0.0",
+        main: "index.js",
+        ...(pkg.deps ? { dependencies: Object.fromEntries(pkg.deps.map((d) => [d, "*"])) } : {}),
+        ...(pkg.peerDeps
+          ? { peerDependencies: Object.fromEntries(pkg.peerDeps.map((d) => [d, "*"])) }
+          : {}),
+      }),
+    );
+    fs.writeFileSync(path.join(dir, "index.js"), "module.exports = {};");
+  }
+  return root;
+}
+
+describe("ecosystem detection: dependency closure", () => {
+  it("detects a package that declares react-native itself", () => {
+    // Control: the behaviour the closure walk builds on. If this ever fails, the
+    // assertions below are testing nothing.
+    const root = project(["rn-lib"], {
+      "react-native": {},
+      "rn-lib": { peerDeps: ["react-native"] },
+    });
+    expect(detectEcosystemPackages(root)).toContain("rn-lib");
+  });
+
+  it("includes a transitive dependency that declares no react-native", () => {
+    const root = project(["rn-lib"], {
+      "react-native": {},
+      "rn-lib": { peerDeps: ["react-native"], deps: ["untranspiled-dep"] },
+      // The react-native-animatable shape: nothing declares it, and it names
+      // react-native nowhere.
+      "untranspiled-dep": {},
+    });
+    expect(detectEcosystemPackages(root)).toContain("untranspiled-dep");
+  });
+
+  it("follows the closure deeper than one level", () => {
+    const root = project(["rn-lib"], {
+      "react-native": {},
+      "rn-lib": { peerDeps: ["react-native"], deps: ["mid"] },
+      mid: { deps: ["leaf"] },
+      leaf: {},
+    });
+    expect(detectEcosystemPackages(root)).toEqual(expect.arrayContaining(["mid", "leaf"]));
+  });
+
+  it("excludes React Native's own dependencies, which the registry owns", () => {
+    const root = project(["rn-lib"], {
+      // `invariant` is reached both ways: React Native depends on it, and so does
+      // the detected package. Node owns it; inlining it would make two instances.
+      "react-native": { deps: ["invariant"] },
+      "rn-lib": { peerDeps: ["react-native"], deps: ["invariant", "safe-dep"] },
+      invariant: {},
+      "safe-dep": {},
+    });
+    const detected = detectEcosystemPackages(root);
+    expect(detected).not.toContain("invariant");
+    expect(detected).toContain("safe-dep");
+  });
+
+  it("does not reach a package that nothing in the closure depends on", () => {
+    const root = project(["rn-lib", "unrelated"], {
+      "react-native": {},
+      "rn-lib": { peerDeps: ["react-native"] },
+      unrelated: {},
+    });
+    expect(detectEcosystemPackages(root)).not.toContain("unrelated");
+  });
+
+  it("ignores a declared dependency that is not installed", () => {
+    const root = project(["rn-lib"], {
+      "react-native": {},
+      "rn-lib": { peerDeps: ["react-native"], deps: ["absent-dep"] },
+    });
+    expect(detectEcosystemPackages(root)).not.toContain("absent-dep");
+  });
+
+  it("terminates on a dependency cycle", () => {
+    const root = project(["rn-lib"], {
+      "react-native": {},
+      "rn-lib": { peerDeps: ["react-native"], deps: ["a"] },
+      a: { deps: ["b"] },
+      b: { deps: ["a"] },
+    });
+    expect(detectEcosystemPackages(root)).toEqual(expect.arrayContaining(["a", "b"]));
+  });
+
+  it("excludes the transform's own toolchain closure", () => {
+    // @babel/core is what the transform runs. Inlining anything Babel reaches means
+    // loading it re-enters the transform while Babel is mid-load. `expo` declares
+    // @babel/core as a runtime dependency, which is how the closure reached it and
+    // then its own dependencies — two separate blow-ups in the packed Expo consumer,
+    // neither reproducible in a synthetic fixture until this test.
+    const root = project(["rn-lib"], {
+      "react-native": {},
+      "rn-lib": { peerDeps: ["react-native"], deps: ["@babel/core", "safe-dep"] },
+      "@babel/core": { deps: ["babel-helper"] },
+      "babel-helper": {},
+      "safe-dep": {},
+    });
+    const detected = detectEcosystemPackages(root);
+    expect(detected).not.toContain("@babel/core");
+    expect(detected, "a package Babel itself depends on").not.toContain("babel-helper");
+    expect(detected).toContain("safe-dep");
+  });
+});


### PR DESCRIPTION
Fixes #143.

## The failure

`react-native-modal` — one of the most-installed RN libraries — fails to import under the native engine, on both current stable and `latest`:

```
SyntaxError: Unexpected token '<'
```

No file. No package. No stack.

## Why detection missed it

The untranspiled JSX is **not** in `react-native-modal`. It is in `react-native-animatable`, which react-native-modal depends on, and which fails both halves of detection:

- **transitive** — nothing in the project declares it, so it is never a candidate;
- declares `react-native` in **neither** `dependencies` nor `peerDependencies`, so the manifest test would reject it even if it were.

The documented remedy does not work:

```ts
reactNative({ transform: ['react-native-modal'] })      // ❌ still fails
reactNative({ transform: ['react-native-animatable'] }) // ✅
```

Nothing in the error points at the second one.

## Fix

A detected package's dependency closure is compiled with it. Two exclusions keep that safe. **Both compute themselves** — neither is a list someone has to remember to extend:

**React Native's own dependencies.** The registry reaches those through pre-resolved absolute paths, so Node owns them; inlining one gives the same package two owners and two instances. Walking react-native-modal's closure reaches `invariant` for exactly this reason.

**The transform's own toolchain closure**, computed from `@babel/core` and the RN Babel preset. The transform *runs* Babel, so inlining anything Babel reaches means loading it re-enters the transform while Babel is mid-load.

## The second exclusion exists because the consumer gate found it — twice

Neither shape reproduced in a synthetic fixture. `expo` declares `@babel/core` as a **runtime** dependency, so the closure walked into it:

```
Failed to transform '@babel/core' … TypeError: _babel.transformSync is not a function
```

My first attempt excluded `@babel/` **by name**. That fixed the first shape and failed on the second:

```
Failed to transform 'chalk' … Cannot read properties of undefined (reading 'transformSync')
```

`chalk` is Babel's dependency, not Babel. That is why the exclusion is a computed closure rather than a prefix — and it is the same "a list that rots" problem this repo has hit before.

I would have shipped the by-name version if the packed Expo consumer had not existed.

## Measurements

| | before | after |
| --- | --- | --- |
| detection (median, per run) | 0.07ms | **0.30ms** |
| 120 isolated RNTL render files | 4.20s | **4.22s** |

Detection cost is once per run and stays under a millisecond. No runtime change.

## Verification

- mock 1650 passed; native 220; forks 220; android 3; hot 220; advice 2
- **packed consumers: all fixtures pass** (bare RN, Expo, monorepo, current-RN, mock-rntl14, jest-migration)
- lint, format, typecheck clean
- `react-native-modal` now renders with **zero config** in a probe project

8 tests in `tests/ecosystem-closure.test.ts` pin the behaviour, including a cycle, an uninstalled dependency, and both exclusions. Mutation-tested: removing the closure walk fails 4; removing the toolchain exclusion fails 1.