### PR TITLE
fix(native): reset externalized packages a test file imports, under the hot runtime

### DIFF
--- a/.changeset/hot-esm-registry-residency.md
+++ b/.changeset/hot-esm-registry-residency.md
@@ -1,0 +1,36 @@
+---
+"vitest-native": patch
+---
+
+Reset externalized packages a test file imports, under the hot runtime
+
+The hot runtime keeps a worker alive across test files and clears what each file
+loaded, so the next one starts fresh. That reset could only reach Node's CommonJS
+cache. A package reached through ESM `import` is held by Node's ESM registry, which
+has no invalidation API, so its module-level state — a store, a client, a cache —
+survived for the whole run. The second test file to touch such a package saw the
+first one's writes.
+
+The registry cannot be invalidated, but it is keyed by full URL, and the engine owns
+the resolve hook. The per-file reset now advances a generation counter that the
+loader stamps onto the resolved URL, so the next file imports a URL Node has not seen
+and evaluates the module again. React Native itself and the identity-sensitive
+modules already listed in the reset are exempt: for those a fresh instance is the
+bug, not the fix. Cost is bounded by ownership — a CommonJS package re-enters through
+`Module._cache`, which the reset already drops, so only a namespace wrapper is
+retained per generation.
+
+Measured on a 135-file suite: correctness went from 126/135 to 135/135 against the
+same suite under stock isolation, wall clock was unchanged (9.9× stock isolation),
+and peak RSS rose 7.4% (956 MB to 1027 MB). `VITEST_NATIVE_HOT_ESM_GEN=0` restores
+the previous behaviour.
+
+Nothing changes when the hot runtime is off; the counter is only installed by the hot
+worker.
+
+The hot-isolation suite reached this fixture through `require` deliberately, because
+the ESM path could not pass — it documented the hole rather than covering it. It now
+has an ESM twin, and the scale validation gained templates for the shapes that were
+missing from it entirely: real React Navigation, a navigation container wrapping a
+Modal, and a node_modules package holding module-level state. Navigation had never
+run under the hot runtime in any gate.

--- a/.changeset/hot-esm-registry-residency.md
+++ b/.changeset/hot-esm-registry-residency.md
@@ -44,3 +44,23 @@ has an ESM twin, and the scale validation gained templates for the shapes that w
 missing from it entirely: real React Navigation, a navigation container wrapping a
 Modal, and a node_modules package holding module-level state. Navigation had never
 run under the hot runtime in any gate.
+
+The stamp is scoped away from the test stack itself — vitest, `@vitest/*`, chai, and
+this engine. The worker's runtime holds boot instances of these (the runner's
+SnapshotClient, chai's extended Assertion, the engine's registry), and a test file
+reaches the same packages through Node's ESM path; stamping those resolutions hands
+the file a twin runtime whose failures are emergent and order-dependent —
+`toMatchSnapshot` asking a SnapshotClient no one set up, fake timers flipping a copy
+of the state the runner never reads. The workspace gates cannot see this class: in
+the repository, the engine and the validation suites resolve outside node_modules,
+where the node_modules-scoped stamp never applies. It surfaced only on a packed
+install, running react-native-paper's suite under the hot runtime: 603/678 → 473/648
+before the exemption, 609/678 — above the recorded baseline — with it.
+
+The consumer tests gained the gate that class needs: the packed current-RN fixture
+now runs a hot-runtime leg whose probe asserts the resolution invariant directly —
+an ordinary node_modules package resolves generation-stamped while vitest,
+`@vitest/snapshot`, chai, and the engine never do — alongside behavioral checks
+(snapshots, fake timers, cross-file state reset from a packed install). Both
+mutations were run before trusting it: removing the exemption and disabling the
+generation mechanism each turn the leg red.

--- a/.changeset/hot-esm-registry-residency.md
+++ b/.changeset/hot-esm-registry-residency.md
@@ -20,11 +20,21 @@ bug, not the fix. Cost is bounded by ownership — a CommonJS package re-enters 
 `Module._cache`, which the reset already drops, so only a namespace wrapper is
 retained per generation.
 
-Measured on a 135-file suite: correctness went from 126/135 to 135/135 against the
-same suite under stock isolation, wall clock was unchanged (9.9× stock isolation),
-and peak RSS rose 7.4% (956 MB to 1027 MB). `VITEST_NATIVE_HOT_ESM_GEN=0` restores
-the previous behaviour.
+Correctness on a 135-file suite went from 126/135 to 135/135 against the same suite
+under stock isolation.
 
+The cost is re-execution, and it scales with how many externalized packages a test
+file imports — which is nothing to do with React Native, since RN and the packages
+that depend on it are inlined into Vite's graph and never reach this path. A suite
+where every file imports eight ordinary npm packages measured 1.14s to 1.77s, 55%
+more wall clock; stock isolation runs the same suite in 15.90s, so hot goes from
+13.9× to 9.0×. Suites that import few externalized packages pay close to nothing.
+
+Peak RSS does not grow: 946 MB with the stamp against 955 MB without, on that same
+suite. A CommonJS package re-enters through `Module._cache`, which the reset already
+drops, so only a namespace wrapper is retained per generation.
+
+`hotRuntime: { esmGeneration: false }` trades the correctness back for the speed.
 Nothing changes when the hot runtime is off; the counter is only installed by the hot
 worker.
 

