### PR TITLE
feat(native): compile what Node cannot run, and nothing else

### DIFF
--- a/.changeset/parse-driven-compilation.md
+++ b/.changeset/parse-driven-compilation.md
@@ -1,0 +1,38 @@
+---
+"vitest-native": minor
+---
+
+Compile what Node cannot run, and nothing else
+
+The native engine decided what to compile by NAME: a package was handed to the React
+Native Babel preset because auto-detection or a dependency-closure walk selected it.
+That guess was wrong far more often than it was right, and every way of being wrong
+looked identical — a parse error deep inside a package the project never mentioned.
+Babel's own emitted helpers, Metro's `lru-cache` chain and a pure-ESM validator all
+arrived that way, and each was answered by adding another name to exclude.
+
+The file answers precisely. If V8 can parse it, Node can run it, so compiling is
+optional; if V8 cannot, Node cannot, so compiling is required — the same question Node
+is about to ask, which is what makes it a fact rather than a heuristic. Files selected
+for compiling are now parsed first, and only compiled if the parse fails.
+
+What is given up is downleveling for Hermes: `const` to `var`, destructuring lowered.
+Measured across React Native's own sources and the installed ecosystem, that is the
+whole of what the preset does to a file V8 accepts, and it is behaviour-preserving on
+Node — arguably closer to what the package published. `__DEV__` is left standing and
+top-level requires are not inlined, so neither observable transform is affected.
+
+**This is a robustness change, not a speed one.** On this repository's native suite
+with a cold transform cache it measured 7.68s against 7.35s without the check: React
+Native's own sources need compiling either way (440 of 450 fail to parse), so the check
+mostly adds work here. The benefit is that a package Node can already run can no longer
+reach Babel, whatever put it on the list.
+
+Scoped to script-goal files. A `type: module` package is compiled exactly as before,
+because the loader hands those to Node as CommonJS and changing that is an interop
+question about named exports and live bindings that a parse cannot answer.
+
+Also adds `transform: { include, exclude }`. `exclude` names packages the engine must
+never compile, overriding auto-detection, the closure walk and the built-in lists —
+so a project that hits a case the parse check does not cover can unblock itself the
+same day instead of waiting for a release. The array form keeps its meaning.

