### PR TITLE
ci: probe the React Native ecosystem on a schedule

### DIFF
--- a/.github/workflows/ecosystem-probe.yml
+++ b/.github/workflows/ecosystem-probe.yml
@@ -1,0 +1,114 @@
+name: Ecosystem Probe
+
+# The repository's suites test vitest-native against fixtures it controls. This
+# installs the libraries real apps actually use and runs realistic usage against them
+# with no configuration. One manual pass of it found three defects every in-repo suite
+# was green through, so it runs on a schedule.
+#
+# Scheduled rather than per-pull-request, for the same reason as compat-check: it
+# resolves third-party packages that move on their own, so a failure here is usually
+# the ecosystem changing rather than the pull request being wrong. A red probe opens a
+# tracking issue instead of blocking anyone.
+on:
+  schedule:
+    # Every Tuesday at 9am UTC — a day after the dependency updates land.
+    - cron: "0 9 * * 2"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    name: Popular React Native libraries, default config
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.14
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.13.0
+
+      - name: Install and build the package
+        run: |
+          bun install --frozen-lockfile
+          bun run --filter vitest-native build
+
+      - name: Pack the package
+        id: pack
+        working-directory: packages/vitest-native
+        run: |
+          npm pack --ignore-scripts --pack-destination "$RUNNER_TEMP"
+          echo "tarball=$(ls "$RUNNER_TEMP"/vitest-native-*.tgz)" >> "$GITHUB_OUTPUT"
+
+      # The probe installs from the packed tarball, so it exercises what is published
+      # rather than the working tree. npm, not bun, because a consumer's install is
+      # what is being reproduced.
+      - name: Install the probe project
+        working-directory: packages/vitest-native/ecosystem-probe
+        env:
+          TARBALL: ${{ steps.pack.outputs.tarball }}
+        run: |
+          npm install --no-audit --no-fund \
+            react@19.2.8 react-native@0.86.0 react-test-renderer@19.2.8 test-renderer@^1 \
+            @react-native/babel-preset@0.86.0 @babel/core \
+            @testing-library/react-native@14 vitest@^4 vite@^8
+          npm install --no-audit --no-fund "$TARBALL"
+
+      - name: Report the resolved versions
+        working-directory: packages/vitest-native/ecosystem-probe
+        run: |
+          node -e "
+            const m = require('./package.json').dependencies;
+            for (const name of Object.keys(m).sort()) {
+              let v = 'NOT INSTALLED';
+              try { v = require(require.resolve(name + '/package.json', { paths: [process.cwd()] })).version } catch {}
+              console.log(name.padEnd(46), v);
+            }
+          "
+
+      - name: Run the probe
+        working-directory: packages/vitest-native/ecosystem-probe
+        run: npm test
+
+      - name: Open a tracking issue
+        if: failure()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7
+        env:
+          RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        with:
+          script: |
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'ecosystem-probe',
+            });
+            if (issues.length === 0) {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: 'Ecosystem probe failing against popular React Native libraries',
+                body: [
+                  'The scheduled ecosystem probe failed. It installs the libraries real apps',
+                  'depend on and runs realistic usage against them with **no configuration**,',
+                  'so a failure means one of those libraries no longer works out of the box.',
+                  '',
+                  `See the [failed run](${process.env.RUN_URL}) — the step before the failure`,
+                  'prints every resolved version, which usually identifies what moved.',
+                  '',
+                  'Reproduce locally with the instructions in',
+                  '`packages/vitest-native/ecosystem-probe/README.md`.',
+                ].join('\n'),
+                labels: ['ecosystem-probe'],
+              });
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ website/.vitepress/dist/
 **/docs/plans/
 docs/superpowers/
 **/docs/real-app-validation/
+
+# The ecosystem probe installs from npm on each run; its lockfile is not pinned
+# on purpose — the point is to resolve what a user would get today.
+packages/vitest-native/ecosystem-probe/package-lock.json

