### PR TITLE
fix(native): scope the transformer toolchain per project root

### DIFF
--- a/.changeset/project-scoped-transformer.md
+++ b/.changeset/project-scoped-transformer.md
@@ -1,0 +1,22 @@
+---
+"vitest-native": patch
+---
+
+Scope the native transformer's toolchain to the project root instead of the process
+
+The transformer resolved its toolchain — `@react-native/babel-preset`,
+`@babel/core`, the flow-enums plugin, and the disk-cache directory — into module
+globals initialized by the first caller. `transformRN` accepts a project root per
+call, but a second root's calls silently reused the first root's resolved
+toolchain and cache. Registries for every project in a Vitest workspace are built
+in the one Vite main process, so two projects with different React Native or
+Babel versions could serve the first project's output to the second project's
+tests.
+
+Proven before fixing: a regression test gives two roots their own Babel preset
+whose plugin stamps a root-specific marker into every transformed file, and the
+second root's file came back carrying the first root's stamp. Toolchain state now
+lives in a per-root context — resolved requires, preset, lazily-loaded Babel,
+in-memory cache, and disk-cache directory each belong to one canonical (realpath)
+project root — and the same test asserts both call orders plus per-root cache
+directories.

--- a/packages/vitest-native/src/native/transform.mjs
+++ b/packages/vitest-native/src/native/transform.mjs
@@ -22,13 +22,39 @@ import vm from "node:vm";
 import { decorateTransformError } from "./explain.mjs";
 import { VitestNativeError } from "../errors.mjs";
 
-let _req;
-let _babel;
-let _preset;
-let _flowEnums;
-let _cacheDir;
-let _writeSeq = 0;
-const mem = new Map();
+// Toolchain state is scoped PER PROJECT ROOT, not per process. It used to be a
+// set of module globals initialized by the first caller — but registries for
+// every project in a Vitest workspace are built in the one Vite main process,
+// so the first project's resolved preset, @babel/core, and cache directory
+// silently served every other project. Proven by
+// tests/transform-project-scope.test.ts: a second root's file came back
+// stamped with the first root's Babel toolchain. Same first-caller-wins guard
+// family as the hot worker's require-hook install (see hooks.mjs).
+const contexts = new Map(); // canonical project root -> toolchain context
+
+// Memoized: transformRN runs per required file, and the realpath of a project
+// root cannot change within a process. Realpath (not just resolve) so a root
+// reached through a symlink — pnpm layouts, linked workspaces — shares one
+// context with its real directory instead of building a twin toolchain.
+const canonicalRoots = new Map();
+function canonicalRoot(projectRoot) {
+  const hit = canonicalRoots.get(projectRoot);
+  if (hit) return hit;
+  let root;
+  try {
+    root = fs.realpathSync(projectRoot);
+  } catch {
+    root = path.resolve(projectRoot);
+  }
+  canonicalRoots.set(projectRoot, root);
+  return root;
+}
+
+/** Any already-built context — for parse-only helpers with no root of their own. */
+function anyContext() {
+  for (const ctx of contexts.values()) return ctx;
+  return null;
+}
 // 4: Flow enums are now transformed ahead of the preset's strip-types pass, so cached
 // output from 3 is missing every `export enum` declaration. Neither the preset nor
 // Babel version changed, and those are the only other inputs to the directory name, so
@@ -58,16 +84,20 @@ export function cacheRootFor(projectRoot) {
   return dir;
 }
 
