### PR TITLE
docs: correct the native engine's mock-boundary description

### DIFF
--- a/website/guide/comparison.md
+++ b/website/guide/comparison.md
@@ -18,7 +18,7 @@ The biggest misconception is that Jest "doesn't run real React Native." It does 
 - **Native modules** — `NativeModules`, `UIManager`, `NativeComponentRegistry`, `requireNativeComponent`, `InitializeCore`.
 - **A few APIs** — `useColorScheme`, `Vibration`, `Linking`, `AppState`, `Clipboard`.
 
-vitest-native's native engine mocks **only the native boundary** (the native-component registry + native modules) — everything else in RN, including the real `View`/`Text`/`ScrollView` component JS, runs for real. That's why a native-engine render produces real host names (`RCTView`, `RCTText`) where Jest's preset shows mock names (`View`, `Text`).
+vitest-native's native engine mocks **only the native boundary** (the native-component registry + native modules) — everything else in RN, including the real `View`/`Text`/`ScrollView` component JS, runs for real. That's why a native-engine render produces real host names (`RCTView`, `RCTText`) where Jest's preset shows mock names (`View`, `Text`). The one component-level exception on both sides is `TextInput`: like Jest's preset, the native engine substitutes a passthrough for it so `onChangeText` fires once per keystroke ([why](/guide/how-it-works#the-native-engine-specifically)).
 
 So the difference is **where the boundary sits**, not "real vs mocked." vitest-native's `native` engine sits lower, which means higher fidelity for component behavior, accessibility, and text nesting — at the cost of running more of RN's real code.
 

--- a/website/guide/how-it-works.md
+++ b/website/guide/how-it-works.md
@@ -29,7 +29,9 @@ You do **not** add anything to `setupFiles` yourself, and you do **not** manuall
 
 ## The native engine, specifically
 
-Under `engine: 'native'`, real React Native is externalized to Node and its Flow types are stripped through a require hook using your project's `@react-native/babel-preset` — the same toolchain RN already uses. Only the thin native boundary is mocked (`View`, `Text`, `UIManager`, `NativeModules`, and friends), exactly the modules `@react-native/jest-preset` mocks.
+Under `engine: 'native'`, real React Native is externalized to Node and its Flow types are stripped through a require hook using your project's `@react-native/babel-preset` — the same toolchain RN already uses. What's mocked is the layer *beneath* the components: native modules (`NativeModules`, `TurboModuleRegistry`, `UIManager`) and native-component **registration** (`NativeComponentRegistry`, `requireNativeComponent`). `View`, `Text`, `Pressable`, and the rest run their **real** component JavaScript against mock host components — this boundary sits *lower* than `@react-native/jest-preset`, which swaps whole components for passthrough mocks (see [where the boundary sits](/guide/comparison#where-the-mock-boundary-sits)).
+
+One deliberate component-level exception: `TextInput` is replaced with the same passthrough shape Jest's preset uses, because the real `TextInput`'s internal event wiring double-fires `onChangeText` under RNTL's `userEvent.type`. That substitution is verified against real RN by the differential cross-check.
 
 This is the same architecture as the original [`vitest-community/vitest-react-native`](https://github.com/vitest-community/vitest-react-native), rebuilt to track current Vitest and React Native.
 


### PR DESCRIPTION
`how-it-works.md` described the native engine as mocking "`View`, `Text`, `UIManager`, `NativeModules`, and friends, **exactly the modules `@react-native/jest-preset` mocks`**" — the opposite of the engine's actual boundary, and the precise misconception `comparison.md` exists to correct. The lower mock boundary (real component JS over mock host components) is the package's central fidelity claim, so the page contradicted the main differentiator.

The corrected text is derived from `boundary.mjs`'s actual `BOUNDARY_SOURCES` rather than from either page's prior wording: mocked are native modules (`NativeModules`, `TurboModuleRegistry`, `UIManager`) and native-component registration (`NativeComponentRegistry`, `requireNativeComponent`); component JavaScript runs for real. Both pages now also name the one deliberate component-level exception — `TextInput`, substituted with the same passthrough shape Jest's preset uses so `onChangeText` fires once per keystroke, verified by the differential cross-check.

`bun run build:website` passes (VitePress dead-link check included).