### PR TITLE
feat(presets): add a netInfo preset for @react-native-community/netinfo

### DIFF
--- a/.changeset/netinfo-preset.md
+++ b/.changeset/netinfo-preset.md
@@ -1,0 +1,25 @@
+---
+"vitest-native": minor
+---
+
+Add a `netInfo` preset for `@react-native-community/netinfo`
+
+NetInfo was detected and compiled correctly, and still failed at the native-module
+boundary. The generic stub answers any method with `undefined`; NetInfo awaits
+`getCurrentState()` and reads `state.isInternetReachable` off the result, so a test
+that called `NetInfo.fetch()` died on a TypeError and an unhandled rejection.
+
+No generic stub can infer that shape, which is what earns a preset. It is auto-detected
+like the others, and covers the package's real runtime surface: `configure`, `fetch`,
+`refresh`, `addEventListener`, `useNetInfo`, `useNetInfoInstance`, and the
+`NetInfoStateType` / `NetInfoCellularGeneration` enums — which are TypeScript enums
+re-exported through `export *`, so unlike the rest of that module they do have runtime
+bindings.
+
+The resting state is a connected wifi device. The real library starts at
+`{ type: 'unknown', isConnected: null }` and resolves to the device a moment later; a
+mock has no device, and a null resting state would send every component under test down
+its offline branch. Tests can drive it, and `resetAllMocks()` restores it.
+
+The package is now a devDependency, so the preset's declared exports are checked against
+the real package's TypeScript surface by the existing fidelity gate rather than trusted.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ want no RN at all — fast, deterministic, environment-controllable.
 - **100% public API coverage** (mock engine) — every stable React Native export is mocked.
 - **RNTL compatible** — Works with `@testing-library/react-native` automatically.
 - **Third-party presets** — auto-detected mocks for reanimated, gesture handler, safe area,
-  navigation, screens, async-storage, device-info, mmkv, svg, webview, and Expo.
+  navigation, screens, async-storage, device-info, mmkv, netinfo, svg, webview, and Expo.
 - **React Native packages compile automatically** — any dependency declaring
   `react-native` in its own manifest is detected and compiled, so the ecosystem's
   untranspiled JSX/Flow/TypeScript just works without a hand-maintained list.
