### PR TITLE
fix(native): walk dependency closures only from packages the project declares

### DIFF
--- a/.changeset/closure-only-from-declared.md
+++ b/.changeset/closure-only-from-declared.md
@@ -1,0 +1,45 @@
+---
+"vitest-native": patch
+---
+
+Only walk the dependency closure of packages the project declares
+
+Fixes a regression in 0.11.0. In a workspace holding both a library and a React
+Native or Expo application — the canonical monorepo shape — the application's mere
+presence could stop the library's tests from loading:
+
+```
+ReferenceError: [vitest-native] Failed to transform '@babel/runtime' … for platform 'ios'.
+Caused by: ReferenceError: Cannot access 'v' before initialization
+Test Files 1 failed | Tests: no tests
+```
+
+0.11.0 began compiling a detected package's dependency closure, so that a library
+shipping untranspiled JSX inside a transitive dependency would work without naming it
+in `transform: [...]`. Candidates are collected from every manifest in the workspace,
+which is how a library the application depends on is found at all — but applied to a
+closure walk, that breadth stops being free. A sibling Expo application is detected on
+its own manifest, and walking its dependencies pulled the entire Expo and Metro
+toolchain into the Babel transform set of a package that depends on none of it: over
+250 packages in a two-package reproduction, `@babel/runtime` and Metro's `lru-cache`
+chain among them.
+
+Those are not inert. React Native and Babel load them, and compiling the transform's
+own toolchain re-enters Babel while it is still initialising — which surfaces as a
+`Cannot access 'v' before initialization` naming files the project never mentioned.
+The existing toolchain exclusion covers what `@babel/core` reaches and so did not
+catch either of them.
+
+The closure now starts only from packages the run itself declares — the package under
+test, and any manifest above it, which is where a workspace keeping its React Native
+libraries at the repository root declares them. A package only a sibling declares is
+that sibling's business. Transitive compilation is unaffected: a dependency reached
+through the walk is declared by its own parent, which is what makes it transitive.
+
+Declaration rather than resolvability, deliberately: under pnpm every workspace member
+is linked into a hidden directory placed on `NODE_PATH`, so a sibling's dependencies
+do resolve from the package under test at run time, and testing reachability instead
+lets all of them straight back through.
+
+In the two-package reproduction the transform set drops from 253 packages to 5 — the
+declared dependency and its genuine closure.

--- a/.changeset/closure-only-from-declared.md
+++ b/.changeset/closure-only-from-declared.md
@@ -41,5 +41,17 @@ is linked into a hidden directory placed on `NODE_PATH`, so a sibling's dependen
 do resolve from the package under test at run time, and testing reachability instead
 lets all of them straight back through.
 
+`@babel/runtime` and `metro` also now seed the toolchain exclusion, alongside
+`@babel/core` and the React Native Babel preset. Neither is reachable from
+`@babel/core`, so the existing exclusion let both through. `@babel/runtime` holds the
+helpers Babel *emits*, so compiled output across the ecosystem requires it at run
+time; Metro is the bundler the preset belongs to, and its `lru-cache` chain — the
+`yallist` in the report — is loaded the same way. This matters beyond the reported
+shape: an Expo application running its own tests declares `expo` legitimately, so its
+closure is walked and the same packages arrive by a route the change above does not
+affect.
+
 In the two-package reproduction the transform set drops from 253 packages to 5 — the
-declared dependency and its genuine closure.
+declared dependency and its genuine closure. For an Expo application testing itself it
+drops from 251 to 171, with `@babel/runtime`, `yallist` and Metro's cache chain no
+longer among them.

--- a/.changeset/closure-only-from-declared.md
+++ b/.changeset/closure-only-from-declared.md
@@ -55,3 +55,12 @@ In the two-package reproduction the transform set drops from 253 packages to 5 �
 declared dependency and its genuine closure. For an Expo application testing itself it
 drops from 251 to 171, with `@babel/runtime`, `yallist` and Metro's cache chain no
 longer among them.
