### PR TITLE
fix(native): match Metro's extension-major platform resolution order

### DIFF
--- a/.changeset/metro-extension-order.md
+++ b/.changeset/metro-extension-order.md
@@ -1,0 +1,27 @@
+---
+"vitest-native": patch
+---
+
+Match Metro's extension-major platform resolution order, verified against real metro-resolver
+
+Platform-file resolution interleaved its candidate extensions platform-major —
+every `.ios.*` variant before any `.native.*` before any bare extension. Metro
+resolves extension-major: for each source extension in order, it tries the
+platform variant, then `.native`, then bare (`.ios.js`, `.native.js`, `.js`,
+`.ios.jsx`, …). The difference selects different files when a module mixes
+platform variants across extensions: `Foo.native.js` beside `Foo.ios.tsx`
+resolves to `.native.js` under Metro — the `js` round finishes before `tsx` is
+tried — but resolved to `.ios.tsx` here, so a test could run a different file
+than the application ships. One shared list feeds both the Vite graph and the
+Node hooks, so the correction applies to both at once.
+
+The order had also been asserted by a unit test whose literals were written from
+the implementation — the gate encoded the mistake it existed to catch. The
+authority is now external: a differential oracle resolves a 160-case sweep of
+mixed platform/extension layouts (plus directory-index and per-extension cases)
+through real metro-resolver and through this package's resolver and requires
+byte-identical answers. The oracle runs against a pinned metro-resolver in the
+PR gate, and the weekly compatibility job bumps metro-resolver@latest alongside
+react-native@latest so upstream resolution changes surface as scheduled drift.
+Reverting the interleaving fails the oracle on the exact mixed-variant shapes
+described above.

--- a/.github/workflows/compat-check.yml
+++ b/.github/workflows/compat-check.yml
@@ -30,9 +30,13 @@ jobs:
       - name: Install with latest react-native
         # This scheduled edge job intentionally bypasses the seven-day adoption
         # gate. Blocking release tests remain pinned and deterministic.
+        # metro-resolver rides along: tests/metro-resolver-oracle.test.ts checks
+        # platform-file resolution against the real resolver, so this edge job
+        # doubles as the upstream-drift detector for Metro's resolution order
+        # while the PR gate stays pinned and deterministic.
         run: |
           bun install --frozen-lockfile
-          bun add -d react-native@latest @react-native/babel-preset@latest --minimum-release-age=0 --cwd packages/vitest-native
+          bun add -d react-native@latest @react-native/babel-preset@latest metro-resolver@latest --minimum-release-age=0 --cwd packages/vitest-native
 
       - name: Resolved versions
         run: |

--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,7 @@
     },
     "packages/vitest-native": {
       "name": "vitest-native",
-      "version": "0.10.0",
+      "version": "0.11.1",
       "bin": {
         "vitest-native": "./dist/cli.mjs",
       },
@@ -65,6 +65,7 @@
         "ext-platform-lib": "file:./tests-native/fixtures/ext-platform-lib",
         "ext-rn-named-lib": "file:./tests-native/fixtures/ext-rn-named-lib",
         "generic-mainfield-lib": "file:./tests-native/fixtures/generic-mainfield-lib",
+        "metro-resolver": "0.87.0",
         "react": "^19.2.8",
         "react-native": "^0.86.0",
         "react-native-gesture-handler": "3.1.0",
@@ -1242,7 +1243,7 @@
 
     "metro-minify-terser": ["metro-minify-terser@0.84.4", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "terser": "^5.15.0" } }, "sha512-5qpbaVOMC7CPitIpuewzVeGw7E+C3ykbv2mqTjQLl85Z3annSVGlSCTcsZjqXZzjupfK4Ztj3dDc4kc44NZwtQ=="],
 