--- a/packages/vitest-native/ecosystem-probe/README.md
+++ b/packages/vitest-native/ecosystem-probe/README.md
@@ -1,0 +1,38 @@
+# Ecosystem probe
+
+Not part of the published package, and not run on pull requests.
+
+The repository's own suites test vitest-native against fixtures it controls. This
+installs the React Native libraries real applications actually depend on — and the
+data-layer libraries their tests are mostly made of — and runs realistic usage against
+them with **no configuration**.
+
+It exists because one pass of it found three real defects that every in-repo suite was
+green through:
+
+- `react-native-modal` failed with a bare `SyntaxError: Unexpected token '<'`, because
+  the untranspiled JSX was in a transitive dependency detection could not see (#143).
+- `@react-native-community/netinfo` died at the native-module boundary, where a generic
+  stub cannot invent the state object the library reads (#144).
+- `doctor` reported a healthy project while six of ten test files failed, because RNTL
+  14's `test-renderer` peer was missing (#142).
+
+## Running it
+
+```bash
+bun run --filter vitest-native build
+npm pack --pack-destination /tmp        # from packages/vitest-native
+cd ecosystem-probe && npm install && npm install /tmp/vitest-native-*.tgz && npm test
+```
+
+The CI workflow does the same on a schedule and opens a tracking issue on failure.
+
+## Adding to it
+
+A probe should be **realistic usage**, not an import smoke test: render the component
+the way a user would, or call the API a user would call. `imagepicker.test.tsx` only
+checks that functions exist because the real call opens a native picker; everything
+that can render, renders.
+
+Keep the default configuration. If a library needs `transform: [...]` or a manual mock
+to pass, that is the finding.

--- a/packages/vitest-native/ecosystem-probe/package.json
+++ b/packages/vitest-native/ecosystem-probe/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "vitest-native-ecosystem-probe",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Not part of the published package. Installs the React Native libraries real apps actually use and runs realistic tests against them, to catch ecosystem breakage the repository's own suites cannot see.",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@babel/core": "^7.29.7",
+    "@react-native-async-storage/async-storage": "2.2.0",
+    "@react-native-community/datetimepicker": "9.1.0",
+    "@react-native-community/netinfo": "12.0.1",
+    "@react-native-community/slider": "5.2.0",
+    "@react-native/babel-preset": "^0.86.0",
+    "@react-navigation/native": "7.3.16",
+    "@react-navigation/native-stack": "7.18.8",
+    "@shopify/flash-list": "2.3.2",
+    "@tanstack/react-query": "5.101.4",
+    "@testing-library/react-native": "^14.0.1",
+    "lottie-react-native": "7.4.0",
+    "msw": "2.15.0",
+    "react": "^19.2.8",
+    "react-native": "^0.86.0",
+    "react-native-gesture-handler": "3.0.0",
+    "react-native-haptic-feedback": "3.0.0",
+    "react-native-image-picker": "8.2.1",
+    "react-native-linear-gradient": "2.8.3",
+    "react-native-modal": "13.0.1",
+    "react-native-pager-view": "8.0.4",
+    "react-native-permissions": "5.6.1",
+    "react-native-reanimated": "4.5.3",
+    "react-native-safe-area-context": "5.8.0",
+    "react-native-screens": "4.20.0",
+    "react-native-worklets": "0.11.3",
+    "react-test-renderer": "^19.2.8",
+    "test-renderer": "^1.2.0",
+    "vite": "^8.2.1",
+    "vitest": "^4.1.10",
+    "vitest-native": "^0.10.0"
+  }
+}

--- a/packages/vitest-native/ecosystem-probe/src/datetimepicker.test.tsx
+++ b/packages/vitest-native/ecosystem-probe/src/datetimepicker.test.tsx
@@ -1,0 +1,7 @@
+import { test, expect } from 'vitest'
+import { render, screen } from '@testing-library/react-native'
+import DateTimePicker from '@react-native-community/datetimepicker'
+test('datetimepicker renders', async () => {
+  await render(<DateTimePicker testID="d" value={new Date(0)} mode="date" />)
+  expect(screen.getByTestId('d')).toBeTruthy()
+})

