### PR TITLE
fix(native): fabricated module stubs follow Expo method conventions

### DIFF
--- a/.changeset/module-stub-conventions.md
+++ b/.changeset/module-stub-conventions.md
@@ -1,0 +1,5 @@
+---
+"vitest-native": patch
+---
+
+Fabricated native-module stubs follow Expo method conventions: unknown `*Async` properties resolve a Promise (fixes expo-notifications crashing at import), and unknown PascalCase properties are memoized classes extending `SharedObject` (fixes expo-file-system's `class File extends ExpoFileSystem.FileSystemFile`).

--- a/packages/vitest-native/src/native/globals.mjs
+++ b/packages/vitest-native/src/native/globals.mjs
@@ -71,15 +71,34 @@ function installExpoGlobal(g) {
   // setUpJsLogger) call methods like `.addListener` on these, so return a
   // permissive NativeModule stub (EventEmitter methods + no-op for unknown native
   // methods) for any accessed module rather than crashing on `undefined`.
+  //
+  // Fabricated properties follow two Expo conventions instead of a blanket
+  // `() => undefined`:
+  // - `*Async` methods return Promises on device, and packages chain on them at
+  //   import time (expo-notifications: `getRegistrationInfoAsync().then(...)`),
+  //   so they resolve undefined — matching jest-expo's generated mocks.
+  // - PascalCase properties are native classes (SharedObjects) that package JS
+  //   subclasses (expo-file-system: `class File extends ExpoFileSystem.FileSystemFile`),
+  //   so they are memoized classes on SharedObject's prototype chain.
+  // Explicitly-set properties (spies, overrides) always win.
   const __moduleCache = new Map();
-  const makeModuleStub = () =>
-    new Proxy(new NativeModule(), {
+  const makeModuleStub = () => {
+    const fabricatedClasses = new Map();
+    return new Proxy(new NativeModule(), {
       get(target, prop) {
         if (prop in target) return target[prop];
         if (typeof prop === "symbol") return undefined;
+        if (prop.endsWith("Async")) return () => Promise.resolve(undefined);
+        if (/^[A-Z]/.test(prop)) {
+          if (!fabricatedClasses.has(prop)) {
+            fabricatedClasses.set(prop, class extends SharedObject {});
+          }
+          return fabricatedClasses.get(prop);
+        }
         return () => undefined;
       },
     });
+  };
   const modules = new Proxy(
     {},
     {

--- a/packages/vitest-native/tests-native/globals.test.ts
+++ b/packages/vitest-native/tests-native/globals.test.ts
@@ -23,3 +23,27 @@ describe("native engine: React Native runtime globals", () => {
     expect((globalThis as Record<string, unknown>).__fbBatchedBridgeConfig).toBeDefined();
   });
 });
+
+describe("native engine: fabricated expo native-module stubs", () => {
+  const modules = (globalThis as Record<string, any>).expo.modules;
+
+  it("resolves fabricated *Async methods to a Promise (Expo convention)", async () => {
+    await expect(modules.SomeFabricatedModule.getRegistrationInfoAsync()).resolves.toBeUndefined();
+  });
+
+  it("serves fabricated PascalCase properties as classes on SharedObject", () => {
+    const NativeClass = modules.SomeFabricatedModule.FileSystemFile;
+    class Sub extends NativeClass {}
+    const instance = new Sub();
+    expect(instance).toBeInstanceOf((globalThis as Record<string, any>).expo.SharedObject);
+    expect(typeof instance.addListener).toBe("function");
+    // Memoized: subclass identity must be stable across reads.
+    expect(modules.SomeFabricatedModule.FileSystemFile).toBe(NativeClass);
+  });
+
+  it("keeps the no-op fallback for other fabricated methods and explicit overrides winning", () => {
+    expect(modules.SomeFabricatedModule.someMethod()).toBeUndefined();
+    modules.SomeFabricatedModule.getOverriddenAsync = () => "explicit";
+    expect(modules.SomeFabricatedModule.getOverriddenAsync()).toBe("explicit");
+  });
+});


### PR DESCRIPTION
`makeModuleStub()` answers every unknown property with `() => undefined`. Two Expo
conventions break on that:

1. **`*Async` methods return Promises on device.** Some packages chain on them at
   import time — expo-notifications does
   `ServerRegistrationModule.getRegistrationInfoAsync().then(...)`, so importing
   `expo-notifications` crashes with `Cannot read properties of undefined (reading 'then')`.

2. **PascalCase properties are native classes.** expo-file-system (SDK 54+ File API)
   does `class File extends ExpoFileSystem.FileSystemFile`, which crashes with
   `Class extends value () => undefined is not a constructor`.

This changes the fabricated-property fallback in `makeModuleStub()`:

- unknown props ending in `Async` → `() => Promise.resolve(undefined)`
  (matches what jest-expo's generated mocks return)
- unknown PascalCase props → a memoized class extending `SharedObject`, so
  `extends`, `instanceof` and the EventEmitter methods keep working

Explicitly-set properties (spies, overrides) still win — only the fallback changes.

With this, `import * as Notifications from 'expo-notifications'` and
`import { File, Paths } from 'expo-file-system'` work under the native engine.

Not touched here: `requireOptionalNativeModule` semantics (the registry claims every
module exists via `has: () => true`, so optional modules read as present). That's a
design question — happy to open a separate discussion if there's interest.