@@ -237,6 +237,7 @@ export default defineConfig({
 | `presets.expo()` | `expo-constants`, `expo-font`, `expo-asset`, `expo-linking`, `expo-status-bar`, … | constants, fonts, linking, status bar, splash screen |
 | `presets.deviceInfo()` | `react-native-device-info` | string/bool/number getters with sync + async variants |
 | `presets.mmkv()` | `react-native-mmkv` | in-memory `MMKV` + `useMMKV*` hooks |
+| `presets.netInfo()` | `@react-native-community/netinfo` | connected-wifi state, `fetch`/`refresh`/`addEventListener`/`useNetInfo`, state-type enums |
 | `presets.svg()` | `react-native-svg` | `Svg`, `Path`, `Circle`, `Rect`, `G`, … as host components |
 | `presets.webview()` | `react-native-webview` | `WebView` (default + named) host component |
 

--- a/bun.lock
+++ b/bun.lock
@@ -49,6 +49,7 @@
       "devDependencies": {
         "@babel/core": "^7.29.7",
         "@gorhom/bottom-sheet": "5.2.14",
+        "@react-native-community/netinfo": "12.0.1",
         "@react-native-vector-icons/common": "13.0.1",
         "@react-native-vector-icons/material-icons": "13.1.2",
         "@react-native/babel-preset": "^0.86.2",
@@ -535,6 +536,8 @@
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.76.0", "", { "os": "win32", "cpu": "x64" }, "sha512-5qcirPHO8nKfkoowEVWtpAoVTcYDy6g0UT0NGic450Qv8J2NrOqg4uQ8QppRP4MDTC7Xx47lbZnmadTH03CGGA=="],
 
     "@quansync/fs": ["@quansync/fs@1.0.0", "", { "dependencies": { "quansync": "^1.0.0" } }, "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ=="],
+
+    "@react-native-community/netinfo": ["@react-native-community/netinfo@12.0.1", "", { "peerDependencies": { "react": "*", "react-native": ">=0.59" } }, "sha512-P/3caXIvfYSJG8AWJVefukg+ZGRPs+M4Lp3pNJtgcTYoJxCjWrKQGNnCkj/Cz//zWa/avGed0i/wzm0T8vV2IQ=="],
 
     "@react-native-vector-icons/common": ["@react-native-vector-icons/common@13.0.1", "", { "dependencies": { "find-up": "^8.0.0", "picocolors": "^1.1.1", "plist": "^3.1.0" }, "peerDependencies": { "@react-native-vector-icons/get-image": "^13.0.0", "@react-native/assets-registry": "*", "expo-font": "*", "react": "*", "react-native": "*" }, "optionalPeers": ["@react-native-vector-icons/get-image", "@react-native/assets-registry", "expo-font"], "bin": { "rnvi-update-plist": "lib/commonjs/scripts/updatePlist.js" } }, "sha512-UPC6L3tW5rXCjBn4kgw9RPURUILIg8tFpEY2uaYwU8aCjEHkywNCMcAO8+PvMCDkR6aICPeHYA0OXvMgrjsF4g=="],
 

--- a/packages/vitest-native/README.md
+++ b/packages/vitest-native/README.md
@@ -476,6 +476,7 @@ export default defineConfig({
 | `presets.expo()`               | Expo modules                              |
 | `presets.deviceInfo()`         | react-native-device-info                  |
 | `presets.mmkv()`               | react-native-mmkv                         |
+| `presets.netInfo()`            | @react-native-community/netinfo           |
 | `presets.svg()`                | react-native-svg                          |
 | `presets.webview()`            | react-native-webview                      |
 | `presets.vectorIcons()`        | react-native-vector-icons                 |

--- a/packages/vitest-native/docs/versioning.md
+++ b/packages/vitest-native/docs/versioning.md
@@ -24,7 +24,7 @@ and deep paths are not supported even when they happen to resolve.
 | --- | --- |
 | `vitest-native` | `reactNative`, `presets`, `disabledPresetNames` |
 | `vitest-native/helpers` | `setPlatform`, `setDimensions`, `setColorScheme`, `setInsets`, `mockNativeModule`, `resetAllMocks` |
-| `vitest-native/presets` | the 16 preset factories, by name |
+| `vitest-native/presets` | the 17 preset factories, by name |
 | `vitest-native/matchers` | `toHaveAnimatedStyle`, `toHaveAnimatedProps`, `animatedMatchers` |
 | `vitest-native/serializer` | `serializer` |
 | `vitest-native/jest-compat` | `jestMockTransform`, `jestCompatAliases`, `jestCompatSetup` |

--- a/packages/vitest-native/package.json
+++ b/packages/vitest-native/package.json
@@ -135,6 +135,7 @@
   "devDependencies": {
     "@babel/core": "^7.29.7",
     "@gorhom/bottom-sheet": "5.2.14",
+    "@react-native-community/netinfo": "12.0.1",
     "@react-native-vector-icons/common": "13.0.1",
     "@react-native-vector-icons/material-icons": "13.1.2",
     "@react-native/babel-preset": "^0.86.2",

--- a/packages/vitest-native/src/preset-map.ts
+++ b/packages/vitest-native/src/preset-map.ts
@@ -22,6 +22,7 @@ export const AUTO_DETECT_PRESETS = {
   "expo-constants": "expo",
   "react-native-device-info": "deviceInfo",
   "react-native-mmkv": "mmkv",
+  "@react-native-community/netinfo": "netInfo",
   "react-native-svg": "svg",
   "react-native-webview": "webview",
   "@react-native-vector-icons/common": "vectorIcons",

--- a/packages/vitest-native/src/presets/index.ts
+++ b/packages/vitest-native/src/presets/index.ts
@@ -7,6 +7,7 @@ export { screens } from "./screens.js";
 export { expo } from "./expo.js";
 export { deviceInfo } from "./device-info.js";
 export { mmkv } from "./mmkv.js";
+export { netInfo } from "./netinfo.js";
 export { svg } from "./svg.js";
 export { webview } from "./webview.js";
 export { vectorIcons } from "./vector-icons.js";

--- a/packages/vitest-native/src/presets/netinfo.ts
+++ b/packages/vitest-native/src/presets/netinfo.ts
@@ -1,0 +1,127 @@
+import type { Preset } from "../types.js";
+import { vi } from "vitest";
+
+/**
+ * The state every fetch/listener resolves to until a test changes it.
+ *
+ * Derived from ONE constant so `_reset()` and the initial value cannot drift — the
+ * failure mode where `beforeEach(_reset())` masks the default it claims to test.
+ *
+ * The real library starts at `{ type: 'unknown', isConnected: null, … }` and resolves
+ * to the device's actual connection a moment later. A mock has no device, and a null
+ * resting state would send every component under test down its offline branch, so the
+ * resting state here is a connected wifi device — the same reasoning that gives
+ * Dimensions a device-shaped default.
+ */
+const RESTING = {
+  type: "wifi",
+  isConnected: true,
+  isInternetReachable: true,
+  details: {
+    isConnectionExpensive: false,
+    ssid: null,
+    bssid: null,
+    strength: null,
+    ipAddress: null,
+    subnet: null,
+    frequency: null,
+    linkSpeed: null,
+    rxLinkSpeed: null,
+    txLinkSpeed: null,
+  },
+} as const;
+
+const state = () => structuredClone(RESTING) as Record<string, unknown>;
+
+export function netInfo(): Preset {
+  return {
+    name: "netInfo",
+    modules: {
+      "@react-native-community/netinfo": {
+        // Exactly the runtime surface: the six functions the entry exports, plus the
+        // two enums re-exported through `export * from './internal/types'`. The rest
+        // of that module is types, which have no runtime binding — declaring one
+        // would make a value import of a type resolve here and fail under Metro.
+        exports: [
+          "configure",
+          "fetch",
+          "refresh",
+          "addEventListener",
+          "useNetInfo",
+          "useNetInfoInstance",
+          "NetInfoStateType",
+          "NetInfoCellularGeneration",
+        ],
+        factory: () => {
+          let current = state();
+          const listeners = new Set<(s: unknown) => void>();
+
+          const emit = (): void => {
+            for (const listener of listeners) listener(current);
+          };
+
+          const fetch = vi.fn(async () => current);
+          const refresh = vi.fn(async () => current);
+          const configure = vi.fn(() => {
+            // The real configure() drops existing listeners; mirroring that keeps a
+            // test that configures mid-run from seeing stale subscriptions fire.
+            listeners.clear();
+          });
+
+          const addEventListener = vi.fn((listener: (s: unknown) => void) => {
+            listeners.add(listener);
+            // The real implementation calls back with the latest state soon after
+            // subscribing, which is what components rely on to render connected.
+            listener(current);
+            return () => {
+              listeners.delete(listener);
+            };
+          });
+
+          const useNetInfo = vi.fn(() => current);
+          const useNetInfoInstance = vi.fn(() => ({ netInfo: current, refresh }));
+
+          const NetInfoStateType = {
+            unknown: "unknown",
+            none: "none",
+            cellular: "cellular",
+            wifi: "wifi",
+            bluetooth: "bluetooth",
+            ethernet: "ethernet",
+            wimax: "wimax",
+            vpn: "vpn",
+            other: "other",
+          };
+
+          const NetInfoCellularGeneration = { "2g": "2g", "3g": "3g", "4g": "4g", "5g": "5g" };
+
+          const api = {
+            configure,
+            fetch,
+            refresh,
+            addEventListener,
+            useNetInfo,
+            useNetInfoInstance,
+          };
+
+          return {
+            ...api,
+            NetInfoStateType,
+            NetInfoCellularGeneration,
+            default: api,
+            /** Drive the connection state from a test. */
+            _setState: (next: Record<string, unknown>) => {
+              current = { ...current, ...next };
+              emit();
+            },
+            /** Internal: restore the resting state. Called by resetAllMocks(). */
+            _reset: () => {
+              current = state();
+              listeners.clear();
+            },
+          };
+        },
+      },
+    },
+  };
+}

--- a/packages/vitest-native/tests/netinfo-preset.test.ts
+++ b/packages/vitest-native/tests/netinfo-preset.test.ts
@@ -1,0 +1,151 @@
+/**
+ * NetInfo is detected and inlined correctly without a preset — the failure it had was
+ * at the native-module boundary. The generic stub answers any method with `undefined`,
+ * NetInfo does `const state = await RNCNetInfo.getCurrentState(...)` and then reads
+ * `state.isInternetReachable`, and the run died on a TypeError plus an unhandled
+ * rejection that Vitest warns can produce false positives elsewhere.
+ *
+ * No generic stub can infer that shape, so this is the case that earns a preset.
+ *
+ * The wiring is asserted as well as the factory. Preset tests here have called
+ * factories directly and never exercised AUTO_DETECT_PRESETS, which is how a preset
+ * once shipped mapped to a name that shadowed nothing.
+ */
+import { describe, expect, it } from "vitest";
+import { AUTO_DETECT_PRESETS } from "../src/preset-map.js";
+import * as presets from "../src/presets/index.js";
+import { netInfo } from "../src/presets/netinfo.js";
+
+const PACKAGE = "@react-native-community/netinfo";
+
+/** The module object a worker would get for the shadowed package. */
+function moduleFor(): Record<string, any> {
+  const preset = netInfo();
+  return preset.modules[PACKAGE].factory();
+}
+
+describe("netInfo preset: wiring", () => {
+  it("is auto-detected for the package it shadows", () => {
+    expect(AUTO_DETECT_PRESETS[PACKAGE]).toBe("netInfo");
+  });
+
+  it("is reachable under the name auto-detection resolves", () => {
+    // The gap this closes: a map entry naming an export that does not exist means
+    // detection finds the package and then shadows nothing.
+    const exportName = AUTO_DETECT_PRESETS[PACKAGE];
+    expect(typeof (presets as Record<string, unknown>)[exportName]).toBe("function");
+  });
+
+  it("shadows exactly the package it claims", () => {
+    expect(Object.keys(netInfo().modules)).toEqual([PACKAGE]);
+  });
+});
+
+describe("netInfo preset: state", () => {
+  it("resolves a connected state before anything resets it", async () => {
+    // Asserted on a FRESH factory with no _reset() first: a beforeEach(_reset())
+    // would otherwise be asserting what _reset does, not what the default is.
+    const m = moduleFor();
+    const state = await m.fetch();
+    expect(state.isConnected).toBe(true);
+    expect(state.isInternetReachable).toBe(true);
+    expect(state.type).toBe("wifi");
+  });
+
+  it("gives refresh the same shape as fetch", async () => {
+    const m = moduleFor();
+    expect(await m.refresh()).toEqual(await m.fetch());
+  });
+
+  it("lets a test drive the connection state", async () => {
+    const m = moduleFor();
+    m._setState({ isConnected: false, isInternetReachable: false, type: "none" });
+    const state = await m.fetch();
+    expect(state.isConnected).toBe(false);
+    expect(state.type).toBe("none");
+  });
+
+  it("restores the resting state on _reset", async () => {
+    const m = moduleFor();
+    m._setState({ isConnected: false, type: "none" });
+    m._reset();
+    const state = await m.fetch();
+    expect(state.isConnected).toBe(true);
+    expect(state.type).toBe("wifi");
+  });
+
+  it("does not leak state between factories", async () => {
+    const first = moduleFor();
+    first._setState({ isConnected: false });
+    expect((await moduleFor().fetch()).isConnected).toBe(true);
+  });
+});
+
+describe("netInfo preset: listeners", () => {
+  it("calls a new listener with the current state", () => {
+    const m = moduleFor();
+    const seen: unknown[] = [];
+    m.addEventListener((s: unknown) => seen.push(s));
+    // The real implementation calls back soon after subscribing; components rely on
+    // it to render connected rather than waiting for a change that never comes.
+    expect(seen).toHaveLength(1);
+    expect((seen[0] as { isConnected: boolean }).isConnected).toBe(true);
+  });
+
+  it("notifies listeners when the state changes", () => {
+    const m = moduleFor();
+    const seen: unknown[] = [];
+    m.addEventListener((s: unknown) => seen.push(s));
+    m._setState({ isConnected: false });
+    expect(seen).toHaveLength(2);
+    expect((seen[1] as { isConnected: boolean }).isConnected).toBe(false);
+  });
+
+  it("stops notifying after unsubscribe", () => {
+    const m = moduleFor();
+    const seen: unknown[] = [];
+    const unsubscribe = m.addEventListener((s: unknown) => seen.push(s));
+    unsubscribe();
+    m._setState({ isConnected: false });
+    expect(seen).toHaveLength(1);
+  });
+
+  it("drops listeners on configure, as the real library does", () => {
+    const m = moduleFor();
+    const seen: unknown[] = [];
+    m.addEventListener((s: unknown) => seen.push(s));
+    m.configure({});
+    m._setState({ isConnected: false });
+    expect(seen).toHaveLength(1);
+  });
+});
+
+describe("netInfo preset: hooks and enums", () => {
+  it("returns the current state from useNetInfo", () => {
+    const m = moduleFor();
+    m._setState({ type: "cellular" });
+    expect(m.useNetInfo().type).toBe("cellular");
+  });
+
+  it("returns state and refresh from useNetInfoInstance", async () => {
+    const m = moduleFor();
+    const instance = m.useNetInfoInstance();
+    expect(instance.netInfo.isConnected).toBe(true);
+    expect(await instance.refresh()).toBeDefined();
+  });
+
+  it("exposes the enums as runtime values", () => {
+    // These are TypeScript enums re-exported through `export * from './internal/types'`,
+    // so unlike the rest of that module they DO have runtime bindings.
+    const m = moduleFor();
+    expect(m.NetInfoStateType.wifi).toBe("wifi");
+    expect(m.NetInfoStateType.none).toBe("none");
+    expect(m.NetInfoCellularGeneration["4g"]).toBe("4g");
+  });
+
+  it("exposes the same api on the default export", () => {
+    const m = moduleFor();
+    expect(typeof m.default.fetch).toBe("function");
+    expect(typeof m.default.addEventListener).toBe("function");
+  });
+});


### PR DESCRIPTION
Fixes #144. With this and #145, **all 10** popular non-preset libraries in the ecosystem probe pass — it was 8 when the probe started.

## Why a preset

NetInfo was detected and compiled correctly. It failed at the **native-module boundary**:

```
TypeError: Cannot read properties of undefined (reading 'isInternetReachable')
```

Probing it:

```
module present: true
keys: []
getCurrentState(): undefined
```

The generic stub answers any method with `undefined`. NetInfo awaits `getCurrentState()` and reads `state.isInternetReachable` off the result. Nothing can infer that shape, so this is the case that earns a preset rather than a fix to the stub — and it is the general shape for any native module returning **structured data** rather than void or a primitive.

It also surfaced as an unhandled rejection, which Vitest warns can produce false positives elsewhere in the run.

## Surface

Read from the compiled build, not guessed:

| Export | |
| --- | --- |
| `configure`, `fetch`, `refresh`, `addEventListener`, `useNetInfo`, `useNetInfoInstance` | the entry's six functions |
| `NetInfoStateType`, `NetInfoCellularGeneration` | **runtime** enums |

The two enums arrive via `export * from './internal/types'` and look type-only. They are TypeScript enums, so they compile to real runtime objects — confirmed by reading `lib/commonjs/internal/types.js` rather than the `.d.ts`. Omitting them would have broken `NetInfoStateType.wifi`, which is common in real code.

## The surface is gated, not trusted

`@react-native-community/netinfo` is now a devDependency, so `tests/preset-real-surface.test.ts` **measures** it instead of listing it as unmeasurable:

```
✓ @react-native-community/netinfo declares no export the real package lacks
```

That gate reads the real surface with the TypeScript checker. Mutation-tested by declaring a fake `isConnectedFast`:

```
AssertionError: expected [ 'isConnectedFast' ] to deeply equal []
```

## Resting state

A connected wifi device, derived from **one constant** so `_reset()` and the initial value cannot drift — the `beforeEach(_reset())` masking problem this repo has hit before.

The real library starts at `{ type: 'unknown', isConnected: null, details: null }` and resolves to the device a moment later. A mock has no device, and a null resting state would send every component under test down its offline branch. Same reasoning that gives `Dimensions` a device-shaped default. Tests drive it with `_setState`, and `resetAllMocks()` restores it.

## Tests

16, covering the factory **and the wiring** — that `AUTO_DETECT_PRESETS` maps the package to a name that actually exists in the presets barrel. Preset tests here have historically called factories directly and never exercised the map, which is how a preset once shipped mapped to a name that shadowed nothing.

The default-state assertion deliberately runs on a fresh factory with no `_reset()` first, so it tests the default rather than what `_reset` does.

## Also

The versioning-contract gate caught the docs drifting the moment this landed — `docs say 16, build has 17` — so `docs/versioning.md` and both README preset tables are updated in the same change.

Suites: mock 78 files / 1667 passed, native 220, android 3, consumers all pass, `check:size` within budget. Lint, format, typecheck clean.