--- a/packages/vitest-native/ecosystem-probe/src/faketimers.test.tsx
+++ b/packages/vitest-native/ecosystem-probe/src/faketimers.test.tsx
@@ -1,0 +1,17 @@
+import { test, expect, vi, afterEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react-native'
+import { useEffect, useState } from 'react'
+import { Text } from 'react-native'
+afterEach(() => vi.useRealTimers())
+function Debounced() {
+  const [v, setV] = useState('idle')
+  useEffect(() => { const id = setTimeout(() => setV('fired'), 500); return () => clearTimeout(id) }, [])
+  return <Text>{v}</Text>
+}
+test('fake timers advance a component timeout', async () => {
+  vi.useFakeTimers()
+  await render(<Debounced />)
+  expect(screen.getByText('idle')).toBeTruthy()
+  await act(async () => { vi.advanceTimersByTime(600) })
+  expect(screen.getByText('fired')).toBeTruthy()
+})

--- a/packages/vitest-native/ecosystem-probe/src/flashlist.test.tsx
+++ b/packages/vitest-native/ecosystem-probe/src/flashlist.test.tsx
@@ -1,0 +1,9 @@
+import { test, expect } from 'vitest'
+import { render, screen } from '@testing-library/react-native'
+import { FlashList } from '@shopify/flash-list'
+import { Text } from 'react-native'
+test('flash-list renders items', async () => {
+  await render(<FlashList data={[{ id: 1, t: 'alpha' }, { id: 2, t: 'beta' }]}
+    renderItem={({ item }) => <Text>{item.t}</Text>} estimatedItemSize={20} />)
+  expect(screen.getByText('alpha')).toBeTruthy()
+})

--- a/packages/vitest-native/ecosystem-probe/src/gestures.test.tsx
+++ b/packages/vitest-native/ecosystem-probe/src/gestures.test.tsx
@@ -1,0 +1,10 @@
+import { test, expect } from 'vitest'
+import { render, screen } from '@testing-library/react-native'
+import { GestureHandlerRootView, Gesture, GestureDetector } from 'react-native-gesture-handler'
+import { Text } from 'react-native'
+test('gesture handler composes and renders', async () => {
+  const tap = Gesture.Tap().onEnd(() => {})
+  await render(
+    <GestureHandlerRootView><GestureDetector gesture={tap}><Text>tappable</Text></GestureDetector></GestureHandlerRootView>)
+  expect(screen.getByText('tappable')).toBeTruthy()
+})

--- a/packages/vitest-native/ecosystem-probe/src/gradient.test.tsx
+++ b/packages/vitest-native/ecosystem-probe/src/gradient.test.tsx
@@ -1,0 +1,8 @@
+import { test, expect } from 'vitest'
+import { render, screen } from '@testing-library/react-native'
+import LinearGradient from 'react-native-linear-gradient'
+import { Text } from 'react-native'
+test('linear-gradient renders children', async () => {
+  await render(<LinearGradient testID="g" colors={['#000', '#fff']}><Text>hi</Text></LinearGradient>)
+  expect(screen.getByText('hi')).toBeTruthy()
+})

--- a/packages/vitest-native/ecosystem-probe/src/haptic.test.tsx
+++ b/packages/vitest-native/ecosystem-probe/src/haptic.test.tsx
@@ -1,0 +1,6 @@
+import { test, expect } from 'vitest'
+import ReactNativeHapticFeedback from 'react-native-haptic-feedback'
+test('haptic feedback triggers', () => {
+  expect(typeof ReactNativeHapticFeedback.trigger).toBe('function')
+  ReactNativeHapticFeedback.trigger('impactLight')
+})

--- a/packages/vitest-native/ecosystem-probe/src/imagepicker.test.tsx
+++ b/packages/vitest-native/ecosystem-probe/src/imagepicker.test.tsx
@@ -1,0 +1,6 @@
+import { test, expect } from 'vitest'
+import { launchImageLibrary, launchCamera } from 'react-native-image-picker'
+test('image-picker exposes its api', () => {
+  expect(typeof launchImageLibrary).toBe('function')
+  expect(typeof launchCamera).toBe('function')
+})

--- a/packages/vitest-native/ecosystem-probe/src/lottie.test.tsx
+++ b/packages/vitest-native/ecosystem-probe/src/lottie.test.tsx
@@ -1,0 +1,7 @@
+import { test, expect } from 'vitest'
+import { render, screen } from '@testing-library/react-native'
+import LottieView from 'lottie-react-native'
+test('lottie renders', async () => {
+  await render(<LottieView testID="l" source={{}} autoPlay loop />)
+  expect(screen.getByTestId('l')).toBeTruthy()
+})

--- a/packages/vitest-native/ecosystem-probe/src/msw.test.tsx
+++ b/packages/vitest-native/ecosystem-probe/src/msw.test.tsx
@@ -1,0 +1,10 @@
+import { test, expect, beforeAll, afterAll } from 'vitest'
+import { setupServer } from 'msw/node'
+import { http, HttpResponse } from 'msw'
+const server = setupServer(http.get('https://api.test/user', () => HttpResponse.json({ name: 'Ada' })))
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterAll(() => server.close())
+test('msw intercepts fetch under the native engine', async () => {
+  const res = await fetch('https://api.test/user')
+  expect(await res.json()).toEqual({ name: 'Ada' })
+})

--- a/packages/vitest-native/ecosystem-probe/src/navigation.test.tsx
+++ b/packages/vitest-native/ecosystem-probe/src/navigation.test.tsx
@@ -1,0 +1,18 @@
+import { test, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react-native'
+import { NavigationContainer } from '@react-navigation/native'
+import { createNativeStackNavigator } from '@react-navigation/native-stack'
+import { Text, Pressable } from 'react-native'
+const Stack = createNativeStackNavigator()
+function Home({ navigation }: any) {
+  return <Pressable onPress={() => navigation.navigate('Details')}><Text>go</Text></Pressable>
+}
+function Details() { return <Text>details screen</Text> }
+test('navigates between screens', async () => {
+  await render(
+    <NavigationContainer>
+      <Stack.Navigator><Stack.Screen name="Home" component={Home} /><Stack.Screen name="Details" component={Details} /></Stack.Navigator>
+    </NavigationContainer>)
+  await fireEvent.press(screen.getByText('go'))
+  expect(screen.getByText('details screen')).toBeTruthy()
+})

--- a/packages/vitest-native/ecosystem-probe/src/netinfo.test.tsx
+++ b/packages/vitest-native/ecosystem-probe/src/netinfo.test.tsx
@@ -1,0 +1,7 @@
+import { test, expect } from 'vitest'
+import NetInfo from '@react-native-community/netinfo'
+test('netinfo resolves a connection state', async () => {
+  const state = await NetInfo.fetch()
+  expect(state).toBeDefined()
+  expect(typeof state.isConnected).toBe('boolean')
+})

--- a/packages/vitest-native/ecosystem-probe/src/pagerview.test.tsx
+++ b/packages/vitest-native/ecosystem-probe/src/pagerview.test.tsx
@@ -1,0 +1,8 @@
+import { test, expect } from 'vitest'
+import { render, screen } from '@testing-library/react-native'
+import PagerView from 'react-native-pager-view'
+import { View, Text } from 'react-native'
+test('pager-view renders pages', async () => {
+  await render(<PagerView testID="p" initialPage={0}><View key="1"><Text>one</Text></View></PagerView>)
+  expect(screen.getByText('one')).toBeTruthy()
+})

--- a/packages/vitest-native/ecosystem-probe/src/permissions.test.tsx
+++ b/packages/vitest-native/ecosystem-probe/src/permissions.test.tsx
@@ -1,0 +1,7 @@
+import { test, expect } from 'vitest'
+import { check, PERMISSIONS, RESULTS } from 'react-native-permissions'
+test('permissions exposes constants and check()', () => {
+  expect(PERMISSIONS.IOS.CAMERA).toBeTruthy()
+  expect(RESULTS.GRANTED).toBe('granted')
+  expect(typeof check).toBe('function')
+})

--- a/packages/vitest-native/ecosystem-probe/src/reactquery.test.tsx
+++ b/packages/vitest-native/ecosystem-probe/src/reactquery.test.tsx
@@ -1,0 +1,13 @@
+import { test, expect } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react-native'
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query'
+import { Text } from 'react-native'
+function User() {
+  const { data, isLoading } = useQuery({ queryKey: ['u'], queryFn: async () => ({ name: 'Ada' }) })
+  return <Text>{isLoading ? 'loading' : data!.name}</Text>
+}
+test('react-query resolves into a component', async () => {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  await render(<QueryClientProvider client={client}><User /></QueryClientProvider>)
+  await waitFor(() => expect(screen.getByText('Ada')).toBeTruthy())
+})

--- a/packages/vitest-native/ecosystem-probe/src/reanimated.test.tsx
+++ b/packages/vitest-native/ecosystem-probe/src/reanimated.test.tsx
@@ -1,0 +1,15 @@
+import { test, expect } from 'vitest'
+import { render, screen } from '@testing-library/react-native'
+import Animated, { useSharedValue, useAnimatedStyle, withTiming, FadeIn } from 'react-native-reanimated'
+import { Text } from 'react-native'
+function Fading() {
+  const o = useSharedValue(0)
+  const style = useAnimatedStyle(() => ({ opacity: o.value }))
+  return <Animated.View testID="fade" style={style} entering={FadeIn}><Text>faded</Text></Animated.View>
+}
+test('reanimated renders an animated component', async () => {
+  await render(<Fading />)
+  expect(screen.getByTestId('fade')).toBeTruthy()
+  expect(screen.getByText('faded')).toBeTruthy()
+  expect(typeof withTiming).toBe('function')
+})

--- a/packages/vitest-native/ecosystem-probe/src/rnmodal.test.tsx
+++ b/packages/vitest-native/ecosystem-probe/src/rnmodal.test.tsx
@@ -1,0 +1,12 @@
+import { test, expect } from 'vitest'
+import { render, screen } from '@testing-library/react-native'
+import Modal from 'react-native-modal'
+import { Text } from 'react-native'
+// The regression this file exists for: the untranspiled JSX is in
+// react-native-animatable, a transitive dependency that declares react-native
+// nowhere, so detection could not see it and the import died on a bare
+// `SyntaxError: Unexpected token '<'`.
+test('react-native-modal renders when visible', async () => {
+  await render(<Modal isVisible><Text>inside</Text></Modal>)
+  expect(screen.getByText('inside')).toBeTruthy()
+})

--- a/packages/vitest-native/ecosystem-probe/src/slider.test.tsx
+++ b/packages/vitest-native/ecosystem-probe/src/slider.test.tsx
@@ -1,0 +1,7 @@
+import { test, expect } from 'vitest'
+import { render, screen } from '@testing-library/react-native'
+import Slider from '@react-native-community/slider'
+test('slider renders', async () => {
+  await render(<Slider testID="s" value={0.5} />)
+  expect(screen.getByTestId('s')).toBeTruthy()
+})

--- a/packages/vitest-native/ecosystem-probe/src/storage.test.tsx
+++ b/packages/vitest-native/ecosystem-probe/src/storage.test.tsx
@@ -1,0 +1,14 @@
+import { test, expect } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react-native'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { useEffect, useState } from 'react'
+import { Text } from 'react-native'
+function Persisted() {
+  const [v, setV] = useState('...')
+  useEffect(() => { (async () => { await AsyncStorage.setItem('k', 'stored'); setV((await AsyncStorage.getItem('k')) ?? 'none') })() }, [])
+  return <Text>{v}</Text>
+}
+test('async-storage round-trips inside a component', async () => {
+  await render(<Persisted />)
+  await waitFor(() => expect(screen.getByText('stored')).toBeTruthy())
+})

--- a/packages/vitest-native/ecosystem-probe/vitest.config.mjs
+++ b/packages/vitest-native/ecosystem-probe/vitest.config.mjs
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+import { reactNative } from 'vitest-native'
+
+// Default configuration on purpose. The probe's question is what a user gets with
+// no configuration at all, so anything that needs a `transform:` entry or a manual
+// mock to pass here is a finding, not something to work around in this file.
+export default defineConfig({ plugins: [reactNative()] })

--- a/packages/vitest-native/vitest.config.ts
+++ b/packages/vitest-native/vitest.config.ts
@@ -15,6 +15,9 @@ export default defineConfig({
     // packed tarball; running them here would use this repository's config.
     // `validation/**` is the idiomatic hot-parity oracle — it runs only via its
     // own native-engine configs (and `validate:hot-parity`), never the mock gate.
+    // `ecosystem-probe/**` installs popular third-party packages into its own
+    // project and runs from the packed tarball on a schedule; those packages are
+    // not installed here, so globbing it into this suite fails to resolve them.
     exclude: [
       ...configDefaults.exclude,
       'tests-native/**',
@@ -22,6 +25,7 @@ export default defineConfig({
       'crosscheck/**',
       'consumer-tests/**',
       'validation/**',
+      'ecosystem-probe/**',
     ],
   },
 });


### PR DESCRIPTION
## Why

Every suite in this repository was green while:

- `react-native-modal` — one of the most-installed RN libraries — could not be imported at all (#143)
- `@react-native-community/netinfo` died at the native-module boundary (#144)
- `doctor` reported a healthy project whose every `render()` failed (#142)

All three were found the same way: build a project a **user** would build, install the libraries real apps depend on, run realistic usage with **no configuration**. That is a mechanism, not a one-off — so it becomes a scheduled job.

The repo's suites test vitest-native against fixtures it controls. This tests it against the ecosystem, which moves on its own.

## What it covers

21 packages, exercised the way an application would use them — not import smoke tests:

| | |
| --- | --- |
| **Native modules** | netinfo, permissions, lottie, linear-gradient, pager-view, slider, datetimepicker, image-picker, haptic-feedback, modal |
| **Presets, in real components** | reanimated (animated style + layout animation), gesture-handler (composed gesture), flash-list (rendered items), async-storage (round-trip inside a component) |
| **The data layer a suite is mostly made of** | react-query resolving into a component, a real navigation flow between screens |
| **Test infrastructure** | MSW intercepting `fetch`, fake timers advancing a component timeout |

The config is deliberately bare:

```js
export default defineConfig({ plugins: [reactNative()] })
```

A library that needs `transform: [...]` or a hand-written mock to pass **is the finding**, not something to work around in the config. That is written into the README so it does not get "fixed" later.

## It installs the way a consumer does

From the **packed tarball**, with **npm**, not from the working tree with bun. That already paid: npm rejected the reanimated / worklets / React Native combination this repo's own devDependencies carry, which bun accepts —

```
peer react-native-worklets@"0.8.x" from react-native-reanimated@4.3.1
Found: react-native-worklets@0.9.1
```

— and reanimated 4.3.1 caps React Native at 0.85 while the probe installs 0.86. My earlier scratch runs had `--legacy-peer-deps` masking both. The probe pins a combination that actually resolves, because a user's install has to.

## Verified load-bearing

Not assumed. Run against the **published 0.10.0**, which predates today's two fixes:

```
FAIL  src/rnmodal.test.tsx
FAIL  src/netinfo.test.tsx > netinfo resolves a connection state
Test Files  2 failed | 16 passed (18)
```

It fails on exactly the two defects it was built from. Against current `main`: **18/18**.

## Scheduling

Weekly (Tuesdays, the day after dependency updates land) plus `workflow_dispatch` — deliberately **not** per-PR, for the same reason `compat-check.yml` is not: it resolves third-party packages that move on their own, so a red probe is usually the ecosystem changing rather than the pull request being wrong. It opens a tracking issue instead of blocking anyone, mirroring the existing compat-check pattern, and prints every resolved version before running, which is normally enough to identify what moved.

## Scope

No source change. Excluded from the published tarball (`files` is unchanged — verified 0 entries in `npm pack --dry-run`), not a bun workspace member (the glob is `packages/*`, one level up), and outside the lint/format/typecheck paths. `bun install --frozen-lockfile`, `check:size`, lint, format, and typecheck all unaffected.