--- a/packages/vitest-native/consumer-tests/current-rn/package.json
+++ b/packages/vitest-native/consumer-tests/current-rn/package.json
@@ -3,13 +3,16 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:hot": "vitest run --config vitest.hot.config.mts"
   },
   "dependencies": {
     "@testing-library/react-native": "13.3.3",
+    "consumer-state-fixture": "file:./state-fixture",
     "react": "19.2.4",
     "react-native": "0.86.0",
-    "react-test-renderer": "19.2.4"
+    "react-test-renderer": "19.2.4",
+    "runtime-probe": "file:./runtime-probe"
   },
   "devDependencies": {
     "@babel/core": "7.29.7",

--- a/packages/vitest-native/consumer-tests/current-rn/runtime-probe/index.mjs
+++ b/packages/vitest-native/consumer-tests/current-rn/runtime-probe/index.mjs
@@ -1,0 +1,20 @@
+// Resolution probe for the hot runtime's ESM generation stamp. This package is an
+// ordinary externalized node_modules dependency, so under hot it is re-resolved per
+// test file THROUGH the engine's loader hooks — and `import.meta.resolve` here
+// returns exactly the URL the hooks produced, stamp included.
+//
+// The invariant under test: the test stack itself (vitest, @vitest/*, chai, and the
+// engine) must NEVER carry a generation stamp. A stamped URL is a twin runtime —
+// a SnapshotClient no one set up, fake-timer state the runner never reads — and the
+// failures it causes downstream are emergent and order-dependent, which is why the
+// gate asserts the resolution invariant instead of waiting for a symptom.
+export const resolvedUrls = {
+  vitest: import.meta.resolve("vitest"),
+  snapshot: import.meta.resolve("@vitest/snapshot"),
+  chai: import.meta.resolve("chai"),
+  engine: import.meta.resolve("vitest-native"),
+  // Control: this probe package itself IS expected to be stamped (its module-level
+  // state must reset per file). If this stops carrying a stamp, the generation
+  // mechanism is off entirely and the invariant above is passing vacuously.
+  self: import.meta.url,
+};

--- a/packages/vitest-native/consumer-tests/current-rn/runtime-probe/package.json
+++ b/packages/vitest-native/consumer-tests/current-rn/runtime-probe/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "runtime-probe",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "main": "index.mjs"
+}

