### PR TITLE
fix(native): require react-native itself in engine auto-detection

### DIFF
--- a/.changeset/native-detect-requires-rn.md
+++ b/.changeset/native-detect-requires-rn.md
@@ -1,0 +1,17 @@
+---
+"vitest-native": patch
+---
+
+Engine auto-detection requires react-native itself, not just its Babel toolchain
+
+`engine: 'auto'` chose the native engine whenever `@react-native/babel-preset`
+and `@babel/core` resolved — react-native itself was never checked, so an
+incomplete install (or a babel-only workspace) selected native mode and then
+failed later at React Native resolution with nothing pointing at the cause.
+
+Detection now requires all three. The check resolves rather than reads
+declarations — everything is located by walking node_modules upward from the
+project root, so a hoisted workspace install or Expo's transitive react-native
+counts without appearing in the project's own manifest. The fallback notice and
+the explicit-`engine: 'native'` configuration error both name exactly which
+dependencies did not resolve.

--- a/packages/vitest-native/src/native/detect.ts
+++ b/packages/vitest-native/src/native/detect.ts
@@ -1,5 +1,6 @@
 import { createRequire } from "node:module";
 import path from "node:path";
+import fs from "node:fs";
 
 export type RequestedEngine = "auto" | "mock" | "native";
 export type ResolvedEngine = "mock" | "native";
@@ -15,21 +16,52 @@ export const AUTO_PREFERS_NATIVE = true;
 
 export interface EngineDecision {
   engine: ResolvedEngine;
-  /** True when @react-native/babel-preset + @babel/core resolve from projectRoot. */
+  /** True when react-native + @react-native/babel-preset + @babel/core resolve from projectRoot. */
   nativeAvailable: boolean;
+  /** The native-engine dependencies that did NOT resolve, in check order. */
+  missing: string[];
   /** One concise line to print once, or null for silence. */
   notice: string | null;
 }
 