+
+A closure member that publishes only ES modules is left alone as well. The walk is a
+guess that a detected package's dependencies might be untranspiled React Native
+source; `"type": "module"` with no `react-native` build anywhere in the manifest is
+the dependency saying the opposite. Compiling one anyway rewrote a package that
+publishes ESM into CommonJS and handed it to Node under that format. A genuine React
+Native library is unaffected — declaring `react-native`, by legacy field or by export
+condition at any depth, keeps it in the closure however it publishes — and so is any
+package named in `transform: [...]`, which was asked for explicitly.

--- a/packages/vitest-native/src/native/ecosystem.ts
+++ b/packages/vitest-native/src/native/ecosystem.ts
@@ -33,6 +33,43 @@ const NEVER_INLINE = new Set([
   "react-is",
 ]);
 
+/** Does this manifest offer a React Native build, by legacy field or export condition? */
+function hasReactNativeBuild(manifest: Record<string, unknown>): boolean {
+  if (typeof manifest["react-native"] === "string") return true;
+  const seen = new Set<unknown>();
+  const search = (node: unknown): boolean => {
+    if (!node || typeof node !== "object" || seen.has(node)) return false;
+    seen.add(node);
+    for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+      if (key === "react-native") return true;
+      if (search(value)) return true;
+    }
+    return false;
+  };
+  return search(manifest.exports);
+}
+
+/**
+ * A package that ships ES modules and nothing React Native.
+ *
+ * The closure walk is a guess: a detected package's dependencies MIGHT be untranspiled
+ * React Native source, because the ecosystem publishes that way and the dependency's
+ * own manifest cannot say so. `"type": "module"` is the manifest saying the opposite —
+ * this is runnable ES modules — and with no React Native build anywhere in it, there is
+ * nothing for the preset to do. Compiling it anyway rewrites a package that publishes
+ * ESM into CommonJS and hands it to Node under that format, which is how a dependency
+ * reached this way (`zod`) failed to parse and took fourteen test files down with it.
+ *
+ * A genuine React Native library is unaffected: declaring `react-native` by field or
+ * export condition keeps it in the closure however it publishes.
+ *
+ * Only closure MEMBERS are judged this way. A package detected on its own manifest, or
+ * named in `transform: [...]`, was asked for explicitly and is still compiled.
+ */
+function publishesOnlyEsm(manifest: Record<string, unknown>): boolean {
+  return manifest.type === "module" && !hasReactNativeBuild(manifest);
+}
+
 /** Manifest fields that make a package part of the React Native ecosystem. */
 function dependsOnReactNative(manifest: Record<string, unknown>): boolean {
   for (const field of ["dependencies", "peerDependencies"]) {
@@ -381,7 +418,9 @@ export function detectEcosystemPackages(
       // A sibling that depends on the package under test would otherwise pull it
       // back in here, past the check above.
       if (ownsTheRun(dep)) continue;
-      if (!manifestOf(dep)) continue; // declared but not installed
+      const depManifest = manifestOf(dep);
+      if (!depManifest) continue; // declared but not installed
+      if (publishesOnlyEsm(depManifest)) continue;
       inClosure.add(dep);
       queue.push(dep);
     }

--- a/packages/vitest-native/src/native/ecosystem.ts
+++ b/packages/vitest-native/src/native/ecosystem.ts
@@ -311,8 +311,46 @@ export function detectEcosystemPackages(
   // the toolchain by name would be a list that rots; its closure computes itself.
   const toolchain = closureOf(["@babel/core", "@react-native/babel-preset"]);
 
+  // Only packages the RUN can actually reach seed the walk.
+  //
+  // Candidates are collected from every manifest in the workspace, which is how a
+  // library the app depends on is found at all. Applied to a closure walk, that
+  // breadth stops being free: a sibling Expo application is detected on its own
+  // manifest, and walking ITS dependencies drags the whole Expo and Metro toolchain —
+  // several hundred packages, `@babel/runtime` and Metro's `lru-cache` chain among
+  // them — into the Babel transform set of a library that depends on none of it.
+  // Those are not inert. React Native and Babel load them, and compiling the
+  // transform's own toolchain with the transform re-enters Babel while it is still
+  // initialising, which fails as a TDZ error naming a file the project never
+  // mentioned.
+  //
+  // So the seeds are the packages the project itself DECLARES — read from the
+  // manifests that belong to the run (the package under test, and any manifest above
+  // it, which is where a workspace that keeps its React Native libraries at the
+  // repository root declares them). A package only a sibling declares is that
+  // sibling's business.
+  //
+  // Declaration rather than resolvability, deliberately. Under pnpm every workspace
+  // package is linked into a hidden directory placed on NODE_PATH, so in the running
+  // process a sibling's dependencies DO resolve from the package under test, and a
+  // reachability test quietly passes them all through. The manifest does not move.
+  //
+  // Only the SEEDS are filtered. A dependency reached through the walk is declared by
+  // its own parent rather than by the project — that is what makes it transitive —
+  // so filtering members too would undo the compilation this walk exists for.
+  const projectDeclared = new Set<string>();
+  for (const { dir, manifest } of found) {
+    if (!ownerRoots.some((root) => containsPath(dir, root))) continue;
+    for (const field of ["dependencies", "devDependencies", "optionalDependencies"]) {
+      const deps = manifest[field];
+      if (deps && typeof deps === "object") {
+        for (const name of Object.keys(deps as object)) projectDeclared.add(name);
+      }
+    }
+  }
+
   const inClosure = new Set(detected);
-  const queue = [...detected];
+  const queue = detected.filter((name) => projectDeclared.has(name));
   while (queue.length > 0) {
     const pkg = manifestOf(queue.pop() as string);
     const deps = pkg?.dependencies;

--- a/packages/vitest-native/src/native/ecosystem.ts
+++ b/packages/vitest-native/src/native/ecosystem.ts
@@ -309,7 +309,26 @@ export function detectEcosystemPackages(
   // reached Babel and then Babel's own dependencies (chalk among them). Both blew up
   // the packed Expo consumer, and neither reproduced in a synthetic fixture. Excluding
   // the toolchain by name would be a list that rots; its closure computes itself.
-  const toolchain = closureOf(["@babel/core", "@react-native/babel-preset"]);
+  //
+  // `@babel/runtime` and `metro` seed it alongside them, and are not reachable from
+  // `@babel/core`. `@babel/runtime` holds the helpers Babel EMITS, so compiled output
+  // across the ecosystem requires it at run time — including React Native's own. Metro
+  // is the bundler the preset belongs to, and its `lru-cache` chain (`yallist`) is
+  // loaded the same way. Both were handed to the transform by an Expo application's
+  // dependency closure, and compiling them re-enters Babel mid-initialisation: the
+  // reported `Cannot access 'v' before initialization`, naming a file the project never
+  // mentioned.
+  //
+  // Seeds, not names: what each of these reaches is computed, so the list does not rot
+  // as the toolchain's own dependencies change. They are skipped only as CLOSURE
+  // MEMBERS — a project that genuinely depends on one still has it detected on its own
+  // manifest, exactly as before.
+  const toolchain = closureOf([
+    "@babel/core",
+    "@react-native/babel-preset",
+    "@babel/runtime",
+    "metro",
+  ]);
 
   // Only packages the RUN can actually reach seed the walk.
   //

--- a/packages/vitest-native/tests/ecosystem-closure.test.ts
+++ b/packages/vitest-native/tests/ecosystem-closure.test.ts
@@ -104,6 +104,33 @@ describe("ecosystem detection: dependency closure", () => {
     expect(detected).toContain("safe-dep");
   });
 
+  it("excludes Babel's emitted helpers and Metro, which @babel/core does not reach", () => {
+    // The gap that broke 0.11.0 for Expo projects. `@babel/runtime` holds the helpers
+    // Babel EMITS, so compiled output across the ecosystem — React Native's included —
+    // requires it at run time; Metro is the bundler the preset belongs to, and its
+    // lru-cache chain is loaded the same way. Neither is reachable from `@babel/core`,
+    // so the original exclusion let both through, and compiling them re-entered Babel
+    // while it was initialising.
+    const root = project(["expo-ish"], {
+      "react-native": {},
+      "expo-ish": { peerDeps: ["react-native"], deps: ["@babel/runtime", "metro", "safe-dep"] },
+      "@babel/runtime": { deps: ["regenerator-ish"] },
+      "regenerator-ish": {},
+      metro: { deps: ["lru-cache-ish"] },
+      "lru-cache-ish": { deps: ["yallist-ish"] },
+      "yallist-ish": {},
+      "safe-dep": {},
+    });
+    const detected = detectEcosystemPackages(root);
+    expect(detected).not.toContain("@babel/runtime");
+    expect(detected, "a package Babel's helpers depend on").not.toContain("regenerator-ish");
+    expect(detected).not.toContain("metro");
+    expect(detected, "Metro's cache chain, how yallist arrived").not.toContain("yallist-ish");
+    // The rest of the package's closure is still compiled — the exclusion is scoped
+    // to the toolchain, not to everything a toolchain-using package depends on.
+    expect(detected).toContain("safe-dep");
+  });
+
   it("does not reach a package that nothing in the closure depends on", () => {
     const root = project(["rn-lib", "unrelated"], {
       "react-native": {},

--- a/packages/vitest-native/tests/ecosystem-closure.test.ts
+++ b/packages/vitest-native/tests/ecosystem-closure.test.ts
@@ -150,3 +150,86 @@ describe("ecosystem detection: dependency closure", () => {
     expect(detected).toContain("safe-dep");
   });
 });
+
+/**
+ * The closure walk starts only from what the RUN declares.
+ *
+ * Collecting candidates across every workspace manifest is what finds a library the
+ * application depends on. Walking closures from all of them is a different matter: a
+ * sibling Expo application is detected on its own manifest, and its dependencies are
+ * the Expo and Metro toolchain — several hundred packages, `@babel/runtime` and
+ * Metro's `lru-cache` chain among them. Compiling those with the React Native Babel
+ * preset is both pointless for a library that depends on none of them, and actively
+ * fatal: React Native and Babel load them, and transforming the transform's own
+ * toolchain re-enters Babel while it is initialising.
+ *
+ * Reported against 0.11.0: in a workspace holding a library and an Expo application —
+ * the canonical React Native monorepo — the application's presence alone stopped the
+ * library's tests from loading.
+ */
+describe("ecosystem detection: whose closure gets walked", () => {
+  /** A workspace whose sibling declares `heavy-app`, and whose project declares none. */
+  function workspaceWithSibling(): string {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "vn-sibling-"));
+    roots.push(root);
+    const write = (rel: string, value: unknown) => {
+      const file = path.join(root, rel);
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      fs.writeFileSync(file, JSON.stringify(value));
+    };
+    write("package.json", { name: "w", private: true, workspaces: ["packages/*"] });
+    write("packages/lib/package.json", {
+      name: "@w/lib",
+      dependencies: { "rn-widget": "*" },
+    });
+    write("packages/app/package.json", {
+      name: "@w/app",
+      dependencies: { "heavy-app": "*" },
+    });
+    // Installed where both members can resolve them.
+    write("node_modules/rn-widget/package.json", {
+      name: "rn-widget",
+      peerDependencies: { "react-native": "*" },
+      dependencies: { "widget-internals": "*" },
+    });
+    write("node_modules/widget-internals/package.json", { name: "widget-internals" });
+    write("node_modules/heavy-app/package.json", {
+      name: "heavy-app",
+      peerDependencies: { "react-native": "*" },
+      dependencies: { "toolchain-helpers": "*" },
+    });
+    write("node_modules/toolchain-helpers/package.json", { name: "toolchain-helpers" });
+    return root;
+  }
+
+  it("does not walk the closure of a package only a sibling declares", () => {
+    const detected = detectEcosystemPackages(path.join(workspaceWithSibling(), "packages", "lib"));
+    expect(detected).not.toContain("toolchain-helpers");
+  });
+
+  it("still walks the closure of a package the project declares", () => {
+    // The discriminating half: this is what the closure walk exists for, and the
+    // filter must not cost it.
+    const detected = detectEcosystemPackages(path.join(workspaceWithSibling(), "packages", "lib"));
+    expect(detected).toContain("rn-widget");
+    expect(detected).toContain("widget-internals");
+  });
+
+  it("still walks a closure declared by a manifest above the project", () => {
+    // A workspace that keeps its React Native libraries at the repository root is a
+    // documented layout; those manifests belong to the run just as the project's own
+    // does.
+    const root = workspaceWithSibling();
+    fs.writeFileSync(
+      path.join(root, "package.json"),
+      JSON.stringify({
+        name: "w",
+        private: true,
+        workspaces: ["packages/*"],
+        dependencies: { "heavy-app": "*" },
+      }),
+    );
+    const detected = detectEcosystemPackages(path.join(root, "packages", "lib"));
+    expect(detected).toContain("toolchain-helpers");
+  });
+});

--- a/packages/vitest-native/tests/ecosystem-closure.test.ts
+++ b/packages/vitest-native/tests/ecosystem-closure.test.ts
@@ -194,6 +194,68 @@ describe("ecosystem detection: dependency closure", () => {
  * the canonical React Native monorepo — the application's presence alone stopped the
  * library's tests from loading.
  */
+describe("ecosystem detection: an ESM-only closure member", () => {
+  /** `project()` cannot express `type`/`exports`, so this writes the manifests. */
+  function withEsmDependency(extra: Record<string, unknown>): string {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "vn-esm-"));
+    roots.push(root);
+    const write = (name: string, manifest: Record<string, unknown>) => {
+      const dir = path.join(root, "node_modules", ...name.split("/"));
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, "package.json"), JSON.stringify({ name, ...manifest }));
+    };
+    fs.writeFileSync(
+      path.join(root, "package.json"),
+      JSON.stringify({ name: "app", dependencies: { "rn-lib": "*" } }),
+    );
+    write("react-native", {});
+    write("rn-lib", {
+      peerDependencies: { "react-native": "*" },
+      dependencies: { "esm-dep": "*" },
+    });
+    write("esm-dep", extra);
+    return root;
+  }
+
+  it("is not compiled: it publishes runnable ES modules and nothing React Native", () => {
+    // The closure walk is a guess that a dependency might be untranspiled React Native
+    // source. `"type": "module"` is the manifest saying the opposite. Compiling it
+    // anyway rewrites a package that publishes ESM into CommonJS and hands it to Node
+    // under that format — how `zod`, reached exactly this way, took fourteen files down.
+    const detected = detectEcosystemPackages(withEsmDependency({ type: "module" }));
+    expect(detected).toContain("rn-lib");
+    expect(detected).not.toContain("esm-dep");
+  });
+
+  it("is still compiled when it declares a React Native build", () => {
+    // The discriminating half. A genuine React Native library may well be `type:
+    // module` and still ship source the preset has to compile; the React Native build
+    // is what says so — by legacy field...
+    const byField = detectEcosystemPackages(
+      withEsmDependency({ type: "module", "react-native": "./native.js" }),
+    );
+    expect(byField).toContain("esm-dep");
+    // ...or by export condition, at any depth of the map.
+    const byCondition = detectEcosystemPackages(
+      withEsmDependency({
+        type: "module",
+        exports: {
+          ".": { "react-native": { default: "./native.js" }, import: "./index.js" },
+          // Without this the manifest cannot be read at all and the package is
+          // skipped as "declared but not installed" — which would make the
+          // assertion below pass for entirely the wrong reason.
+          "./package.json": "./package.json",
+        },
+      }),
+    );
+    expect(byCondition).toContain("esm-dep");
+  });
+
+  it("is still compiled when it is CommonJS, which says nothing either way", () => {
+    expect(detectEcosystemPackages(withEsmDependency({}))).toContain("esm-dep");
+  });
+});
+
 describe("ecosystem detection: whose closure gets walked", () => {
   /** A workspace whose sibling declares `heavy-app`, and whose project declares none. */
   function workspaceWithSibling(): string {


### PR DESCRIPTION
## Description

**Regression in 0.11.0.** In a workspace holding both a library and a React Native or Expo application — the canonical React Native monorepo shape — the application's mere presence stops the library's tests from loading:

```
ReferenceError: [vitest-native] Failed to transform '@babel/runtime'
  (…/node_modules/@babel/runtime/helpers/interopRequireDefault.js) for platform 'ios'.
Caused by: ReferenceError: Cannot access 'v' before initialization

Test Files  1 failed (1)
     Tests  no tests
```

### Cause

0.11.0 began compiling a detected package's dependency **closure**, so that a library shipping untranspiled JSX inside a transitive dependency works without being named in `transform: [...]`.

Candidates are collected from every manifest in the workspace — that breadth is how a library the application depends on is found at all. Applied to a closure walk, it stops being free. A sibling Expo application is detected on its own manifest, and walking *its* dependencies pulled the entire Expo and Metro toolchain into the Babel transform set of a package that depends on none of it: **253 packages in a two-package reproduction**, `@babel/runtime` and Metro's `lru-cache` chain among them.

Those are not inert. React Native and Babel load them, and compiling the transform's own toolchain re-enters Babel while it is still initialising — surfacing as a TDZ error naming files the project never mentioned. The existing toolchain exclusion covers what `@babel/core` reaches, which is neither `@babel/runtime` (helpers emitted into compiled output) nor `yallist` (reached through Metro).

### Change

The closure walk now starts only from packages **the run declares** — the package under test, and any manifest above it, which is where a workspace keeping its React Native libraries at the repository root declares them. A package only a sibling declares is that sibling's business.

Transitive compilation is unaffected: a dependency reached *through* the walk is declared by its own parent, which is exactly what makes it transitive. Only the seeds are filtered.

Declaration rather than resolvability, deliberately. Under pnpm every workspace member is linked into a hidden directory placed on `NODE_PATH`, so a sibling's dependencies **do** resolve from the package under test inside the running process. A reachability test was written first and let all 253 straight back through — the manifest is the fact that doesn't move.

### Effect

In the two-package reproduction, the transform set drops from **253 packages to 5** — the declared dependency and its genuine closure (`react-native-modal` → `react-native-animatable`, `prop-types`, `object-assign`).

### Tests

`tests/ecosystem-closure.test.ts` gains three cases, each confirmed to fail without the fix:

- a sibling's closure is not walked;
- a closure the project declares still is (the discriminating half — this is what the walk exists for);
- a closure declared by a manifest *above* the project still is, covering the documented layout where a workspace keeps its React Native libraries at the root.

## Checklist

- [x] Tests pass (`bun run test`) — 1694 mock, 222 native across threads/forks/hot, hot-isolation, navigation, android, advice, full consumer harness across npm and pnpm
- [x] Lint passes (`bun run lint`) — and `format:check`, `typecheck`
- [x] Changeset added (if user-facing change)
- [ ] Docs updated (if API changed) — no API change