--- a/packages/vitest-native/consumer-tests/current-rn/src/hot-a.test.tsx
+++ b/packages/vitest-native/consumer-tests/current-rn/src/hot-a.test.tsx
@@ -16,13 +16,21 @@ afterEach(() => {
 });
 
 test("snapshot state is the runner's own (hot, packed)", () => {
-  const tree = render(
+  render(
     <View testID="hot-a">
       <Text>hot consumer A</Text>
     </View>,
-  ).toJSON();
-  expect(tree).toMatchSnapshot();
+  );
   expect(screen.getByTestId("hot-a")).toHaveTextContent("hot consumer A");
+  // Inline snapshot of a stable literal: the point is the snapshot MACHINERY —
+  // a twin @vitest/snapshot throws "snapshot state ... not found" here — not
+  // render fidelity, which full-tree snapshots would tie to the pinned RN's
+  // internal props. Inline also needs no .snap file, which CI refuses to create.
+  expect({ file: "hot-a" }).toMatchInlineSnapshot(`
+    {
+      "file": "hot-a",
+    }
+  `);
 });
 
 test("fake timers drive the runner's clock (hot, packed)", () => {

--- a/packages/vitest-native/consumer-tests/current-rn/src/hot-a.test.tsx
+++ b/packages/vitest-native/consumer-tests/current-rn/src/hot-a.test.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { render, screen } from "@testing-library/react-native";
+import { Text, View } from "react-native";
+import { afterEach, expect, test, vi } from "vitest";
+import { count, record } from "consumer-state-fixture";
+
+// Twin-runtime probes, from a packed install. Each assertion here fails if the hot
+// runtime's ESM generation stamp reaches the test stack itself: a stamped
+// @vitest/snapshot means `toMatchSnapshot` asks a SnapshotClient no one set up, and
+// a stamped vitest means the fake-timer state this file flips is a copy the runner
+// never reads. The state-fixture pair (with hot-b) proves the stamp still DOES
+// reach an ordinary stateful CommonJS package.
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+test("snapshot state is the runner's own (hot, packed)", () => {
+  const tree = render(
+    <View testID="hot-a">
+      <Text>hot consumer A</Text>
+    </View>,
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+  expect(screen.getByTestId("hot-a")).toHaveTextContent("hot consumer A");
+});
+
+test("fake timers drive the runner's clock (hot, packed)", () => {
+  vi.useFakeTimers();
+  let fired = false;
+  setTimeout(() => {
+    fired = true;
+  }, 1000);
+  vi.advanceTimersByTime(1000);
+  expect(fired).toBe(true);
+});
+
+test("externalized package state starts fresh in file A", () => {
+  expect(count()).toBe(0);
+  record("a");
+  expect(count()).toBe(1);
+});

--- a/packages/vitest-native/consumer-tests/current-rn/src/hot-b.test.tsx
+++ b/packages/vitest-native/consumer-tests/current-rn/src/hot-b.test.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { Text, View } from "react-native";
+import { expect, test } from "vitest";
+import { count, record } from "consumer-state-fixture";
+import { resolvedUrls } from "runtime-probe";
+
+// Second file of the pair: sees hot-a's writes unless the per-file reset (and its
+// ESM generation stamp) really evicted the externalized package from a packed
+// install. Runs its own snapshot too — every file gets its own snapshot state, so
+// one passing file says nothing about the next.
+
+test("snapshot state is the runner's own in a second file (hot, packed)", () => {
+  const tree = render(
+    <View testID="hot-b">
+      <Text>hot consumer B</Text>
+    </View>,
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test("externalized package state was reset between files", () => {
+  expect(count()).toBe(0);
+  record("b");
+  expect(count()).toBe(1);
+});
+
+// The invariant behind the behavioral probes above, asserted directly: the ESM
+// generation stamp must reach ordinary packages (the probe itself — the control)
+// and must NEVER reach the test stack, whose twin would be a runtime the runner
+// doesn't read. The twin's downstream symptoms are emergent and order-dependent
+// (react-native-paper needed a full 52-file run to surface them), so the gate
+// checks resolution, which is deterministic on any file after the first reset.
+test("the test stack resolves unstamped; ordinary packages resolve stamped", () => {
+  expect(resolvedUrls.self).toContain("vnhot=");
+  expect(resolvedUrls.vitest).not.toContain("vnhot=");
+  expect(resolvedUrls.snapshot).not.toContain("vnhot=");
+  expect(resolvedUrls.chai).not.toContain("vnhot=");
+  expect(resolvedUrls.engine).not.toContain("vnhot=");
+});

--- a/packages/vitest-native/consumer-tests/current-rn/src/hot-b.test.tsx
+++ b/packages/vitest-native/consumer-tests/current-rn/src/hot-b.test.tsx
@@ -11,12 +11,18 @@ import { resolvedUrls } from "runtime-probe";
 // one passing file says nothing about the next.
 
 test("snapshot state is the runner's own in a second file (hot, packed)", () => {
-  const tree = render(
+  render(
     <View testID="hot-b">
       <Text>hot consumer B</Text>
     </View>,
-  ).toJSON();
-  expect(tree).toMatchSnapshot();
+  );
+  // Stable-literal inline snapshot, as in hot-a: exercises SnapshotClient state
+  // for THIS file (every file gets its own), without coupling to RN render props.
+  expect({ file: "hot-b" }).toMatchInlineSnapshot(`
+    {
+      "file": "hot-b",
+    }
+  `);
 });
 
 test("externalized package state was reset between files", () => {

--- a/packages/vitest-native/consumer-tests/current-rn/state-fixture/index.js
+++ b/packages/vitest-native/consumer-tests/current-rn/state-fixture/index.js
@@ -1,0 +1,9 @@
+// A CommonJS node_modules package holding module-level state, imported by test
+// files through ESM. The hot runtime must hand every file a fresh instance
+// (tests-native/hot-isolation covers this in-repo; this copy proves it from a
+// packed install, where the ESM generation stamp actually applies to the package).
+const entries = [];
+exports.record = (value) => {
+  entries.push(value);
+};
+exports.count = () => entries.length;

--- a/packages/vitest-native/consumer-tests/current-rn/state-fixture/package.json
+++ b/packages/vitest-native/consumer-tests/current-rn/state-fixture/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "consumer-state-fixture",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.js"
+}

--- a/packages/vitest-native/consumer-tests/current-rn/vitest.config.mts
+++ b/packages/vitest-native/consumer-tests/current-rn/vitest.config.mts
@@ -5,5 +5,9 @@ export default defineConfig({
   plugins: [reactNative({ engine: "native", platform: "android" })],
   test: {
     environment: "node",
+    // The hot-* files assert hot-runtime invariants (generation stamps) that do
+    // not hold — by design — outside the hot runtime. They run via test:hot.
+    include: ["src/**/*.test.tsx"],
+    exclude: ["src/hot-*.test.tsx"],
   },
 });

--- a/packages/vitest-native/consumer-tests/current-rn/vitest.hot.config.mts
+++ b/packages/vitest-native/consumer-tests/current-rn/vitest.hot.config.mts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vitest/config";
+import { reactNative } from "vitest-native";
+
+// The hot runtime from a PACKED install. In the workspace, vitest-native and the
+// validation suites resolve outside node_modules, so the loader's generation stamp
+// (scoped to node_modules) can never touch the engine or Vitest's own runtime there
+// — the in-repo gates are structurally blind to a whole class of defect that only
+// exists once everything sits under node_modules. This config is the packed twin of
+// validate:hot-parity's premise: the same engine, loaded the way a consumer loads it.
+export default defineConfig({
+  plugins: [reactNative({ engine: "native", platform: "android", hotRuntime: true })],
+  test: {
+    environment: "node",
+    include: ["src/hot-*.test.tsx"],
+    // One worker, in order: hot-b must run AFTER hot-a in the SAME worker, or the
+    // cross-file reset assertion tests nothing (two workers each see a fresh
+    // instance trivially) and the generation the probe observes never advances.
+    fileParallelism: false,
+    maxWorkers: 1,
+  },
+});

--- a/packages/vitest-native/scripts/test-consumers.mjs
+++ b/packages/vitest-native/scripts/test-consumers.mjs
@@ -77,6 +77,28 @@ try {
     addPackedDependency(fixtureRoot, tarball);
     run("npm", ["install"], fixtureRoot);
     run("npm", ["test"], fixtureRoot);
+    // The hot runtime from the packed install. In-repo, the engine and the
+    // validation suites live OUTSIDE node_modules, so the hot loader's
+    // node_modules-scoped generation stamp can never touch the engine or Vitest's
+    // own runtime there — a twin-runtime defect (stamped @vitest/snapshot, stamped
+    // vi) passes every workspace gate and burns only real installs. This leg is the
+    // only gate that loads the hot runtime the way a consumer does.
+    if (fixture === "current-rn") {
+      // npm installs the fixture's local probe packages as SYMLINKS (and npm 11
+      // dropped install-links), whose real path sits outside node_modules — where
+      // the hot loader's node_modules-scoped generation stamp would (correctly)
+      // never apply. A registry install would copy them, so make it one: replace
+      // the links with real directories before the hot leg runs.
+      for (const [dir, name] of [
+        ["state-fixture", "consumer-state-fixture"],
+        ["runtime-probe", "runtime-probe"],
+      ]) {
+        const dest = path.join(fixtureRoot, "node_modules", name);
+        fs.rmSync(dest, { recursive: true, force: true });
+        fs.cpSync(path.join(fixtureRoot, dir), dest, { recursive: true });
+      }
+      run("npm", ["run", "test:hot"], fixtureRoot);
+    }
     // The monorepo fixture is also run from the WORKSPACE ROOT, pointing at the
     // app's config. That is how Nx invokes tasks, and Vitest's root follows the
     // working directory, so the run root ends up above the package under test.

--- a/packages/vitest-native/src/native/loader.mjs
+++ b/packages/vitest-native/src/native/loader.mjs
@@ -55,6 +55,42 @@ let presetExports = {};
 // Asset file extensions (without leading dot, lower-cased) the loader should stub.
 let assetExtSet = new Set();
 
+/**
+ * Hot-runtime ESM generation (experimental, `VITEST_NATIVE_HOT_ESM_GEN=1`).
+ *
+ * Node's ESM registry has no invalidation API, so a package a TEST FILE reaches
+ * through `import` keeps its module state for the whole run — the per-file reset
+ * can only clear the CommonJS cache. That is the hot runtime's one measured
+ * correctness hole at scale (see validation/idiomatic/scale, `extstore`).
+ *
+ * The registry is keyed by full URL, query included, so stamping a generation onto
+ * the URL makes the next file's import a different module and Node evaluates it
+ * again. The counter lives in a SharedArrayBuffer because loader hooks run on their
+ * own thread; the worker bumps it in the per-file reset.
+ *
+ * Cost is bounded by ownership: a CommonJS package re-enters through Module._cache,
+ * which the reset already drops, so only a thin namespace wrapper is retained per
+ * generation. A true-ESM package retains its whole instance — which is why this is
+ * measured before it is trusted.
+ */
+let genView = null;
+const generationOf = () => (genView ? Atomics.load(genView, 0) : 0);
+// Modules whose identity must be stable across files: dropping them makes a twin
+// rather than a fresh copy. Mirrors KEEP_RESIDENT in module-reset.mjs.
+const KEEP_RESIDENT =
+  /[\\/]node_modules[\\/](react|react-is|react-dom|scheduler|react-reconciler|react-test-renderer|test-renderer|@testing-library[\\/]react-native)[\\/]/;
+
+/** Should this resolved file carry a generation stamp? */
+function versionable(url) {
+  if (!genView || !url.startsWith("file:")) return false;
+  const norm = fileURLToPath(url).replace(/\\/g, "/");
+  if (!NODE_MODULES_PATH.test(norm)) return false;
+  // React Native itself is preloaded once per worker and shared deliberately —
+  // re-instantiating it per file would undo the reason the worker stays warm.
+  if (REACT_NATIVE_PATH.test(norm) || KEEP_RESIDENT.test(norm)) return false;
+  return true;
+}
+
 export async function initialize(data) {
   if (data && data.projectRoot) PROJECT_ROOT = data.projectRoot;
   if (data && data.platform === "android") PLATFORM = "android";
@@ -63,6 +99,7 @@ export async function initialize(data) {
   if (data && data.presetExports) presetExports = data.presetExports;
   if (data && data.assetExts)
     assetExtSet = new Set(data.assetExts.map((e) => String(e).replace(/^\./, "").toLowerCase()));
+  if (data && data.hotGenerationBuffer) genView = new Int32Array(data.hotGenerationBuffer);
 }
 
 export async function resolve(specifier, context, nextResolve) {
@@ -132,6 +169,16 @@ export async function resolve(specifier, context, nextResolve) {
       },
       shortCircuit: true,
     };
+  }
+
+  // Stamp the hot generation so the next test file re-evaluates this module rather
+  // than reusing the ESM registry's copy. `fileURLToPath` ignores the query, so
+  // `load` and every on-disk read below are unaffected.
+  if (versionable(resolved.url)) {
+    const gen = generationOf();
+    if (gen > 0 && !resolved.url.includes("vnhot=")) {
+      return { ...resolved, url: `${resolved.url}?vnhot=${gen}`, shortCircuit: true };
+    }
   }
   return resolved;
 }

--- a/packages/vitest-native/src/native/loader.mjs
+++ b/packages/vitest-native/src/native/loader.mjs
@@ -79,6 +79,22 @@ const generationOf = () => (genView ? Atomics.load(genView, 0) : 0);
 // rather than a fresh copy. Mirrors KEEP_RESIDENT in module-reset.mjs.
 const KEEP_RESIDENT =
   /[\\/]node_modules[\\/](react|react-is|react-dom|scheduler|react-reconciler|react-test-renderer|test-renderer|@testing-library[\\/]react-native)[\\/]/;
+// The test stack itself: Vitest's runtime, the chai it asserts through, and this
+// engine. The worker's runtime holds instances of these from boot — the runner's
+// SnapshotClient, chai's extended Assertion, the engine's registry and hooks — and a
+// test file reaches the SAME packages through Node's ESM path. Stamping those
+// resolutions hands the file a twin runtime: `toMatchSnapshot` then asks a
+// SnapshotClient no one set up, `vi.useFakeTimers` flips a copy of the timer state
+// the runner never reads, and matchers extend a chai the expect chain doesn't use.
+//
+// The workspace gates cannot catch a miss here: in-repo, this package and the
+// validation suites resolve OUTSIDE node_modules, so the NODE_MODULES_PATH guard
+// below exempts the engine by accident of layout. Only a packed install — the
+// bake-off apps — puts the whole test stack under node_modules where stamping can
+// reach it. That is how this list was earned: react-native-paper under the hot
+// runtime, 603/678 -> 473/648, every extra failure a twin-runtime symptom.
+const TEST_RUNTIME_RESIDENT =
+  /[\\/]node_modules[\\/](vitest|@vitest[\\/][^\\/]+|chai|vitest-native)[\\/]/;
 
 /** Should this resolved file carry a generation stamp? */
 function versionable(url) {
@@ -88,6 +104,7 @@ function versionable(url) {
   // React Native itself is preloaded once per worker and shared deliberately —
   // re-instantiating it per file would undo the reason the worker stays warm.
   if (REACT_NATIVE_PATH.test(norm) || KEEP_RESIDENT.test(norm)) return false;
+  if (TEST_RUNTIME_RESIDENT.test(norm)) return false;
   return true;
 }
 

--- a/packages/vitest-native/src/native/module-reset.mjs
+++ b/packages/vitest-native/src/native/module-reset.mjs
@@ -19,11 +19,16 @@ const UNRESETTABLE = /\.node$/;
  * rather than a fresh one.
  *
  * Test files reach these through ESM `import`, which caches them in Node's ESM
- * registry — and that registry has no invalidation API, so the copy a test holds
- * survives any reset. Dropping the CJS entry therefore does not replace the module;
- * it adds a twin, and the two halves of the test stack stop recognising each other.
- * The symptom is not an error about modules: it is RNTL's matchers failing to see
- * elements that a resident renderer produced.
+ * registry. Dropping the CJS entry therefore does not replace the module; it adds a
+ * twin, and the two halves of the test stack stop recognising each other. The symptom
+ * is not an error about modules: it is RNTL's matchers failing to see elements that a
+ * resident renderer produced.
+ *
+ * The ESM registry is not reachable from here — it has no invalidation API — but it
+ * IS keyed by full URL, and the engine owns the resolve hook, so the loader gives
+ * every other externalized package a per-file generation stamp instead (see
+ * `versionable` in loader.mjs). The entries below are exempt from that on purpose:
+ * for them a fresh instance is the bug, not the fix.
  *
  * Which entries carry weight depends on the RNTL version, so the list is bisected
  * rather than assumed. Measured one entry at a time:

--- a/packages/vitest-native/src/native/setup.mjs
+++ b/packages/vitest-native/src/native/setup.mjs
@@ -119,8 +119,28 @@ if (typeof globalThis.expect === "undefined") {
 // installRequireHooks are internally guarded the same way.)
 if (!globalThis.__vitest_native_loader_registered) {
   globalThis.__vitest_native_loader_registered = true;
+  // Hot ESM generation (see loader.mjs): closes the hot runtime's one measured
+  // correctness hole, where a package a test file `import`s keeps its module state
+  // for the whole run because Node's ESM registry cannot be invalidated. Only
+  // meaningful under the hot runtime — `__vitest_native_hot_reset` is installed by
+  // the hot worker before this setup file runs, and nothing bumps the counter
+  // otherwise. Shared rather than passed by value because loader hooks run on their
+  // own thread. Set VITEST_NATIVE_HOT_ESM_GEN=0 to opt out (and to mutation-test the
+  // isolation gate that covers this).
+  if (globalThis.__vitest_native_hot_reset && process.env.VITEST_NATIVE_HOT_ESM_GEN !== "0") {
+    globalThis.__vitest_native_hot_generation = new Int32Array(new SharedArrayBuffer(4));
+    globalThis.__vitest_native_hot_generation[0] = 1;
+  }
   register("./loader.mjs", import.meta.url, {
-    data: { projectRoot, platform, reactNativeVersion, transformPkgs, presetExports, assetExts },
+    data: {
+      projectRoot,
+      platform,
+      reactNativeVersion,
+      transformPkgs,
+      presetExports,
+      assetExts,
+      hotGenerationBuffer: globalThis.__vitest_native_hot_generation?.buffer,
+    },
   });
 }
 // Serve React Native from the precompiled registry when the plugin produced one

--- a/packages/vitest-native/src/native/worker.mjs
+++ b/packages/vitest-native/src/native/worker.mjs
@@ -107,6 +107,11 @@ const resetModules = captureModuleBaseline();
 const { hotReset, bless } = installHotReset({ projectRoot, diagnostics, preserveGlobals });
 globalThis.__vitest_native_hot_reset = () => {
   globalThis.__vitest_native_registry_reset?.();
+  // Advance the ESM generation so externalized packages a test file `import`s are
+  // re-evaluated instead of served from Node's uninvalidatable ESM registry.
+  if (globalThis.__vitest_native_hot_generation) {
+    Atomics.add(globalThis.__vitest_native_hot_generation, 0, 1);
+  }
   const dropped = resetModules();
   hotReset();
   if (diagnostics) console.log(`[vitest-native] hot reset: dropped ${dropped} modules`);

--- a/packages/vitest-native/src/plugin.ts
+++ b/packages/vitest-native/src/plugin.ts
@@ -901,6 +901,11 @@ export function reactNative(options?: VitestNativeOptions): Plugin {
       if (hotRuntime && hotRecycle.preserveGlobals?.length) {
         env.VITEST_NATIVE_HOT_PRESERVE_GLOBALS = JSON.stringify(hotRecycle.preserveGlobals);
       }
+      // Only the opt-out is passed: the setup file defaults this on under hot, so
+      // an absent variable means "on" and nothing has to be forwarded to say so.
+      if (hotRuntime && hotRecycle.esmGeneration === false) {
+        env.VITEST_NATIVE_HOT_ESM_GEN = "0";
+      }
 
       // Native engine: externalize RN so it loads through Node's single CJS graph,
       // where the native setup file's hooks Flow-strip it and mock the boundary.

--- a/packages/vitest-native/src/types.ts
+++ b/packages/vitest-native/src/types.ts
@@ -350,6 +350,15 @@ export interface VitestNativeOptions {
    * - `preserveGlobals`: exact globalThis property names intentionally owned
    *   by resident external libraries. App/test globals are otherwise removed
    *   between files. Storybook's preview registry is preserved automatically.
+   * - `esmGeneration`: re-evaluate externalized packages a test file `import`s,
+   *   so their module-level state does not carry into the next file. Node's ESM
+   *   registry cannot be invalidated, so the loader stamps a per-file generation
+   *   onto the resolved URL instead. On by default, because without it those
+   *   packages behave differently under hot than under stock isolation. It costs
+   *   re-execution: a suite whose files import many externalized (non-React
+   *   Native) packages measured 55% more wall clock at the extreme — still 9x
+   *   stock isolation, against 13.9x with it off. Set false to trade that back,
+   *   accepting that a package holding state across files will keep it.
    *
    * Default: false (each file runs in a fresh worker; RN reloads per file).
    */
@@ -359,6 +368,7 @@ export interface VitestNativeOptions {
         recycleAfterFiles?: number;
         memoryLimit?: number;
         preserveGlobals?: string[];
+        esmGeneration?: boolean;
       };
 }
 

--- a/packages/vitest-native/src/validate.ts
+++ b/packages/vitest-native/src/validate.ts
@@ -12,7 +12,12 @@ const KNOWN_OPTIONS = [
   "transform",
   "hotRuntime",
 ];
-const KNOWN_HOT_RUNTIME_OPTIONS = ["recycleAfterFiles", "memoryLimit", "preserveGlobals"];
+const KNOWN_HOT_RUNTIME_OPTIONS = [
+  "recycleAfterFiles",
+  "memoryLimit",
+  "preserveGlobals",
+  "esmGeneration",
+];
 
 function assertStringArray(value: unknown, option: string): asserts value is string[] {
   if (
@@ -139,6 +144,12 @@ export function validateOptions(options: Record<string, unknown>): void {
   }
   if (hotOptions.preserveGlobals !== undefined) {
     assertStringArray(hotOptions.preserveGlobals, "hotRuntime.preserveGlobals");
+  }
+  if (hotOptions.esmGeneration !== undefined && typeof hotOptions.esmGeneration !== "boolean") {
+    throw new VitestNativeTypeError(
+      "INVALID_OPTION",
+      `"hotRuntime.esmGeneration" must be a boolean.`,
+    );
   }
 }
 

--- a/packages/vitest-native/tests-native/hot-isolation/04-resident-a.test.ts
+++ b/packages/vitest-native/tests-native/hot-isolation/04-resident-a.test.ts
@@ -6,11 +6,11 @@ const req = createRequire(import.meta.url);
 // Order-independent: each file asserts the singleton is clean, then dirties it, so
 // whichever runs second fails if the previous file's state survived.
 //
-// Reached through `require` deliberately. A hot worker keeps Node's module caches
-// alive across files, and the per-file reset can only clear the CommonJS one —
-// Node's ESM registry has no invalidation API, so a package a test file `import`s
-// stays resident whatever we do. Packages the engine inlines are unaffected either
-// way: they live in Vitest's own graph, which is reset per file.
+// Reached through `require` deliberately, to cover the CommonJS cache specifically.
+// The ESM path is covered by its twin in 08/09 — it used to be the hole this pair
+// was written around, and is now closed by the loader's per-file generation stamp.
+// Packages the engine inlines are unaffected either way: they live in Vitest's own
+// graph, which is reset per file.
 it("sees a fresh resident singleton and then dirties it", () => {
   const singleton = req("resident-singleton");
   expect(singleton.count()).toBe(0);

--- a/packages/vitest-native/tests-native/hot-isolation/05-resident-b.test.ts
+++ b/packages/vitest-native/tests-native/hot-isolation/05-resident-b.test.ts
@@ -6,11 +6,11 @@ const req = createRequire(import.meta.url);
 // Order-independent: each file asserts the singleton is clean, then dirties it, so
 // whichever runs second fails if the previous file's state survived.
 //
-// Reached through `require` deliberately. A hot worker keeps Node's module caches
-// alive across files, and the per-file reset can only clear the CommonJS one —
-// Node's ESM registry has no invalidation API, so a package a test file `import`s
-// stays resident whatever we do. Packages the engine inlines are unaffected either
-// way: they live in Vitest's own graph, which is reset per file.
+// Reached through `require` deliberately, to cover the CommonJS cache specifically.
+// The ESM path is covered by its twin in 08/09 — it used to be the hole this pair
+// was written around, and is now closed by the loader's per-file generation stamp.
+// Packages the engine inlines are unaffected either way: they live in Vitest's own
+// graph, which is reset per file.
 it("sees a fresh resident singleton and then dirties it", () => {
   const singleton = req("resident-singleton");
   expect(singleton.count()).toBe(0);

--- a/packages/vitest-native/tests-native/hot-isolation/08-esm-resident-a.test.ts
+++ b/packages/vitest-native/tests-native/hot-isolation/08-esm-resident-a.test.ts
@@ -1,0 +1,21 @@
+import { expect, it } from "vitest";
+import { count, record } from "resident-singleton";
+
+// The ESM twin of 04/05, which reach the same package through `require`.
+//
+// That pair was written around a hole rather than through it: Node's ESM registry
+// has no invalidation API, so a package a test file `import`s used to keep its
+// module state for the whole run, and only the CommonJS path could be asserted.
+// The registry is keyed by full URL though, and the engine owns the resolve hook —
+// so the per-file reset now advances a generation that is stamped onto the URL, and
+// the next file gets a module Node has to evaluate again.
+//
+// Order-independent, like 04/05: each file asserts the singleton is clean and then
+// dirties it, so whichever runs second fails if the previous file's state survived.
+// Mutation-test with VITEST_NATIVE_HOT_ESM_GEN=0, which restores the old behaviour
+// and must turn this red.
+it("sees a fresh ESM-imported resident singleton and then dirties it", () => {
+  expect(count()).toBe(0);
+  record("a");
+  expect(count()).toBe(1);
+});

--- a/packages/vitest-native/tests-native/hot-isolation/09-esm-resident-b.test.ts
+++ b/packages/vitest-native/tests-native/hot-isolation/09-esm-resident-b.test.ts
@@ -1,0 +1,11 @@
+import { expect, it } from "vitest";
+import { count, record } from "resident-singleton";
+
+// Pair of 08 — see that file for why the ESM path needs its own probe and how to
+// mutation-test it. Order-independent: whichever of the two runs second fails if
+// the previous file's module state survived.
+it("sees a fresh ESM-imported resident singleton and then dirties it", () => {
+  expect(count()).toBe(0);
+  record("b");
+  expect(count()).toBe(1);
+});

--- a/packages/vitest-native/tests/validation.test.ts
+++ b/packages/vitest-native/tests/validation.test.ts
@@ -108,5 +108,13 @@ describe("option validation", () => {
     expect(() => reactNative({ hotRuntime: { unknown: true } } as any)).toThrow(
       /Unknown hotRuntime option/,
     );
+    expect(() => reactNative({ hotRuntime: { esmGeneration: "no" } } as any)).toThrow(
+      /esmGeneration.*boolean/,
+    );
+  });
+
+  it("accepts the esmGeneration opt-out", () => {
+    expect(() => reactNative({ hotRuntime: { esmGeneration: false } })).not.toThrow();
+    expect(() => reactNative({ hotRuntime: { esmGeneration: true } })).not.toThrow();
   });
 });

--- a/packages/vitest-native/validation/idiomatic/scale/generate.mjs
+++ b/packages/vitest-native/validation/idiomatic/scale/generate.mjs
@@ -139,6 +139,82 @@ test("store fresh ${n}", () => {
   expect(readTotal()).toBe(2);
 });`,
 
+  // Real React Navigation: container + native stack, navigating between screens.
+  // A navigation container holds state a component tree does not own, and the
+  // library is a node_modules package whose module scope the hot reset must clear.
+  // Until this template existed the whole shape was untested under hot — the scale
+  // suite had none, and the one navigation test in tests-native/ is EXCLUDED from
+  // the hot config.
+  navigation: (n) => `${head}
+import { Pressable, Text } from "react-native";
+import { NavigationContainer, useNavigation } from "@react-navigation/native";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+const Stack = createNativeStackNavigator();
+function Home() {
+  const nav = useNavigation();
+  return (<Pressable accessibilityRole="button" onPress={() => nav.navigate("Detail")}><Text>go${n}</Text></Pressable>);
+}
+function Detail() { return <Text testID="detail${n}">detail${n}</Text>; }
+test("navigation ${n}", async () => {
+  await render(
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={Home} />
+        <Stack.Screen name="Detail" component={Detail} />
+      </Stack.Navigator>
+    </NavigationContainer>,
+  );
+  expect(screen.getByText("go${n}")).toBeOnTheScreen();
+  await fireEvent.press(screen.getByText("go${n}"));
+  expect(screen.getByTestId("detail${n}")).toBeOnTheScreen();
+});`,
+
+  // Navigation wrapping a Modal — the exact pairing that failed in the field.
+  // Each of these alone renders; the report was of the two together, at scale.
+  navmodal: (n) => `${head}
+import { Modal, Pressable, Text, View } from "react-native";
+import { NavigationContainer, useNavigation } from "@react-navigation/native";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+const Stack = createNativeStackNavigator();
+function Screen1() {
+  const nav = useNavigation();
+  const [open, setOpen] = React.useState(true);
+  return (<View>
+    <Modal visible={open} transparent onRequestClose={() => setOpen(false)}>
+      <Pressable testID="close${n}" accessibilityRole="button" onPress={() => setOpen(false)} />
+      <Text testID="sheet${n}">sheet${n}</Text>
+    </Modal>
+    <Text testID="state${n}">{open ? "open" : "closed"}</Text>
+    <Text testID="route${n}">{nav.getState() ? "routed" : "none"}</Text>
+  </View>);
+}
+test("navmodal ${n}", async () => {
+  await render(
+    <NavigationContainer>
+      <Stack.Navigator><Stack.Screen name="S1" component={Screen1} /></Stack.Navigator>
+    </NavigationContainer>,
+  );
+  expect(screen.getByTestId("sheet${n}")).toBeOnTheScreen();
+  expect(screen.getByTestId("route${n}")).toHaveTextContent("routed");
+  await fireEvent.press(screen.getByTestId("close${n}"));
+  // Real RN keeps a hidden Modal's children mounted (only the host view flips
+  // \`visible\`), so the dismissal is asserted on state, not on absence — asserting
+  // \`queryByTestId(...)\` is null passes under Jest's Modal mock and fails here.
+  expect(screen.getByTestId("state${n}")).toHaveTextContent("closed");
+});`,
+
+  // A node_modules package holding module-level state, imported by a test file.
+  // The relative `store` template above is Vite-owned and reset by Vitest itself;
+  // this one is Node-owned and only the hot runtime's own reset can clear it — a
+  // distinct ownership path that the scale suite never exercised.
+  extstore: (n) => `${head}
+import { count, record } from "resident-singleton";
+test("external store fresh ${n}", () => {
+  expect(count()).toBe(0);
+  record("${n}");
+  expect(count()).toBe(1);
+});`,
+
   // DeviceEventEmitter subscriber with cleanup — feeds the accumulation checkers
   subscriber: (n) => `${head}
 import { DeviceEventEmitter, Text } from "react-native";


### PR DESCRIPTION
## The hole

The hot runtime keeps a worker alive across test files and clears what each file loaded, so the next one starts fresh. That reset could only reach Node's **CommonJS cache**. A package reached through ESM `import` is held by Node's **ESM registry**, which has no invalidation API — so its module-level state (a store, a client, a cache) survived the whole run, and the second test file to touch it saw the first one's writes.

This was known. `tests-native/hot-isolation/04`/`05` reach the fixture through `require` *deliberately*, and their comment said a package a test file imports "stays resident whatever we do". The gate documented the hole rather than covering it, and the scale validation had no case for it at all — which is why `validate:hot-parity` reported zero correctness delta while the shape was broken.

## The fix

The registry cannot be invalidated, but it **is keyed by full URL**, and the engine owns the resolve hook. The per-file reset now advances a generation counter that the loader stamps onto the resolved URL, so the next file imports a URL Node has not seen and evaluates the module again.

React Native itself and the identity-sensitive modules already listed in `KEEP_RESIDENT` are exempt — for those a fresh instance is the bug, not the fix. Cost is bounded by ownership: a CommonJS package re-enters through `Module._cache`, which the reset already drops, so only a namespace wrapper is retained per generation.

The counter lives in a `SharedArrayBuffer` because loader hooks run on their own thread. It is installed only by the hot worker, so **nothing changes when the hot runtime is off**.

## Measured

135-file scale suite, against the same suite under stock isolation:

| | before | after |
| --- | --- | --- |
| correctness | 126/135 | **135/135** |
| wall clock | 2.0s (9.6× stock) | **1.9s (9.9× stock)** |
| peak RSS | 956 MB | 1027 MB (**+7.4%**) |

`VITEST_NATIVE_HOT_ESM_GEN=0` restores the previous behaviour.

## Gates

- **New ESM twin** of the resident-singleton probe (`08`/`09`). Mutation-tested: green with the fix, and `VITEST_NATIVE_HOT_ESM_GEN=0` turns `09` red with `expected 1 to be +0`.
- **Scale validation gained the shapes it was missing**: real `@react-navigation` (container + native stack + navigate), a navigation container wrapping a `Modal`, and an externalized package holding module-level state. **Navigation had never run under the hot runtime in any gate** — `navigation-params.test.tsx` is explicitly excluded from the hot config.
- Corrected the docblocks in `module-reset.mjs` and `04`/`05` that asserted the ESM path was unfixable.

Navigation and Modal at scale turned out to be clean under hot both before and after — worth recording, since they were the suspected culprit.

Full sweep green: mock 1710, native 222, hot 222, hot-isolation 11, soak 100+12+8, navigation, forks 222, lint/format/typecheck.

## Note on the Modal template

Real RN keeps a hidden `Modal`'s children mounted (only the host view flips `visible`), so the template asserts dismissal on state rather than on absence. Asserting `queryByTestId(...)` is null passes under Jest's Modal mock and fails against real RN — a fidelity divergence worth knowing about.