-    "metro-resolver": ["metro-resolver@0.84.4", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-1qLgbxQ5ZGhhutuPot1Yp348ofDsATL2WkrHF65TobqTT9K3P9qJXw38bomk7ncp5B7OYMfWwtyBZo1lCV792A=="],
+    "metro-resolver": ["metro-resolver@0.87.0", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-Xl3M9R3KToaHJvXlI2lSOxtYHitzxite+195DSi00HL9PcS7Xik5+3xlRjfkKb3FA86SZxYPj+WJwlcfgaZoxg=="],
 
     "metro-runtime": ["metro-runtime@0.84.4", "", { "dependencies": { "@babel/runtime": "^7.25.0", "flow-enums-runtime": "^0.0.6" } }, "sha512-Jibypds4g7AhzdRKY+kDoj51s5EXMwgyp5ddtlreDAsWefMdOx+agWqgm0H2XSZ/ueanHHVM89fnf5OJnlxa8Q=="],
 
@@ -1762,6 +1763,8 @@
 
     "@expo/devcert/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
+    "@expo/metro/metro-resolver": ["metro-resolver@0.84.4", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-1qLgbxQ5ZGhhutuPot1Yp348ofDsATL2WkrHF65TobqTT9K3P9qJXw38bomk7ncp5B7OYMfWwtyBZo1lCV792A=="],
+
     "@expo/metro-config/hermes-parser": ["hermes-parser@0.33.3", "", { "dependencies": { "hermes-estree": "0.33.3" } }, "sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA=="],
 
     "@expo/metro-config/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
@@ -1860,7 +1863,11 @@
 
     "metro/hermes-parser": ["hermes-parser@0.35.0", "", { "dependencies": { "hermes-estree": "0.35.0" } }, "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA=="],
 
+    "metro/metro-resolver": ["metro-resolver@0.84.4", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-1qLgbxQ5ZGhhutuPot1Yp348ofDsATL2WkrHF65TobqTT9K3P9qJXw38bomk7ncp5B7OYMfWwtyBZo1lCV792A=="],
+
     "metro-babel-transformer/hermes-parser": ["hermes-parser@0.35.0", "", { "dependencies": { "hermes-estree": "0.35.0" } }, "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA=="],
+
+    "metro-core/metro-resolver": ["metro-resolver@0.84.4", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-1qLgbxQ5ZGhhutuPot1Yp348ofDsATL2WkrHF65TobqTT9K3P9qJXw38bomk7ncp5B7OYMfWwtyBZo1lCV792A=="],
 
     "metro-source-map/vlq": ["vlq@1.0.1", "", {}, "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w=="],
 

--- a/packages/vitest-native/package.json
+++ b/packages/vitest-native/package.json
@@ -151,6 +151,7 @@
     "ext-platform-lib": "file:./tests-native/fixtures/ext-platform-lib",
     "ext-rn-named-lib": "file:./tests-native/fixtures/ext-rn-named-lib",
     "generic-mainfield-lib": "file:./tests-native/fixtures/generic-mainfield-lib",
+    "metro-resolver": "0.87.0",
     "react": "^19.2.8",
     "react-native": "^0.86.0",
     "react-native-gesture-handler": "3.1.0",

--- a/packages/vitest-native/src/native/resolve.mjs
+++ b/packages/vitest-native/src/native/resolve.mjs
@@ -18,16 +18,26 @@ import path from "node:path";
 export const METRO_SOURCE_EXTS = ["js", "jsx", "json", "ts", "tsx"];
 
 /**
- * Metro tries every platform-suffixed variant first, then every `.native` one,
- * then the bare extensions — not extension-major.
+ * Extension-MAJOR, exactly as Metro resolves: for each source extension in order,
+ * try the platform variant, then `.native`, then bare — `.ios.js`, `.native.js`,
+ * `.js`, `.ios.jsx`, … (metro-resolver's `resolveSourceFile` loops `sourceExts`
+ * in the outer loop and the platform variants inside it).
+ *
+ * This order previously interleaved the other way — every `.ios.*` before any
+ * `.native.*` before any bare extension — and the difference is not stylistic:
+ * a module shipping `Foo.native.js` beside `Foo.ios.tsx` resolves to
+ * `.native.js` under Metro (the `js` round wins before `tsx` is ever tried) but
+ * resolved to `.ios.tsx` here, so the test ran a different file than the app
+ * ships. The order is asserted against real metro-resolver by
+ * tests/metro-resolver-oracle.test.ts, not just against these literals.
  */
 export function extensionsFor(platform) {
   const suffix = platform === "android" ? "android" : "ios";
-  return [
-    ...METRO_SOURCE_EXTS.map((e) => `.${suffix}.${e}`),
-    ...METRO_SOURCE_EXTS.map((e) => `.native.${e}`),
-    ...METRO_SOURCE_EXTS.map((e) => `.${e}`),
-  ];
+  const exts = [];
+  for (const e of METRO_SOURCE_EXTS) {
+    exts.push(`.${suffix}.${e}`, `.native.${e}`, `.${e}`);
+  }
+  return exts;
 }
 
 // Per-worker resolution cache: `${platform}\0${absBase}` → resolved path | null.

--- a/packages/vitest-native/tests/metro-resolver-oracle.test.ts
+++ b/packages/vitest-native/tests/metro-resolver-oracle.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Differential oracle: platform-file resolution is checked against REAL
+ * metro-resolver, not against this package's beliefs about it.
+ *
+ * Why an oracle and not literals: the extension-interleaving order was once
+ * wrong here — platform-major instead of Metro's extension-major — and the unit
+ * test asserting the order had been written FROM the implementation, so the gate
+ * encoded the mistake it existed to catch. Literals can restate a belief; only
+ * the external implementation can contradict one.
+ *
+ * The pinned devDependency version runs in the PR gate (this file). The weekly
+ * compat workflow bumps metro-resolver@latest alongside react-native@latest and
+ * re-runs this same file, so upstream resolution changes surface as scheduled
+ * drift without destabilizing PRs.
+ *
+ * Scope: extensionless relative specifiers (`./m`, `./dir`) — the surface
+ * resolvePlatformFile owns. Package/haste/asset/exports resolution is Node's or
+ * Vite's and is not decided by this list.
+ */
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createRequire } from "node:module";
+// @ts-expect-error — runtime .mjs
+import { resolvePlatformFile, METRO_SOURCE_EXTS } from "../src/native/resolve.mjs";
+
+const req = createRequire(import.meta.url);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const metro: any = req("metro-resolver");
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), "vn-metro-oracle-"));
+const origin = path.join(root, "origin.js");
+fs.writeFileSync(origin, "");
+
+/** Minimal metro-resolver context for relative source-file resolution. */
+function contextFor(originModulePath: string) {
+  return {
+    originModulePath,
+    sourceExts: [...METRO_SOURCE_EXTS],
+    preferNativePlatform: true,
+    mainFields: ["react-native", "main"],
+    nodeModulesPaths: [],
+    extraNodeModules: null,
+    allowHaste: false,
+    disableHierarchicalLookup: true,
+    doesFileExist: (f: string) => {
+      try {
+        return fs.statSync(f).isFile();
+      } catch {
+        return false;
+      }
+    },
+    fileSystemLookup: (f: string) => {
+      try {
+        const st = fs.statSync(f);
+        return { exists: true, type: st.isFile() ? "f" : "d", realPath: fs.realpathSync(f) };
+      } catch {
+        return { exists: false };
+      }
+    },
+    getPackage: (f: string) => {
+      try {
+        return JSON.parse(fs.readFileSync(f, "utf8"));
+      } catch {
+        return null;
+      }
+    },
+    getPackageForModule: () => null,
+    isAssetFile: () => false,
+    redirectModulePath: (p: string) => p,
+    resolveAsset: () => null,
+    resolveHasteModule: () => null,
+    resolveHastePackage: () => null,
+    unstable_conditionNames: [],
+    unstable_conditionsByPlatform: {},
+    unstable_enablePackageExports: false,
+    unstable_logWarning: () => {},
+    customResolverOptions: {},
+    assetExts: new Set<string>(),
+  };
+}
+
+function metroResolve(specifier: string, platform: "ios" | "android"): string | null {
+  try {
+    const r = metro.resolve(contextFor(origin), specifier, platform);
+    return r && r.type === "sourceFile" ? fs.realpathSync(r.filePath) : null;
+  } catch {
+    return null;
+  }
+}
+
+function ours(base: string, platform: "ios" | "android"): string | null {
+  const r = resolvePlatformFile(base, platform);
+  return r ? fs.realpathSync(r) : null;
+}
+
+let caseId = 0;
+/** Create `m<N>.<variant>` files for each [variantSuffix, ext] pair; return the base name. */
+function writeCase(files: Array<[string, string]>): string {
+  const name = `m${caseId++}`;
+  for (const [variant, ext] of files) {
+    const suffix = variant === "" ? `.${ext}` : `.${variant}.${ext}`;
+    fs.writeFileSync(path.join(root, name + suffix), "");
+  }
+  return name;
+}
+
+describe("platform resolution agrees with real metro-resolver", () => {
+  it("across a sweep of mixed platform/extension variant sets", () => {
+    // Every non-empty subset of variant kinds, each carrying either the first or
+    // the last source extension — the assignment that maximally separates
+    // extension-major from platform-major interleaving.
+    const kinds = ["ios", "android", "native", ""];
+    const exts = ["js", "tsx"];
+    const disagreements: string[] = [];
+    let cases = 0;
+    for (let mask = 1; mask < 1 << kinds.length; mask++) {
+      const chosen = kinds.filter((_, i) => mask & (1 << i));
+      const assignments: Array<Array<[string, string]>> = [[]];
+      for (const kind of chosen) {
+        const next: Array<Array<[string, string]>> = [];
+        for (const partial of assignments) {
+          for (const ext of exts) next.push([...partial, [kind, ext]]);
+        }
+        assignments.length = 0;
+        assignments.push(...next);
+      }
+      for (const files of assignments) {
+        const name = writeCase(files);
+        for (const platform of ["ios", "android"] as const) {
+          cases++;
+          const expected = metroResolve(`./${name}`, platform);
+          const actual = ours(path.join(root, name), platform);
+          if (expected !== actual) {
+            disagreements.push(
+              `${platform} ${JSON.stringify(files)} -> metro: ${expected}, ours: ${actual}`,
+            );
+          }
+        }
+      }
+    }
+    // 15 non-empty subsets of 4 kinds, 2^k extension assignments each = 80
+    // file layouts, × 2 platforms. Asserted exactly so a sweep-shrinking edit
+    // cannot silently reduce coverage.
+    expect(cases).toBe(160);
+    expect(disagreements).toEqual([]);
+  });
+
+  it("for the remaining source extensions (jsx, json, ts)", () => {
+    for (const ext of ["jsx", "json", "ts"]) {
+      const name = writeCase([
+        ["native", ext],
+        ["ios", "tsx"],
+        ["", "tsx"],
+      ]);
+      for (const platform of ["ios", "android"] as const) {
+        expect(ours(path.join(root, name), platform)).toBe(metroResolve(`./${name}`, platform));
+      }
+    }
+  });
+
+  it("for directory index resolution", () => {
+    const dir = path.join(root, "pkgdir");
+    fs.mkdirSync(dir);
+    fs.writeFileSync(path.join(dir, "index.native.js"), "");
+    fs.writeFileSync(path.join(dir, "index.ios.tsx"), "");
+    for (const platform of ["ios", "android"] as const) {
+      expect(ours(dir, platform)).toBe(metroResolve("./pkgdir", platform));
+    }
+  });
+});

--- a/packages/vitest-native/tests/native-unit.test.ts
+++ b/packages/vitest-native/tests/native-unit.test.ts
@@ -189,34 +189,65 @@ import { getPlatformExtensions } from "../src/resolve.js";
 describe("platform extension order", () => {
   // Metro's defaults, from metro-config/src/defaults/defaults.js:
   //   sourceExts = ["js", "jsx", "json", "ts", "tsx"]
-  // and its resolver tries every platform-suffixed variant, then every .native
-  // one, then the bare extensions. metro-config is not a dependency of this
-  // package, so the list is asserted literally rather than read back from it.
-  it("matches Metro's sourceExts, in Metro's order", () => {
+  // and metro-resolver's resolveSourceFile loops those in the OUTER loop, trying
+  // platform, .native, and bare variants inside each round — extension-major.
+  //
+  // An earlier version of this test asserted the platform-major interleaving AS
+  // Metro's order: the implementation's own mistake, written into the gate that
+  // existed to catch it. These literals are therefore no longer the authority —
+  // tests/metro-resolver-oracle.test.ts checks the resolver against a real pinned
+  // metro-resolver, so a wrong belief here fails there.
+  it("matches Metro's sourceExts, in Metro's order (extension-major)", () => {
     expect(extensionsFor("ios")).toEqual([
       ".ios.js",
-      ".ios.jsx",
-      ".ios.json",
-      ".ios.ts",
-      ".ios.tsx",
       ".native.js",
-      ".native.jsx",
-      ".native.json",
-      ".native.ts",
-      ".native.tsx",
       ".js",
+      ".ios.jsx",
+      ".native.jsx",
       ".jsx",
+      ".ios.json",
+      ".native.json",
       ".json",
+      ".ios.ts",
+      ".native.ts",
       ".ts",
+      ".ios.tsx",
+      ".native.tsx",
       ".tsx",
     ]);
-    expect(extensionsFor("android").slice(0, 5)).toEqual([
-      ".android.js",
-      ".android.jsx",
-      ".android.json",
-      ".android.ts",
-      ".android.tsx",
-    ]);
+    expect(extensionsFor("android").slice(0, 3)).toEqual([".android.js", ".native.js", ".js"]);
+  });
+
+  // The mixed-variant shapes where the two interleavings genuinely disagree —
+  // each of these resolved to the WRONG file before the ordering fix.
+  it("resolves mixed platform/extension variants exactly as Metro does", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "vn-resolve-order-"));
+    try {
+      // .native.js beats .ios.tsx: the js round completes before tsx is tried.
+      const a = path.join(dir, "a");
+      fs.writeFileSync(a + ".native.js", "");
+      fs.writeFileSync(a + ".ios.tsx", "");
+      expect(resolvePlatformFile(a, "ios")).toBe(a + ".native.js");
+      // Bare .js beats .native.tsx for the same reason.
+      const b = path.join(dir, "b");
+      fs.writeFileSync(b + ".js", "");
+      fs.writeFileSync(b + ".native.tsx", "");
+      expect(resolvePlatformFile(b, "ios")).toBe(b + ".js");
+      // Within one extension round, platform still beats .native beats bare.
+      const c = path.join(dir, "c");
+      fs.writeFileSync(c + ".android.js", "");
+      fs.writeFileSync(c + ".native.js", "");
+      fs.writeFileSync(c + ".js", "");
+      expect(resolvePlatformFile(c, "android")).toBe(c + ".android.js");
+      // A platform variant in a LATER extension round loses to an earlier round's
+      // .native — the shape most likely to ship a different file than the app.
+      const d = path.join(dir, "d");
+      fs.writeFileSync(d + ".android.tsx", "");
+      fs.writeFileSync(d + ".native.jsx", "");
+      expect(resolvePlatformFile(d, "android")).toBe(d + ".native.jsx");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("gives the Vite graph and the Node graph the same list", () => {


### PR DESCRIPTION
## Problem

Platform-file resolution interleaved candidate extensions **platform-major** — every `.ios.*` before any `.native.*` before any bare extension. Metro resolves **extension-major**: `resolveSourceFile` loops `sourceExts` in the outer loop and tries platform/`.native`/bare inside each round (`.ios.js`, `.native.js`, `.js`, `.ios.jsx`, …). The two orders pick different files when a module mixes platform variants across extensions: `Foo.native.js` beside `Foo.ios.tsx` ships `.native.js` under Metro but tested `.ios.tsx` here — the test runs a different file than the application.

A unit test asserted the wrong interleaving *as* Metro's order — its literals were written from the implementation, so the gate encoded the belief it existed to check.

## Change

- `extensionsFor()` now emits Metro's extension-major order. It is the single source for both the Vite graph's `resolve.extensions` and the Node hooks, so both correct together.
- New mixed-variant unit fixtures cover the shapes where the interleavings disagree.
- **Differential oracle** (`tests/metro-resolver-oracle.test.ts`): a 160-case sweep of mixed platform/extension layouts, plus directory-index and per-extension cases, resolved through real `metro-resolver` (pinned devDependency, runs in the PR gate) and through this package's resolver, requiring identical answers. The weekly compat workflow bumps `metro-resolver@latest` alongside `react-native@latest`, so upstream resolution drift surfaces on schedule without destabilizing PRs.

## Verification

- Mutation: restoring the platform-major interleaving fails the oracle with named divergences (`metro: …native.js, ours: …ios.tsx`) — the exact defect class.
- All suites green: mock 1714, native 222, hot 222, isolation, hot-parity zero-delta.
- External bake-off: react-native-paper stock 625/678 (= baseline), hot 607/678 (above 603 baseline); obytes 34/36 both modes. Neither app ships mixed-variant modules — which is why only an oracle, not the bake-off, can hold this line.