--- a/packages/vitest-native/src/native/ecosystem.ts
+++ b/packages/vitest-native/src/native/ecosystem.ts
@@ -211,6 +211,7 @@ export function detectEcosystemPackages(
   projectRoot: string | string[],
   explicit: string[] = [],
   testRoots: string[] = [],
+  neverTransform: string[] = [],
 ): string[] {
   // More than one root because `manifestsFrom` only walks UP. In a workspace the
   // run root is often above the package under test — Nx invokes tasks from the
@@ -221,7 +222,15 @@ export function detectEcosystemPackages(
   // time triggered by nothing but the working directory. The config file's
   // directory is the second root, since that is where the package under test lives.
   const roots = (Array.isArray(projectRoot) ? projectRoot : [projectRoot]).filter(Boolean);
-  const skip = new Set<string>([...NEVER_INLINE, ...Object.keys(AUTO_DETECT_PRESETS), ...explicit]);
+  // `neverTransform` is the user's `transform.exclude`. It joins the built-in lists
+  // rather than being checked separately, so it overrides detection AND the closure
+  // walk by the same mechanism they do.
+  const skip = new Set<string>([
+    ...NEVER_INLINE,
+    ...Object.keys(AUTO_DETECT_PRESETS),
+    ...explicit,
+    ...neverTransform,
+  ]);
   const candidates = new Set<string>();
   const found = roots.flatMap((root) => manifestsFrom(root));
   // One resolver per directory that declared something. Under pnpm a workspace

--- a/packages/vitest-native/src/native/ecosystem.ts
+++ b/packages/vitest-native/src/native/ecosystem.ts
@@ -369,6 +369,13 @@ export function detectEcosystemPackages(
   // as the toolchain's own dependencies change. They are skipped only as CLOSURE
   // MEMBERS — a project that genuinely depends on one still has it detected on its own
   // manifest, exactly as before.
+  // NOTE: since the parse check landed (see needsTransform in transform.mjs), a
+  // script-goal toolchain package can no longer reach Babel however it is listed —
+  // `@babel/runtime` and Metro's chain all parse, so they are skipped at the point of
+  // compiling. This list is retained only for MODULE-goal toolchain packages, which
+  // the parse check deliberately does not judge. It should be deleted when ESM-goal
+  // files stop being force-converted, and not extended before then: a new name here is
+  // a sign the parse check was bypassed rather than that the list was incomplete.
   const toolchain = closureOf([
     "@babel/core",
     "@react-native/babel-preset",

--- a/packages/vitest-native/src/native/hooks.mjs
+++ b/packages/vitest-native/src/native/hooks.mjs
@@ -3,7 +3,7 @@
 import Module from "node:module";
 import path from "node:path";
 import fs from "node:fs";
-import { transformRN, isFlow } from "./transform.mjs";
+import { transformRN, isFlow, needsTransform } from "./transform.mjs";
 import { boundarySourceFor } from "./boundary.mjs";
 import { resolvePlatformFile } from "./resolve.mjs";
 import {
@@ -289,10 +289,15 @@ export function installRequireHooks(
       if (isFlow(src))
         return mod._compile(transformRN(filename, src, projectRoot, platform), filename);
     } else if (isExtra(norm)) {
-      // Configured third-party packages: transform unconditionally — TS `import
-      // type`/JSX aren't caught by isFlow, and babel passes plain JS through.
+      // Selected for compiling — but only compile what Node cannot run as published.
+      // `isFlow` is not enough here (TS `import type` and JSX slip past it), and
+      // compiling everything is what handed Babel its own toolchain. See
+      // needsTransform: V8 answers the question Node is about to ask.
       const src = fs.readFileSync(filename, "utf8");
-      return mod._compile(transformRN(filename, src, projectRoot, platform), filename);
+      if (needsTransform(filename, src)) {
+        return mod._compile(transformRN(filename, src, projectRoot, platform), filename);
+      }
+      return origJs(mod, filename);
     }
     if (NODE_MODULES_PATH.test(norm)) {
       // A node_modules package we did NOT transform: when Node's compile throws a

--- a/packages/vitest-native/src/native/loader.mjs
+++ b/packages/vitest-native/src/native/loader.mjs
@@ -3,7 +3,7 @@
 import { fileURLToPath, pathToFileURL } from "node:url";
 import path from "node:path";
 import fs from "node:fs";
-import { transformRN, isFlow, cjsExportNames } from "./transform.mjs";
+import { transformRN, isFlow, cjsExportNames, needsTransform } from "./transform.mjs";
 import { boundarySourceFor } from "./boundary.mjs";
 import { resolvePlatformFile } from "./resolve.mjs";
 import {
@@ -248,6 +248,10 @@ export async function load(url, context, nextLoad) {
   // JSX are not installed, so a require here fails with "Unexpected token '<'".
   if (TRANSFORMABLE.test(norm)) {
     const src = fs.readFileSync(file, "utf8");
+    // Only compile what Node cannot run as published — see needsTransform. A file V8
+    // accepts is handed straight back to Node, which is how the toolchain packages a
+    // closure walk drags in stop reaching the Babel preset at all.
+    if (!needsTransform(file, src)) return nextLoad(url, context);
     const code = transformRN(file, src, PROJECT_ROOT, PLATFORM);
     const names = cjsExportNames(code);
     return {

--- a/packages/vitest-native/src/native/transform.mjs
+++ b/packages/vitest-native/src/native/transform.mjs
@@ -18,6 +18,7 @@ import path from "node:path";
 import fs from "node:fs";
 import os from "node:os";
 import crypto from "node:crypto";
+import vm from "node:vm";
 import { decorateTransformError } from "./explain.mjs";
 import { VitestNativeError } from "../errors.mjs";
 
@@ -195,6 +196,82 @@ export function cjsExportNames(code) {
 
 export function isFlow(src) {
   return /@flow|import typeof|\bcomponent\s+\w/.test(src);
+}
+
+/**
+ * Does this file need compiling, or can Node run it as published?
+ *
+ * The engine used to answer this by NAME: a package was compiled because detection or
+ * a closure walk selected it. That guess was wrong far more often than it was right,
+ * and every way of being wrong looked the same — a parse error deep inside a package
+ * the project never mentioned. `@babel/runtime`, Metro's `lru-cache` chain and a
+ * pure-ESM validator all arrived that way, and each was answered with another name to
+ * exclude.
+ *
+ * The file itself answers precisely. If V8 can parse it, Node can run it, so compiling
+ * is optional; if V8 cannot, Node cannot, so compiling is required. That is not a
+ * heuristic — it is the same question Node is about to ask.
+ *
+ * Measured on a 41 KB file: the check costs 0.02 ms against 91 ms for the transform it
+ * avoids. That is NOT a speed win in practice and should not be sold as one — on this
+ * repository's own native suite, cold cache, it measured 7.68 s against 7.35 s without
+ * the check, because React Native's own sources need compiling either way (440 of 450
+ * fail to parse) and the check adds a parse to each. The win is that a package Node can
+ * already run is never handed to Babel, whatever selected it.
+ *
+ * What is lost by skipping is downleveling for Hermes — `const` to `var`, destructuring
+ * lowered. Verified against React Native's own sources and the installed ecosystem:
+ * that is all the preset does to a file V8 accepts. It is behaviour-preserving on
+ * Node, and if anything closer to what the package published. `__DEV__` is left
+ * standing and top-level requires are not inlined, so neither observable transform
+ * applies here.
+ *
+ * SCRIPT GOAL ONLY. A `type: module` package is still compiled as before: the loader
+ * hands those to Node as CommonJS today, and changing that is an interop question
+ * about named exports and live bindings that this check does not answer.
+ */
+export function needsTransform(file, src) {
+  if (file.endsWith(".mjs") || moduleGoal(file)) return true; // Not this check's business.
+  try {
+    // Parsed for the verdict only; the compiled script is never run.
+    const parsed = new vm.Script(src, { filename: file });
+    return parsed === undefined;
+  } catch {
+    return true;
+  }
+}
+
+/** Is this file's nearest package.json `type: module`? Cached per directory. */
+const goalCache = new Map();
+function moduleGoal(file) {
+  if (file.endsWith(".cjs")) return false;
+  let dir = path.dirname(file);
+  const seen = [];
+  for (;;) {
+    const cached = goalCache.get(dir);
+    if (cached !== undefined) {
+      for (const d of seen) goalCache.set(d, cached);
+      return cached;
+    }
+    seen.push(dir);
+    let verdict;
+    try {
+      verdict =
+        JSON.parse(fs.readFileSync(path.join(dir, "package.json"), "utf8")).type === "module";
+    } catch {
+      verdict = undefined;
+    }
+    if (verdict !== undefined) {
+      for (const d of seen) goalCache.set(d, verdict);
+      return verdict;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      for (const d of seen) goalCache.set(d, false);
+      return false;
+    }
+    dir = parent;
+  }
 }
 
 /** Transform an RN source file to runnable CJS. Cached in-memory + on disk. */

--- a/packages/vitest-native/src/plugin.ts
+++ b/packages/vitest-native/src/plugin.ts
@@ -129,6 +129,33 @@ function nearestPackageDir(from: string): string | null {
   }
 }
 
+/**
+ * The `transform` option in either shape: an array of packages to compile, or an
+ * object naming those and the ones to leave alone.
+ *
+ * `exclude` overrides everything — auto-detection, the closure walk, and the engine's
+ * built-in toolchain and infrastructure lists. Those built-in lists are names the
+ * engine learned from packages that broke, which means they are only ever as current
+ * as the last release; `exclude` is the same decision, handed to the project.
+ */
+export function normalizeTransformOption(option: unknown): {
+  include: string[];
+  exclude: string[];
+} {
+  const names = (value: unknown): string[] =>
+    Array.isArray(value) ? value.filter((v): v is string => typeof v === "string" && v !== "") : [];
+  if (Array.isArray(option)) return { include: names(option), exclude: [] };
+  if (option && typeof option === "object") {
+    const shape = option as { include?: unknown; exclude?: unknown };
+    const exclude = names(shape.exclude);
+    // Excluding a package the same config also asks to transform is a contradiction;
+    // the safer reading wins, since the cost of not compiling something is a legible
+    // syntax error and the cost of compiling the wrong thing is a crash inside Babel.
+    return { include: names(shape.include).filter((n) => !exclude.includes(n)), exclude };
+  }
+  return { include: [], exclude: [] };
+}
+
 function resolvePackageVersion(packageName: string, projectRoot: string): string | null {
   const req = createRequire(path.join(projectRoot, "package.json"));
   try {
@@ -781,9 +808,11 @@ export function reactNative(options?: VitestNativeOptions): Plugin {
   const diagnostics = options?.diagnostics ?? false;
   // Capture the user-requested engine; concrete resolution happens in config().
   const requestedEngine = options?.engine ?? "auto";
-  // Extra node_modules packages the native engine should transform (Flow/TS/JSX).
-  const transformPkgs = (options?.transform ?? []).filter(
-    (p) => typeof p === "string" && p.length > 0,
+  // Extra node_modules packages the native engine should transform (Flow/TS/JSX),
+  // and the ones it must never transform whatever else selects them. Two shapes: an
+  // array is the include list, an object names both.
+  const { include: transformPkgs, exclude: neverTransform } = normalizeTransformOption(
+    options?.transform,
   );
   // Hot runtime (native engine only): persistent RN-hot workers with per-file
   // isolation via the custom pool. Opt-in while it bakes (see design doc).
@@ -936,6 +965,7 @@ export function reactNative(options?: VitestNativeOptions): Plugin {
           [resolvedRoot, ...includeRoots],
           transformPkgs,
           includeRoots,
+          neverTransform,
         );
         // The directories Vite owns outright. Handed to the worker so the require
         // hook can say so if Node loads one of their files anyway — which happens

--- a/packages/vitest-native/src/types.ts
+++ b/packages/vitest-native/src/types.ts
@@ -299,12 +299,34 @@ export interface VitestNativeOptions {
    * (e.g. `react-native-reanimated`, `react-native-safe-area-context`) need to
    * be listed here, analogous to Jest's `transformIgnorePatterns` allowlist.
    *
+   * The object form adds `exclude`, which names packages the engine must NEVER
+   * transform, whatever else would have selected them — auto-detection, a detected
+   * package's dependency closure, or the engine's own built-in lists.
+   *
+   * `exclude` exists because the engine's judgement about what is React Native source
+   * is a heuristic, and when it guesses wrong the failure is a parse error deep inside
+   * a package the project never named. Build toolchains are the recurring case:
+   * compiling one re-enters Babel while it is loading. The engine excludes the ones it
+   * knows about, but that list is only as current as the last release — `exclude` is
+   * how a project unblocks itself the same day, without waiting for one.
+   *
+   * Run with `diagnostics: true` to print the packages the engine chose to compile;
+   * that list is what `exclude` subtracts from.
+   *
    * @example
    * ```ts
    * reactNative({ engine: 'native', transform: ['react-native-reanimated'] })
+   *
+   * reactNative({
+   *   engine: 'native',
+   *   transform: {
+   *     include: ['react-native-reanimated'],
+   *     exclude: ['some-build-tool'], // never hand this to the Babel preset
+   *   },
+   * })
    * ```
    */
-  transform?: string[];
+  transform?: string[] | { include?: string[]; exclude?: string[] };
 
   /**
    * `engine: 'native'` only. **Experimental.** Run tests in persistent

--- a/packages/vitest-native/src/validate.ts
+++ b/packages/vitest-native/src/validate.ts
@@ -58,7 +58,31 @@ export function validateOptions(options: Record<string, unknown>): void {
     throw new VitestNativeTypeError("INVALID_OPTION", `"diagnostics" must be a boolean.`);
   }
   if (options.assetExts !== undefined) assertStringArray(options.assetExts, "assetExts");
-  if (options.transform !== undefined) assertStringArray(options.transform, "transform");
+  // Two shapes, like `presets`: an array is the include list; an object names
+  // `include` and/or `exclude`.
+  if (options.transform !== undefined) {
+    if (Array.isArray(options.transform)) {
+      assertStringArray(options.transform, "transform");
+    } else if (options.transform !== null && typeof options.transform === "object") {
+      const shape = options.transform as { include?: unknown; exclude?: unknown };
+      const unknownKeys = Object.keys(shape).filter((k) => k !== "include" && k !== "exclude");
+      if (unknownKeys.length > 0) {
+        throw new VitestNativeTypeError(
+          "INVALID_OPTION",
+          `"transform" accepts only "include" and "exclude"; received ${unknownKeys
+            .map((k) => `"${k}"`)
+            .join(", ")}.`,
+        );
+      }
+      if (shape.include !== undefined) assertStringArray(shape.include, "transform.include");
+      if (shape.exclude !== undefined) assertStringArray(shape.exclude, "transform.exclude");
+    } else {
+      throw new VitestNativeTypeError(
+        "INVALID_OPTION",
+        `"transform" must be an array of package names, or an object with "include" and/or "exclude".`,
+      );
+    }
+  }
   // Two shapes: an array replaces auto-detection, an object of booleans keeps it and
   // switches named presets off. Anything else is rejected with both spellings named,
   // since "must be an array" would now be wrong advice.

--- a/packages/vitest-native/tests/needs-transform.test.ts
+++ b/packages/vitest-native/tests/needs-transform.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Compile what Node cannot run, and nothing else.
+ *
+ * The engine used to decide by NAME: a package was compiled because detection or a
+ * dependency-closure walk selected it. That guess was wrong far more often than right,
+ * and every way of being wrong looked identical — a parse error deep inside a package
+ * the project never mentioned. `@babel/runtime`, Metro's `lru-cache` chain and a
+ * pure-ESM validator all arrived that way, and each was answered by adding another
+ * name to exclude.
+ *
+ * The file answers precisely: if V8 can parse it, Node can run it, so compiling is
+ * optional; if V8 cannot, Node cannot, so compiling is required. It is the same
+ * question Node is about to ask, which is why it is not a heuristic.
+ *
+ * What skipping costs is downleveling for Hermes — `const` to `var`, destructuring
+ * lowered. Measured against React Native's own sources and the installed ecosystem,
+ * that is the whole of what the preset does to a file V8 accepts, and it is
+ * behaviour-preserving on Node.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { needsTransform } from "../src/native/transform.mjs";
+
+const roots: string[] = [];
+afterAll(() => {
+  for (const r of roots) fs.rmSync(r, { recursive: true, force: true });
+});
+
+/** A file inside a package with the given `type`, so the goal is unambiguous. */
+function fileIn(type: "commonjs" | "module" | undefined, name: string, source: string): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vn-parse-"));
+  roots.push(root);
+  fs.writeFileSync(
+    path.join(root, "package.json"),
+    JSON.stringify({ name: "p", ...(type ? { type } : {}) }),
+  );
+  const file = path.join(root, name);
+  fs.writeFileSync(file, source);
+  return file;
+}
+
+describe("what has to be compiled", () => {
+  const cjs = (name: string, src: string) => {
+    const file = fileIn("commonjs", name, src);
+    return needsTransform(file, src);
+  };
+
+  it("compiles the syntax Node cannot run", () => {
+    // Every shape the React Native ecosystem actually ships untranspiled.
+    expect(cjs("flow.js", "function f(x: number): string { return String(x); }")).toBe(true);
+    expect(cjs("flowtype.js", 'import type {A} from "./a"; module.exports = {};')).toBe(true);
+    expect(cjs("enum.js", "export enum Status { Active, Done }")).toBe(true);
+    expect(cjs("jsx.js", "const A = () => <View><Text>hi</Text></View>;")).toBe(true);
+    expect(cjs("ts.js", 'const x: string = "a";')).toBe(true);
+    // React Native's own `component` syntax, which only the preset lowers.
+    expect(cjs("component.js", "component Greeting(name: string) { return null; }")).toBe(true);
+  });
+
+  it("leaves alone what Node can already run", () => {
+    // The packages that kept arriving at the Babel preset and crashing it: Babel's own
+    // emitted helpers, and a minified one-liner of the shape Metro's cache chain ships.
+    expect(
+      cjs(
+        "helper.js",
+        "exports.d = function (o) { return o && o.__esModule ? o : { default: o }; };",
+      ),
+    ).toBe(false);
+    expect(
+      cjs("min.js", "var a=1,b=void 0;module.exports=function(){return void 0===b?a:b};"),
+    ).toBe(false);
+    // Modern syntax V8 accepts needs no downleveling on Node, whatever Hermes wants.
+    expect(
+      cjs("modern.js", "const {a} = require('x'); class C { #p = 1; m() { return a?.b ?? 1; } }"),
+    ).toBe(false);
+  });
+
+  it("treats ESM as out of scope rather than guessing", () => {
+    // A `type: module` package is still compiled exactly as before. The loader hands
+    // those to Node as CommonJS today, and changing that is an interop question about
+    // named exports and live bindings that a parse cannot answer.
+    const esm = fileIn("module", "index.js", "export const a = 1;");
+    expect(needsTransform(esm, "export const a = 1;")).toBe(true);
+    const mjs = fileIn("commonjs", "index.mjs", "export const a = 1;");
+    expect(needsTransform(mjs, "export const a = 1;")).toBe(true);
+    // The discriminating case: a module-goal file that WOULD parse as a script. The
+    // goal has to be consulted, not just the parse, or ESM packages quietly change
+    // format — which is the Stage 2 question, not this one.
+    const plain = "const a = 1;";
+    expect(needsTransform(fileIn("module", "plain.js", plain), plain)).toBe(true);
+  });
+
+  it("reads the goal from the package, not the file", () => {
+    // ESM syntax inside a CommonJS package is something Node cannot run either, so it
+    // is compiled — which is what makes the externalized-ESM path keep working.
+    expect(cjs("esm-in-cjs.js", "export const a = 1;")).toBe(true);
+    // ...and an explicit .cjs extension is a script whatever the package says.
+    const cjsFile = fileIn("module", "thing.cjs", "const a = 1; module.exports = a;");
+    expect(needsTransform(cjsFile, "const a = 1; module.exports = a;")).toBe(false);
+  });
+});

--- a/packages/vitest-native/tests/transform-exclude.test.ts
+++ b/packages/vitest-native/tests/transform-exclude.test.ts
@@ -1,0 +1,113 @@
+/**
+ * `transform: { exclude: [...] }` — the escape hatch for the engine guessing wrong.
+ *
+ * Deciding which packages are untranspiled React Native source is a heuristic, and
+ * when it guesses wrong the failure is a parse error deep inside a package the project
+ * never named. Build toolchains are the recurring case: compiling one re-enters Babel
+ * while it is loading. The engine carries built-in exclusions for the ones it knows
+ * about — `@babel/core`, the Babel preset, `@babel/runtime`, Metro, React, the test
+ * renderers — but every name on that list was learned from a package that broke, which
+ * makes the list exactly as current as the last release.
+ *
+ * `exclude` is the same decision handed to the project, so a team hitting the next one
+ * can unblock itself the same day. It overrides everything that would otherwise select
+ * a package: auto-detection, a detected package's dependency closure, the built-in
+ * lists, and an `include` in the same config.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { detectEcosystemPackages } from "../src/native/ecosystem.js";
+import { normalizeTransformOption } from "../src/plugin.js";
+import { validateOptions } from "../src/validate.js";
+
+const roots: string[] = [];
+afterAll(() => {
+  for (const r of roots) fs.rmSync(r, { recursive: true, force: true });
+});
+
+/** A project declaring `rn-lib`, which drags `helper` in through its closure. */
+function project(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vn-exclude-"));
+  roots.push(root);
+  const write = (name: string, manifest: Record<string, unknown>) => {
+    const dir = path.join(root, "node_modules", ...name.split("/"));
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "package.json"), JSON.stringify({ name, ...manifest }));
+  };
+  fs.writeFileSync(
+    path.join(root, "package.json"),
+    JSON.stringify({ name: "app", dependencies: { "rn-lib": "*" } }),
+  );
+  write("react-native", {});
+  write("rn-lib", { peerDependencies: { "react-native": "*" }, dependencies: { helper: "*" } });
+  write("helper", {});
+  return root;
+}
+
+describe("the transform option's two shapes", () => {
+  it("reads an array as the include list", () => {
+    expect(normalizeTransformOption(["a", "b"])).toEqual({ include: ["a", "b"], exclude: [] });
+  });
+
+  it("reads an object as both lists", () => {
+    expect(normalizeTransformOption({ include: ["a"], exclude: ["b"] })).toEqual({
+      include: ["a"],
+      exclude: ["b"],
+    });
+  });
+
+  it("lets exclude win over include in the same config", () => {
+    // A contradiction has to resolve somewhere, and this is the safer direction: not
+    // compiling something surfaces as a legible syntax error in a named package, while
+    // compiling the wrong thing crashes inside Babel naming a file nobody recognises.
+    expect(normalizeTransformOption({ include: ["a", "b"], exclude: ["b"] })).toEqual({
+      include: ["a"],
+      exclude: ["b"],
+    });
+  });
+
+  it("ignores absent, empty and non-string entries", () => {
+    expect(normalizeTransformOption(undefined)).toEqual({ include: [], exclude: [] });
+    expect(normalizeTransformOption({})).toEqual({ include: [], exclude: [] });
+    expect(normalizeTransformOption(["a", "", 7 as unknown as string])).toEqual({
+      include: ["a"],
+      exclude: [],
+    });
+  });
+});
+
+describe("transform.exclude overrides every route into the transform set", () => {
+  it("drops a package that auto-detection would have claimed", () => {
+    expect(detectEcosystemPackages(project())).toContain("rn-lib");
+    expect(detectEcosystemPackages(project(), [], [], ["rn-lib"])).not.toContain("rn-lib");
+  });
+
+  it("drops a package reached only through a closure", () => {
+    // The route that produced every toolchain crash so far: the project never named
+    // it, so `transform: [...]` was no help and neither was removing anything.
+    expect(detectEcosystemPackages(project())).toContain("helper");
+    const detected = detectEcosystemPackages(project(), [], [], ["helper"]);
+    expect(detected).not.toContain("helper");
+    expect(detected, "excluding a closure member leaves its parent alone").toContain("rn-lib");
+  });
+});
+
+describe("transform option validation", () => {
+  const check = (transform: unknown) => () => validateOptions({ transform } as never);
+
+  it("accepts both shapes", () => {
+    expect(check(["a"])).not.toThrow();
+    expect(check({ include: ["a"] })).not.toThrow();
+    expect(check({ exclude: ["a"] })).not.toThrow();
+    expect(check({ include: ["a"], exclude: ["b"] })).not.toThrow();
+  });
+
+  it("names the mistake rather than the shape", () => {
+    // "must be an array" would be wrong advice now that the object form exists.
+    expect(check("react-native-reanimated")).toThrow(/array of package names, or an object/);
+    expect(check({ includes: ["a"] })).toThrow(/only "include" and "exclude".*"includes"/s);
+    expect(check({ exclude: [7] })).toThrow(/transform\.exclude/);
+  });
+});


### PR DESCRIPTION
## Description

The native engine decided what to compile by **name**: a package reached the React Native Babel preset because auto-detection or a dependency-closure walk selected it. Four corrections to that guess landed in the last two releases — a toolchain closure, a run-declares-it rule, an ESM-only rule, a user override — and every one was a symptom of the same thing: compiling packages that did not need compiling, and finding out through a parse error inside a package the project never mentioned.

**The file answers the question precisely.** If V8 can parse it, Node can run it, so compiling is optional; if V8 cannot, Node cannot, so compiling is required. That is the same question Node is about to ask, which is what makes it a fact rather than a heuristic. Files selected for compiling are now parsed first, and compiled only if the parse fails.

### The research, including where it corrected me

The first measurement was **wrong**: a comment-stripper deleted everything after a `//` inside a string on a minified single line, inventing a 522,919 → 3,610 char code loss that does not exist (real output: 478,363).

The corrected comparison — the preset's output against a plain parse-and-regenerate with identical generator settings, so only preset effects show:

| corpus | parseable files | preset a no-op | preset changes output |
|---|---|---|---|
| react-native | 10 | 5 | 5 |
| ecosystem packages | 122 | 32 | 90 |

That **falsified** the original claim that the transform is a no-op for parseable files. Reading the diffs showed what it actually does:

```
baseline: const {polyfillObjectProperty} = require('../Utilities/PolyfillFunctions');
preset:   var _require = require('../Utilities/PolyfillFunctions'),
          polyfillObjectProperty = _require.polyfillObjectProperty;
```

Downleveling for Hermes — behaviour-preserving on Node, and arguably closer to what the package published. `__DEV__` is left standing and top-level requires are not inlined, so the two transforms that *would* be observable do not apply. Same conclusion, different and now-grounded reason.

### Scope

**Script-goal files only.** A `type: module` package is compiled exactly as before: the loader hands those to Node as CommonJS today, and changing that is an interop question about named exports and live bindings that a parse cannot answer. 478 of 600 ecosystem files in this repository are module-goal, so that is a separate change needing its own evidence.

### This is not a speed win

Cold transform cache, this repository's native suite: **7.68s with the check against 7.35s without**. React Native's own sources need compiling either way (440 of 450 fail to parse), so the check mostly adds a parse. The benefit is robustness — a package Node can already run can no longer reach Babel, whatever put it on the list.

### Also: `transform: { include, exclude }`

`exclude` names packages the engine must never compile, overriding auto-detection, the closure walk and the built-in lists. The built-in lists are only ever as current as the last release; this is the same decision handed to the project, so a team hitting a case the parse check does not cover unblocks itself the same day. The array form keeps its meaning; `exclude` wins over `include` in the same config.

The toolchain seed list stays, scoped by comment to module-goal packages and marked for deletion when ESM-goal files stop being force-converted. A new name added to it should be read as the parse check having been bypassed, not the list being incomplete.

### Verification

- Every gate mutation-tested, including two that initially passed for the wrong reason and were rewritten to discriminate.
- 1710 mock, 222 native across threads/forks/hot, hot-isolation, android, navigation, advice.
- Consumer matrix: six invocations across npm and pnpm.
- mock ≡ real-RN cross-check: 85/85.
- The Expo two-package reproduction from the 0.11.0 regression: green.
- Files that genuinely need compiling still do — the untranspiled-JSX fixtures are unchanged and passing.

## Checklist

- [x] Tests pass (`bun run test`)
- [x] Lint passes (`bun run lint`)
- [x] Changeset added (if user-facing change)
- [ ] Docs updated (if API changed) — `transform.exclude` is documented in the option's JSDoc; the docs site page is a follow-up
