### PR TITLE
fix(native): compile preset packages' pass-through entries Node cannot run

### DIFF
--- a/.changeset/preset-passthrough-transform.md
+++ b/.changeset/preset-passthrough-transform.md
@@ -1,0 +1,36 @@
+---
+"vitest-native": patch
+---
+
+Compile a preset-shadowed package's pass-through entries when Node cannot run them
+
+Preset packages are shadowed: their bare and subpath imports are redirected to the
+preset mock before any file loads. The deliberate exceptions — package.json
+subpaths, assets, and Node-safe utility entries such as `mock`, `plugin`, and
+`jest-utils` — pass through to the real file. Some of those files only Metro can
+run: react-native-worklets publishes its own mock entry (`lib/module/mock.js`) as
+ESM `import` statements over a `module.exports = …` footer. And because the preset
+shadow is exactly what keeps such packages out of ecosystem detection, nothing else
+would ever compile them. A suite that maps the package onto its published mock —
+react-native-paper does, via
+`vi.mock('react-native-worklets', () => require('react-native-worklets/lib/module/mock'))` —
+lost every test file whose component imports the package.
+
+Preset-shadowed package names now join the Node-side transform set, built in the
+worker from the same preset definitions that power the redirect, so user-supplied
+presets are covered alongside the auto-detected ones. Membership only makes a file
+eligible: `needsTransform` still gates every compile, so a pass-through Node can
+already run is served untouched. The hot runtime needed one more piece — its worker
+installs the require hooks at boot, before the setup file has built the preset
+mocks, and the install-once guard silently pinned that boot-time list; the guard
+now updates the transform matcher instead.
+
+What the served-as-published failure looks like depends on the Node version, and
+both shapes are cured: where Node lacks a `module` global the require(esm) retry
+throws "module is not defined in ES module scope", and on Node 24 — which defines
+`module` as a global — the file loads silently with EMPTY exports instead.
+
+The thrown shape also joins the explained-error family: the ReferenceError from a
+mixed ES-module/CommonJS file now gets the same actionable message as untranspiled
+JSX/Flow/TS SyntaxErrors — naming the owning package and the `transform: [...]`
+remedy — instead of a bare "module is not defined in ES module scope".