-function init(projectRoot) {
-  if (_cacheDir) return;
-  _req = createRequire(path.join(projectRoot, "package.json"));
+function ctxFor(projectRoot) {
+  const root = canonicalRoot(projectRoot);
+  const existing = contexts.get(root);
+  if (existing) return existing;
+  const req = createRequire(path.join(root, "package.json"));
+  let preset;
+  let flowEnums;
   let presetVersion;
   let babelVersion;
   try {
     // Resolve-only here (cheap); the actual require of @babel/core happens
     // lazily on the first cache miss.
-    _preset = _req.resolve("@react-native/babel-preset");
-    _req.resolve("@babel/core");
+    preset = req.resolve("@react-native/babel-preset");
+    req.resolve("@babel/core");
     // Flow enums must be transformed BEFORE @babel/plugin-transform-flow-strip-types
     // sees them, or the declaration is removed as if it were a type annotation. The
     // React Native preset carries both, but in separate `overrides` entries that Babel
@@ -80,16 +110,16 @@ function init(projectRoot) {
     // and the enum survives. Resolved from the preset, which depends on it, so no new
     // dependency is required.
     try {
-      _flowEnums = createRequire(_req.resolve("@react-native/babel-preset/package.json")).resolve(
+      flowEnums = createRequire(req.resolve("@react-native/babel-preset/package.json")).resolve(
         "babel-plugin-transform-flow-enums",
       );
     } catch {
       // A preset layout without it: fall back to the preset's own handling rather than
       // failing the run. Flow enums are rare and only two React Native files use them.
-      _flowEnums = null;
+      flowEnums = null;
     }
-    presetVersion = _req("@react-native/babel-preset/package.json").version;
-    babelVersion = _req("@babel/core/package.json").version;
+    presetVersion = req("@react-native/babel-preset/package.json").version;
+    babelVersion = req("@babel/core/package.json").version;
   } catch {
     throw new VitestNativeError(
       "ENGINE_REQUIRES_BABEL",
@@ -104,16 +134,19 @@ function init(projectRoot) {
   // output (e.g. _jsxFileName injection) under NODE_ENV=development than under
   // test/production.
   const babelEnv = process.env.BABEL_ENV || process.env.NODE_ENV || "none";
-  _cacheDir = path.join(
-    cacheRootFor(projectRoot),
+  const cacheDir = path.join(
+    cacheRootFor(root),
     `transform-${presetVersion}-b${babelVersion}-${babelEnv}-v${TRANSFORM_CACHE_VERSION}`,
   );
-  fs.mkdirSync(_cacheDir, { recursive: true });
+  fs.mkdirSync(cacheDir, { recursive: true });
+  const ctx = { req, preset, flowEnums, cacheDir, babel: null, mem: new Map(), writeSeq: 0 };
+  contexts.set(root, ctx);
+  return ctx;
 }
 
-/** The active transform disk-cache directory (resolved on first use). Test hook. */
-export function transformCacheDir() {
-  return _cacheDir ?? null;
+/** A project's transform disk-cache directory, once resolved. Test hook. */
+export function transformCacheDir(projectRoot) {
+  return contexts.get(canonicalRoot(projectRoot))?.cacheDir ?? null;
 }
 
 /** Returns true if the source contains RN Flow syntax that must be transformed. */
@@ -139,13 +172,15 @@ const IDENTIFIER = /^[A-Za-z_$][\w$]*$/;
  * someValue`), which leaves Node's own detection in charge — no worse than before.
  */
 export function cjsExportNames(code) {
-  if (!_babel) {
-    if (!_req) return [];
-    _babel = _req("@babel/core");
-  }
+  // Parse-only, so any project's @babel/core serves: the input is this module's
+  // own transformed output, and parsing is toolchain-neutral across the versions
+  // in play. Callers have no project root of their own to hand over.
+  const ctx = anyContext();
+  if (!ctx) return [];
+  if (!ctx.babel) ctx.babel = ctx.req("@babel/core");
   let ast;
   try {
-    ast = _babel.parseSync(code, { babelrc: false, configFile: false, sourceType: "script" });
+    ast = ctx.babel.parseSync(code, { babelrc: false, configFile: false, sourceType: "script" });
   } catch {
     return [];
   }
@@ -276,7 +311,7 @@ function moduleGoal(file) {
 
 /** Transform an RN source file to runnable CJS. Cached in-memory + on disk. */
 export function transformRN(file, src, projectRoot, platform = "ios") {
-  init(projectRoot);
+  const ctx = ctxFor(projectRoot);
   // The in-memory key uses mtime+size (one statSync) so the hot path skips
   // hashing; the DISK key hashes the actual content, so entries stay valid
   // across fresh installs, Docker mtime normalization, and CI cache restores —
@@ -286,7 +321,7 @@ export function transformRN(file, src, projectRoot, platform = "ios") {
   // identical sources at different paths must not share an entry.
   const st = fs.statSync(file);
   const memKey = `${platform}\0${file}\0${st.mtimeMs}\0${st.size}`;
-  const memHit = mem.get(memKey);
+  const memHit = ctx.mem.get(memKey);
   if (memHit !== undefined) return memHit;
 
   const key = crypto
@@ -297,20 +332,20 @@ export function transformRN(file, src, projectRoot, platform = "ios") {
     .update("\0")
     .update(src)
     .digest("hex");
-  const cachePath = path.join(_cacheDir, key + ".js");
+  const cachePath = path.join(ctx.cacheDir, key + ".js");
   try {
     const cached = fs.readFileSync(cachePath, "utf8");
-    mem.set(memKey, cached);
+    ctx.mem.set(memKey, cached);
     return cached;
   } catch {}
 
-  if (!_babel) _babel = _req("@babel/core");
+  if (!ctx.babel) ctx.babel = ctx.req("@babel/core");
   let out;
   try {
-    out = _babel.transformSync(src, {
+    out = ctx.babel.transformSync(src, {
       filename: file,
-      plugins: _flowEnums ? [_flowEnums] : [],
-      presets: [[_preset, { disableStaticViewConfigsCodegen: true }]],
+      plugins: ctx.flowEnums ? [ctx.flowEnums] : [],
+      presets: [[ctx.preset, { disableStaticViewConfigsCodegen: true }]],
       babelrc: false,
       configFile: false,
       caller: { name: "metro", bundler: "metro", platform, supportsStaticESM: false },
@@ -324,7 +359,7 @@ export function transformRN(file, src, projectRoot, platform = "ios") {
   // Atomic write: multiple worker threads may transform the same RN file
   // concurrently on a cold cache. Write to a unique temp file then rename
   // (atomic on POSIX same-dir) so a concurrent reader never sees a partial file.
-  const tmp = `${cachePath}.${process.pid}.${_writeSeq++}.tmp`;
+  const tmp = `${cachePath}.${process.pid}.${ctx.writeSeq++}.tmp`;
   try {
     fs.writeFileSync(tmp, out);
     fs.renameSync(tmp, cachePath);
@@ -333,6 +368,6 @@ export function transformRN(file, src, projectRoot, platform = "ios") {
       fs.rmSync(tmp, { force: true });
     } catch {}
   }
-  mem.set(memKey, out);
+  ctx.mem.set(memKey, out);
   return out;
 }

--- a/packages/vitest-native/tests/transform-cache.test.ts
+++ b/packages/vitest-native/tests/transform-cache.test.ts
@@ -71,7 +71,7 @@ describe("transform disk cache", () => {
       const fileA = path.join(dir, "a.js");
       fs.writeFileSync(fileA, src);
       transformRN(fileA, src, projectRoot);
-      const cacheDir = transformCacheDir();
+      const cacheDir = transformCacheDir(projectRoot);
       expect(cacheDir).toBeTruthy();
       const entryA = path.join(cacheDir, diskKeyFor("ios", fileA, src) + ".js");
       expect(fs.existsSync(entryA)).toBe(true);

--- a/packages/vitest-native/tests/transform-project-scope.test.ts
+++ b/packages/vitest-native/tests/transform-project-scope.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Discriminating experiment for project-scoped transformer state.
+ *
+ * The transformer once initialized module-scope globals (`_req`, `_preset`,
+ * `_cacheDir`, the in-memory cache) exactly once per process — first caller
+ * wins. `transformRN(file, src, projectRoot)` accepts a root PER CALL, but a
+ * second project's calls silently reused the first project's resolved
+ * toolchain and cache directory. In a Vitest workspace, registries for every
+ * project are built in the one Vite main process, so two projects with
+ * different React Native or Babel versions could ship the first project's
+ * output to the second project's tests.
+ *
+ * The probe makes the toolchains DISTINGUISHABLE at runtime: each tmp project
+ * root carries its own stub `@react-native/babel-preset` whose plugin stamps a
+ * root-specific marker into every transformed file. If project Y's file comes
+ * back stamped with X's marker, the toolchain was pinned. Both directions are
+ * asserted, so the test is order-independent evidence.
+ */
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createRequire } from "node:module";
+// @ts-expect-error — runtime .mjs
+import { transformRN, transformCacheDir } from "../src/native/transform.mjs";
+
+const req = createRequire(import.meta.url);
+
+/** A stub preset whose plugin appends `var __VN_TOOLCHAIN = "<marker>";`. */
+function presetSource(marker: string): string {
+  return `
+module.exports = () => ({
+  plugins: [
+    {
+      visitor: {
+        Program: {
+          exit(programPath) {
+            programPath.pushContainer("body", {
+              type: "VariableDeclaration",
+              kind: "var",
+              declarations: [
+                {
+                  type: "VariableDeclarator",
+                  id: { type: "Identifier", name: "__VN_TOOLCHAIN" },
+                  init: { type: "StringLiteral", value: ${JSON.stringify(marker)} },
+                },
+              ],
+            });
+          },
+        },
+      },
+    },
+  ],
+});
+`;
+}
+
+/** A project root with its own marker preset and a link to the real @babel/core. */
+function makeRoot(marker: string): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), `vn-proj-${marker}-`));
+  fs.writeFileSync(
+    path.join(root, "package.json"),
+    JSON.stringify({ name: `proj-${marker}`, private: true }),
+  );
+  const presetDir = path.join(root, "node_modules", "@react-native", "babel-preset");
+  fs.mkdirSync(presetDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(presetDir, "package.json"),
+    JSON.stringify({
+      name: "@react-native/babel-preset",
+      // Distinct versions keep the two roots' disk caches in distinct
+      // directories even if they ever shared a cache root.
+      version: `0.0.1-${marker}`,
+      main: "index.js",
+    }),
+  );
+  fs.writeFileSync(path.join(presetDir, "index.js"), presetSource(marker));
+  // The real @babel/core, reached through a symlink: Node resolves its own
+  // dependencies from its REAL path, so the workspace install keeps working.
+  const babelScope = path.join(root, "node_modules", "@babel");
+  fs.mkdirSync(babelScope, { recursive: true });
+  fs.symlinkSync(
+    path.dirname(fs.realpathSync(req.resolve("@babel/core/package.json"))),
+    path.join(babelScope, "core"),
+    "dir",
+  );
+  return root;
+}
+
+describe("transformer state is scoped per project root", () => {
+  it("two roots keep their own toolchains and cache directories, both orders", () => {
+    const rootX = makeRoot("X");
+    const rootY = makeRoot("Y");
+    try {
+      const fileX = path.join(rootX, "moduleX.js");
+      const fileY = path.join(rootY, "moduleY.js");
+      fs.writeFileSync(fileX, "export const a = 1;\n");
+      fs.writeFileSync(fileY, "export const a = 1;\n");
+
+      // X first, then Y: under first-caller-wins, Y's output carried X's stamp.
+      const outX = transformRN(fileX, fs.readFileSync(fileX, "utf8"), rootX);
+      const outY = transformRN(fileY, fs.readFileSync(fileY, "utf8"), rootY);
+      expect(outX).toContain('__VN_TOOLCHAIN = "X"');
+      expect(outY).toContain('__VN_TOOLCHAIN = "Y"');
+
+      // And X again AFTER Y, so neither ordering can mask a pinned toolchain.
+      const outX2 = transformRN(fileX, fs.readFileSync(fileX, "utf8"), rootX);
+      expect(outX2).toContain('__VN_TOOLCHAIN = "X"');
+
+      // Each project's disk cache lives under its own root — output produced
+      // for one project must not populate (or be served from) another's cache.
+      const dirX = transformCacheDir(rootX);
+      const dirY = transformCacheDir(rootY);
+      expect(dirX).toContain(rootX);
+      expect(dirY).toContain(rootY);
+      expect(dirX).not.toBe(dirY);
+    } finally {
+      fs.rmSync(rootX, { recursive: true, force: true });
+      fs.rmSync(rootY, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Problem

The native transformer resolved its toolchain — `@react-native/babel-preset`, `@babel/core`, the flow-enums plugin, and the disk-cache directory — into module globals initialized by the **first caller** (`init()` early-returned once `_cacheDir` was set). `transformRN(file, src, projectRoot)` accepts a root per call, but a second root's calls silently reused the first root's toolchain and cache. Registries for every project in a Vitest workspace are built in the one Vite main process, so two projects with different React Native or Babel versions could serve the first project's output to the second project's tests.

## Proof before fix

`tests/transform-project-scope.test.ts` gives two tmp roots their own `@react-native/babel-preset` stub whose plugin stamps a root-specific marker into every transformed file. Against the unfixed code, the second root's file came back stamped with the **first** root's marker:

```
AssertionError: expected 'export const a = 1;\nvar __VN_TOOLCHA…' to contain '__VN_TOOLCHAIN = "Y"'
+ var __VN_TOOLCHAIN = "X";
```

## Change

Toolchain state lives in a per-root context — resolved requires, preset path, lazily-loaded Babel, in-memory cache, write sequence, and disk-cache directory — keyed by the root's **realpath** (memoized), so a symlinked root (pnpm layouts, linked workspaces) shares one context with its real directory instead of building a twin. The regression test asserts both call orders plus per-root cache directories. `transformCacheDir()` now takes the root it reports on. `cjsExportNames` (parse-only, no root of its own) uses any built context, preserving its prior semantics.

## Guard audit (same first-caller-wins family — this is its second confirmed defect)

- `enableV8CompileCache`: pins only the cache *directory* to the first root — pollution, not correctness (V8 CRC-validates entries). Left as-is.
- `installRegistry`, the reanimated preset's `react-native` require, and the ESM loader registration capture per-project state **per worker** — correct unless Vitest ever reuses one worker process across projects. Deliberately not changed blind; a dedicated two-project workspace experiment is the follow-up.

## Verification

All suites green (mock 1711, native 222, hot 222, isolation, hot-parity zero-delta); react-native-paper bake-off unchanged (stock 625/678 = baseline, hot 607/678 above baseline).