-/** Can this project run the native engine? (Both transform deps resolvable.) */
-function isNativeCapable(projectRoot: string): boolean {
-  try {
-    const req = createRequire(path.join(projectRoot, "package.json"));
-    req.resolve("@react-native/babel-preset");
-    req.resolve("@babel/core");
-    return true;
-  } catch {
-    return false;
+/**
+ * The native engine's dependencies that do NOT resolve from the project root.
+ *
+ * react-native itself is part of the check: the Babel toolchain alone chose
+ * native mode in a project with the preset installed but no react-native — an
+ * incomplete install, a babel-only workspace — which then failed later at RN
+ * resolution with nothing pointing at the cause. Resolution, not declaration:
+ * every check walks node_modules upward from the root — so a hoisted workspace
+ * install or Expo's transitive react-native counts, and a project does not need
+ * react-native in its own manifest.
+ */
+function missingNativeDeps(projectRoot: string): string[] {
+  const req = createRequire(path.join(projectRoot, "package.json"));
+  const missing: string[] = [];
+  // react-native is located by walking node_modules up from the root — the same
+  // places require() would look — rather than through the require machinery,
+  // which this package's own engines intercept for the react-native specifier
+  // (the mock engine's CJS bridge answers `req.resolve("react-native")` from ANY
+  // root, which would make this check unconditionally true under it).
+  if (!reactNativeInstalledNear(projectRoot)) missing.push("react-native");
+  for (const dep of ["@react-native/babel-preset", "@babel/core"]) {
+    try {
+      req.resolve(dep);
+    } catch {
+      missing.push(dep);
+    }
+  }
+  return missing;
+}
+
+/** Does node_modules/react-native exist in projectRoot or any ancestor? */
+function reactNativeInstalledNear(projectRoot: string): boolean {
+  let dir = path.resolve(projectRoot);
+  for (;;) {
+    if (fs.existsSync(path.join(dir, "node_modules", "react-native", "package.json"))) return true;
+    const parent = path.dirname(dir);
+    if (parent === dir) return false;
+    dir = parent;
   }
 }
 
@@ -39,28 +71,31 @@ export function detectEngine(
   projectRoot: string,
   opts?: { autoPrefersNative?: boolean },
 ): EngineDecision {
-  const nativeAvailable = isNativeCapable(projectRoot);
+  const missing = missingNativeDeps(projectRoot);
+  const nativeAvailable = missing.length === 0;
 
-  if (requested === "native") return { engine: "native", nativeAvailable, notice: null };
-  if (requested === "mock") return { engine: "mock", nativeAvailable, notice: null };
+  if (requested === "native") return { engine: "native", nativeAvailable, missing, notice: null };
+  if (requested === "mock") return { engine: "mock", nativeAvailable, missing, notice: null };
 
   // requested === "auto"
   const prefersNative = opts?.autoPrefersNative ?? AUTO_PREFERS_NATIVE;
   if (prefersNative && nativeAvailable) {
     // The happy path (real RN, deps present) is silent — elegance is no chatter.
-    return { engine: "native", nativeAvailable, notice: null };
+    return { engine: "native", nativeAvailable, missing, notice: null };
   }
   if (prefersNative) {
     // Wanted native but can't: explain the fallback so the mock engine is never
-    // a silent surprise. (Silent when the user explicitly asked for mock above.)
+    // a silent surprise, naming exactly what did not resolve. (Silent when the
+    // user explicitly asked for mock above.)
     return {
       engine: "mock",
       nativeAvailable: false,
+      missing,
       notice:
-        "[vitest-native] @react-native/babel-preset not found — using the mock engine. " +
-        "Install it (and @babel/core) to run real React Native, or set engine:'mock' to silence this.",
+        `[vitest-native] ${missing.join(", ")} not found — using the mock engine. ` +
+        "Install what's missing to run real React Native, or set engine:'mock' to silence this.",
     };
   }
   // autoPrefersNative explicitly disabled → mock, no notice.
-  return { engine: "mock", nativeAvailable, notice: null };
+  return { engine: "mock", nativeAvailable, missing, notice: null };
 }

--- a/packages/vitest-native/src/plugin.ts
+++ b/packages/vitest-native/src/plugin.ts
@@ -874,9 +874,9 @@ export function reactNative(options?: VitestNativeOptions): Plugin {
           `engine:'native' requires react-native, '@react-native/babel-preset', and ` +
             `'@babel/core' to resolve from ${resolvedRoot} — missing: ` +
             `${decision.missing.join(", ")}. React Native projects ship all three ` +
-            `by default:\n\n` +
-            `  npm install -D ${decision.missing.join(" ")}\n\n` +
-            `Or set engine:'mock' to run without a React Native install.`,
+            `by default. Install what's missing (react-native as a dependency, the ` +
+            `toolchain as devDependencies), or set engine:'mock' to run without a ` +
+            `React Native install.`,
         );
       }
       // The fallback notice is a warning — a team that believes it is testing real

--- a/packages/vitest-native/src/plugin.ts
+++ b/packages/vitest-native/src/plugin.ts
@@ -871,10 +871,11 @@ export function reactNative(options?: VitestNativeOptions): Plugin {
       if (engine === "native" && !decision.nativeAvailable) {
         throw new VitestNativeError(
           "ENGINE_REQUIRES_BABEL",
-          `engine:'native' requires '@react-native/babel-preset' and ` +
-            `'@babel/core' to resolve from ${resolvedRoot}. Install them as ` +
-            `devDependencies (React Native projects ship them by default):\n\n` +
-            `  npm install -D @react-native/babel-preset @babel/core\n\n` +
+          `engine:'native' requires react-native, '@react-native/babel-preset', and ` +
+            `'@babel/core' to resolve from ${resolvedRoot} — missing: ` +
+            `${decision.missing.join(", ")}. React Native projects ship all three ` +
+            `by default:\n\n` +
+            `  npm install -D ${decision.missing.join(" ")}\n\n` +
             `Or set engine:'mock' to run without a React Native install.`,
         );
       }

--- a/packages/vitest-native/tests/detect.test.ts
+++ b/packages/vitest-native/tests/detect.test.ts
@@ -49,7 +49,36 @@ describe("detectEngine", () => {
     const d = detectEngine("auto", emptyRoot);
     expect(d.engine).toBe("mock");
     expect(d.nativeAvailable).toBe(false);
-    expect(d.notice).toContain("@react-native/babel-preset not found");
+    expect(d.notice).toContain("react-native, @react-native/babel-preset, @babel/core not found");
+  });
+
+  it("auto falls back to mock when the Babel toolchain resolves but react-native does not", () => {
+    // The shape that used to choose native and explode later at RN resolution:
+    // a root where the preset and @babel/core resolve (stubs suffice — detection
+    // only resolves, never loads) but react-native itself is absent.
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "vn-detect-babelonly-"));
+    try {
+      fs.writeFileSync(
+        path.join(root, "package.json"),
+        JSON.stringify({ name: "b", private: true }),
+      );
+      for (const pkg of ["@react-native/babel-preset", "@babel/core"]) {
+        const dir = path.join(root, "node_modules", ...pkg.split("/"));
+        fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(
+          path.join(dir, "package.json"),
+          JSON.stringify({ name: pkg, version: "0.0.1", main: "index.js" }),
+        );
+        fs.writeFileSync(path.join(dir, "index.js"), "module.exports = {};");
+      }
+      const d = detectEngine("auto", root);
+      expect(d.engine).toBe("mock");
+      expect(d.nativeAvailable).toBe(false);
+      expect(d.notice).toContain("react-native not found");
+      expect(d.notice).not.toContain("@babel/core not found");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("autoPrefersNative:false override resolves auto to mock with no notice", () => {

--- a/packages/vitest-native/tests/native-unit.test.ts
+++ b/packages/vitest-native/tests/native-unit.test.ts
@@ -630,7 +630,7 @@ describe("engine-selection notices", () => {
       );
       const plugin = reactNative({ engine: "native" }) as any;
       await expect(plugin.config({ root: tmp }, SERVE_ENV)).rejects.toThrow(
-        /@react-native\/babel-preset.*npm install -D/s,
+        /missing: react-native, @react-native\/babel-preset, @babel\/core/s,
       );
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });

--- a/packages/vitest-native/tests/native-unit.test.ts
+++ b/packages/vitest-native/tests/native-unit.test.ts
@@ -609,7 +609,7 @@ describe("engine-selection notices", () => {
       const plugin = reactNative({}) as any;
       await plugin.config({ root: tmp }, SERVE_ENV);
       const notices = warn.mock.calls.filter((c) =>
-        String(c[0]).includes("@react-native/babel-preset not found"),
+        String(c[0]).includes("not found — using the mock engine"),
       );
       expect(notices).toHaveLength(1);
       const banners = err.mock.calls.filter((c) => String(c[0]).includes("engine: mock"));


### PR DESCRIPTION
## Problem

`engine: 'auto'` chose the native engine whenever `@react-native/babel-preset` and `@babel/core` resolved — `react-native` itself was never checked. An incomplete install (or a babel-only workspace) selected native mode and then failed later, at React Native resolution, with an error pointing nowhere near the cause.

## Change

Detection requires all three, **by resolution rather than declaration**: every check walks `node_modules` upward from the project root, so a hoisted workspace install or Expo's transitive `react-native` counts without appearing in the project's own manifest.

One implementation subtlety: `react-native` specifically is located by a filesystem walk rather than the require machinery, because this package's own engines intercept that specifier — the mock engine's CJS bridge answers `req.resolve("react-native")` from *any* root, which would have made the check unconditionally true under the very test config that guards it.

The fallback notice and the explicit-`engine: 'native'` configuration error now name exactly which dependencies did not resolve (`EngineDecision` gains a `missing` list).

## Verification

- New regression test: a root whose Babel toolchain resolves but has no `react-native` now falls back to mock with a notice naming `react-native`; mutation-verified (removing the check turns it red).
- Suites green: mock 1711, native 222; lint/typecheck/format clean.