--- a/packages/vitest-native/src/native/explain.mjs
+++ b/packages/vitest-native/src/native/explain.mjs
@@ -44,21 +44,42 @@ export function decorateTransformError(err, file, platform) {
 const UNTRANSPILED_SYNTAX =
   /Unexpected token '?<'?|Unexpected identifier|Unexpected reserved word|Missing initializer in const|Unexpected token ':'/;
 
+// Node's ReferenceError when a MIXED-SYNTAX file runs: top-level `import` makes the
+// CJS parse fail, Node retries the file as an ES module (require(esm)), and the
+// CommonJS half then dereferences a wrapper variable that ESM scope never defines.
+// Metro compiles both halves, so packages ship this shape — react-native-worklets'
+// lib/module/mock.js ends in `module.exports = ...` under a header of `import`s.
+// It is the runtime sibling of the SyntaxError class above: same cause, same fix,
+// but it parses cleanly and so fails AFTER compilation, as a ReferenceError.
+const ESM_SCOPE_REFERENCE =
+  /\b(?:module|exports|require|__dirname|__filename) is not defined in ES module scope/;
+
 /**
- * When Node throws a SyntaxError compiling a node_modules file that vitest-native
- * did NOT transform, explain the (very common) real cause: the package ships
- * untranspiled JSX/Flow/TS and needs to be added to `transform: [...]`.
+ * When Node throws compiling or running a node_modules file that vitest-native did
+ * NOT transform, explain the (very common) real cause: the package ships source
+ * only Metro can run — untranspiled JSX/Flow/TS (a SyntaxError), or mixed
+ * ESM-import/CommonJS-exports (a ReferenceError from the require(esm) retry) —
+ * and needs to be added to `transform: [...]`.
  * Returns a decorated error, or null when the failure doesn't match the pattern.
  */
 export function explainUntransformedSyntaxError(err, file) {
-  if (!err || err.name !== "SyntaxError") return null;
-  if (!UNTRANSPILED_SYNTAX.test(String(err.message))) return null;
+  if (!err) return null;
+  const matches =
+    (err.name === "SyntaxError" && UNTRANSPILED_SYNTAX.test(String(err.message))) ||
+    (err.name === "ReferenceError" && ESM_SCOPE_REFERENCE.test(String(err.message)));
+  if (!matches) return null;
   const pkg = packageNameFromPath(file);
   if (!pkg) return null;
-  const wrapped = new SyntaxError(
+  const cause =
+    err.name === "ReferenceError"
+      ? `This usually means the package publishes mixed ES-module/CommonJS source ` +
+        `that only a bundler like Metro can run.`
+      : `This usually means the package publishes untranspiled JSX, Flow, or TypeScript.`;
+  const Ctor = err.name === "ReferenceError" ? ReferenceError : SyntaxError;
+  const wrapped = new Ctor(
     `[vitest-native] '${pkg}' shipped source Node can't run directly ` +
       `(${err.message} in ${file}).\n` +
-      `This usually means the package publishes untranspiled JSX, Flow, or TypeScript. ` +
+      `${cause} ` +
       `Ask vitest-native to transform it:\n\n` +
       `  reactNative({ transform: ['${pkg}'] })\n\n` +
       `in your vitest config. See https://github.com/danfry1/vitest-native` +

--- a/packages/vitest-native/src/native/hooks.mjs
+++ b/packages/vitest-native/src/native/hooks.mjs
@@ -163,7 +163,17 @@ export function installRequireHooks(
   reactNativeVersion = "0.0.0",
   assetExts = [],
 ) {
-  if (globalThis.__vitest_native_require_hooks_installed) return;
+  if (globalThis.__vitest_native_require_hooks_installed) {
+    // Install once per worker — but not with a frozen transform list. The hot
+    // worker installs the hooks at BOOT, before the setup file has built the
+    // preset mocks and can extend the list with preset-shadowed packages (their
+    // pass-through entries are compiled only if named here); a pure no-op would
+    // pin the boot-time env list forever, and the divergence is hot-only because
+    // under stock the setup file IS the first caller. Rebuild the matcher when
+    // a later caller brings a different list; hook layers are never stacked.
+    globalThis.__vitest_native_require_hooks_update?.(transformPkgs);
+    return;
+  }
   globalThis.__vitest_native_require_hooks_installed = true;
 
   // Asset requires (`require('./logo.png')`, `require('./Icon.ttf')`) reaching
@@ -186,7 +196,16 @@ export function installRequireHooks(
   }
 
   // Configured third-party packages to also transform (Flow/TS/JSX stripped).
-  const isExtra = buildPkgMatcher(transformPkgs, projectRoot);
+  // `let` + the updater below: the hot worker installs the hooks at boot with the
+  // raw env list, and the setup file re-calls with the preset-extended one.
+  let isExtra = buildPkgMatcher(transformPkgs, projectRoot);
+  let isExtraKey = JSON.stringify(transformPkgs);
+  globalThis.__vitest_native_require_hooks_update = (pkgs) => {
+    const key = JSON.stringify(pkgs);
+    if (key === isExtraKey) return;
+    isExtraKey = key;
+    isExtra = buildPkgMatcher(pkgs, projectRoot);
+  };
 
   // Preset redirect (CJS): when an externalized third-party module require()s a
   // preset package by its bare name (e.g. @gorhom/bottom-sheet → require(

--- a/packages/vitest-native/src/native/setup.mjs
+++ b/packages/vitest-native/src/native/setup.mjs
@@ -98,6 +98,21 @@ for (const name of presetNames) {
   }
 }
 
+// Preset-shadowed packages join the Node-side transform set. Their bare and
+// subpath imports are redirected to the preset mock before any file loads, so the
+// only real files reachable from them are the deliberately exempted pass-throughs
+// (package.json subpaths, assets, and Node-safe utility entries such as `mock`,
+// `plugin`, `jest-utils`). Some of those ship Metro-only source —
+// react-native-worklets' lib/module/mock.js mixes ESM `import` with
+// `module.exports`, which served as published throws "module is not defined in
+// ES module scope" or, on Node 24 (whose global `module` is the Module
+// constructor), loads SILENTLY with empty exports —
+// and the preset shadow is exactly what keeps such packages OUT of the detected
+// ecosystem list, so nothing else will ever compile them. Membership here only
+// makes their files eligible: needsTransform still gates every compile, so a
+// pass-through Node can already run is served untouched.
+const nodeTransformPkgs = [...new Set([...transformPkgs, ...Object.keys(presetExports)])];
+
 // Enable the V8 compile cache before RN is compiled (it loads when the test file
 // imports react-native, after this setup runs) so its bytecode is cached to disk
 // and reused on the next file/worker/run. Covers the stock (non-hot) path.
@@ -120,7 +135,14 @@ if (typeof globalThis.expect === "undefined") {
 if (!globalThis.__vitest_native_loader_registered) {
   globalThis.__vitest_native_loader_registered = true;
   register("./loader.mjs", import.meta.url, {
-    data: { projectRoot, platform, reactNativeVersion, transformPkgs, presetExports, assetExts },
+    data: {
+      projectRoot,
+      platform,
+      reactNativeVersion,
+      transformPkgs: nodeTransformPkgs,
+      presetExports,
+      assetExts,
+    },
   });
 }
 // Serve React Native from the precompiled registry when the plugin produced one
@@ -136,7 +158,7 @@ if (process.env.VITEST_NATIVE_RN_REGISTRY) {
     );
   }
 }
-installRequireHooks(projectRoot, transformPkgs, platform, reactNativeVersion, assetExts);
+installRequireHooks(projectRoot, nodeTransformPkgs, platform, reactNativeVersion, assetExts);
 
 // Build the mock objects now that the require hooks are installed (preset
 // factories may lazily resolve react-native at render time).

--- a/packages/vitest-native/tests-native/preset-subpath.test.tsx
+++ b/packages/vitest-native/tests-native/preset-subpath.test.tsx
@@ -37,13 +37,24 @@ describe("preset subpath imports under the native engine", () => {
     expect(viaSubpath.default).toBe(root.Swipeable);
   });
 
-  // NOTE: utility subpaths (jest-utils, jestSetup, mock, plugin) passing through
-  // to the real file is asserted at the resolution layer in
-  // tests/native-unit.test.ts. Asserting that the real third-party file then
-  // LOADS end-to-end would test the package's own Node compatibility (RNGH
-  // 3.0's ESM jest-utils graph fails to load on some environments) — that is
-  // not this project's contract, and pass-through was the pre-redirect status
-  // quo for these paths.
+  // Utility subpaths (jest-utils, jestSetup, mock, plugin) passing through to
+  // the real file is asserted at the resolution layer in
+  // tests/native-unit.test.ts. Loading them end-to-end IS this engine's
+  // contract, though — an earlier note here claimed it was "the package's own
+  // Node compatibility", but the preset shadow is exactly what keeps these
+  // packages out of ecosystem detection, so nothing else can ever compile a
+  // pass-through the package ships in Metro-only form. react-native-paper's
+  // suite requires worklets' published mock entry this way, and that file mixes
+  // ESM `import`s with `module.exports = …`: served as published it throws
+  // "module is not defined in ES module scope" where Node lacks the `module`
+  // global, and on Node 24 — which defines `module` as a global — it loads
+  // SILENTLY with empty exports instead.
+  it("compiles a preset package's Metro-only mock entry instead of serving it raw", () => {
+    const mod = require("react-native-worklets/lib/module/mock");
+    expect(typeof mod.scheduleOnUI).toBe("function");
+    expect(typeof mod.runOnJS).toBe("function");
+    expect(typeof mod.isWorkletFunction).toBe("function");
+  });
 
   it("CJS deep require yields the leaf with interop default, identity-stable", () => {
     const a = require("react-native-gesture-handler/Swipeable");

--- a/packages/vitest-native/tests/explain.test.ts
+++ b/packages/vitest-native/tests/explain.test.ts
@@ -65,4 +65,30 @@ describe("explainUntransformedSyntaxError", () => {
     const unrelated = new SyntaxError("Cannot use import statement outside a module");
     expect(explainUntransformedSyntaxError(unrelated, "/p/node_modules/a/x.js")).toBeNull();
   });
+
+  // The runtime sibling of the SyntaxError class: a mixed ESM-import/CommonJS-
+  // exports file parses cleanly as ESM, so Node's require(esm) retry runs it and
+  // the CJS half fails as a ReferenceError — where Node lacks a `module` global.
+  // (react-native-worklets' lib/module/mock.js is the reported shape, #163.)
+  it("suggests transform: ['pkg'] for the require(esm) mixed-syntax ReferenceError", () => {
+    const e = new ReferenceError("module is not defined in ES module scope");
+    const out = explainUntransformedSyntaxError(
+      e,
+      "/p/node_modules/react-native-worklets/lib/module/mock.js",
+    );
+    expect(out).not.toBeNull();
+    expect(out.message).toContain("transform: ['react-native-worklets']");
+    expect(out.message).toContain("mixed ES-module/CommonJS");
+    expect(out.name).toBe("ReferenceError");
+    expect(out.cause).toBe(e);
+  });
+
+  it("returns null for ReferenceErrors that are not the ES-module-scope family", () => {
+    expect(
+      explainUntransformedSyntaxError(
+        new ReferenceError("someGlobal is not defined"),
+        "/p/node_modules/a/x.js",
+      ),
+    ).toBeNull();
+  });
 });


### PR DESCRIPTION
Closes #163.

## Problem

Preset-shadowed packages are redirected to their mock before any file loads. The deliberate pass-throughs — `package.json` subpaths, assets, and Node-safe utility entries (`mock`, `plugin`, `jest-utils`, `jestSetup`) — serve the real file. Some of those files are Metro-only: `react-native-worklets/lib/module/mock.js` mixes ESM `import` statements with a `module.exports = …` footer. And because the preset shadow is exactly what keeps such packages out of ecosystem detection, nothing would ever compile them.

Served as published, the file throws `module is not defined in ES module scope` — or on Node 24, whose `module` global is the `Module` constructor, it loads **silently with empty exports**. react-native-paper's suite maps worklets onto that entry (`vi.mock('react-native-worklets', () => require('react-native-worklets/lib/module/mock'))`), losing every test file whose component imports the package.

## Change

- Preset package names join the Node-side transform set, computed in the worker from the same preset definitions that power the redirect — so user-supplied presets are covered alongside auto-detected ones. `needsTransform` still gates every compile; a pass-through Node can already run is served untouched.
- The require hooks' install-once guard now **updates** the transform matcher instead of pinning the first list. The hot worker installs the hooks at boot, before the setup file can extend the list — a hot-only divergence, since under stock the setup file is the first caller.
- The mixed-syntax ReferenceError joins the explained-error family (#143's sibling): it now names the owning package and the `transform: [...]` remedy instead of a bare `module is not defined in ES module scope`.

## Evidence

react-native-paper, packed install:

| leg | before | after |
| --- | --- | --- |
| stock | 625/678 | **662/715** |
| hot | 603/678 | **646/715** |

37 previously-uncollectable tests now run and pass; failure count is flat (53) under stock and drops 75 → 69 under hot. All in-repo gates green (mock 1712, native 223, hot 223, isolation, hot-parity 135/135).

Mutation-verified both ways: dropping the preset extension fails the new regression test under stock; no-oping the guard's update path fails it under hot while stock stays green — the exact boot-order asymmetry the guard fix addresses.

## Follow-up after merge

The external bake-off's recorded observation baselines (`bakeoffs-ratchet.json`) will report *changed* — totals moved from 678 to 715 — and should be re-recorded with `--update` once this (and #162, which also moves the hot count) land.