### PR TITLE
feat(presets): complete the expo-linking mock surface

### DIFF
--- a/.changeset/expo-linking-preset-surface.md
+++ b/.changeset/expo-linking-preset-surface.md
@@ -1,0 +1,5 @@
+---
+"vitest-native": patch
+---
+
+Complete the expo-linking preset mock: add `addEventListener`, `resolveScheme` and `getInitialURL`, which expo-router's linking layer calls at render time.

--- a/packages/vitest-native/src/presets/expo.ts
+++ b/packages/vitest-native/src/presets/expo.ts
@@ -118,7 +118,14 @@ export function expo(): Preset {
       },
 
       "expo-linking": {
-        exports: ["createURL", "parse", "useURL"],
+        exports: [
+          "createURL",
+          "parse",
+          "useURL",
+          "resolveScheme",
+          "addEventListener",
+          "getInitialURL",
+        ],
         factory: () => {
           const createURL = vi.fn((path: string) => `exp://localhost:19000/${path}`);
           const parse = vi.fn((url: string) => ({
@@ -128,11 +135,20 @@ export function expo(): Preset {
             queryParams: {},
           }));
           const useURL = vi.fn(() => null);
+          // expo-router's linking layer calls these while rendering an ExpoRoot;
+          // without them any router render throws. Mirrors the module mock that
+          // expo-router/testing-library registers for Jest.
+          const resolveScheme = vi.fn(() => "exp");
+          const addEventListener = vi.fn(() => ({ remove: () => {} }));
+          const getInitialURL = vi.fn(async () => null);
 
           const exports = {
             createURL,
             parse,
             useURL,
+            resolveScheme,
+            addEventListener,
+            getInitialURL,
           };
 
           return {

--- a/packages/vitest-native/tests-native/expo.test.tsx
+++ b/packages/vitest-native/tests-native/expo.test.tsx
@@ -42,3 +42,14 @@ describe("Expo modules under the native engine", () => {
     expect(screen.getByText(/Hello from/)).toBeTruthy();
   });
 });
+
+describe("expo-linking preset surface", () => {
+  it("provides the functions expo-router's linking layer calls at render time", async () => {
+    const Linking = await import("expo-linking");
+    const subscription = Linking.addEventListener("url", () => {});
+    expect(typeof subscription.remove).toBe("function");
+    expect(Linking.resolveScheme({})).toBe("exp");
+    await expect(Linking.getInitialURL()).resolves.toBeNull();
+    expect(Linking.createURL("path")).toBe("exp://localhost:19000/path");
+  });
+});


### PR DESCRIPTION
The expo-linking preset currently mocks `createURL`, `parse` and `useURL`. expo-router's
linking layer calls three more functions at render time, so rendering an `ExpoRoot`
(or anything built on it) under the native engine crashes with
`TypeError: Linking.addEventListener is not a function`.

This adds the missing surface, mirroring the mock that `expo-router/testing-library`
registers for Jest:

- `addEventListener` → returns `{ remove() {} }`
- `resolveScheme` → returns a fixed scheme (no manifest available in tests)
- `getInitialURL` → resolves `null`

Repro before this change:

```tsx
import { ExpoRoot } from 'expo-router/build/ExpoRoot';
render(<ExpoRoot context={mockContext} location="/" />);
// TypeError: Linking.addEventListener is not a function
```

Tested with a new preset test; existing expo preset tests unchanged.
