### PR TITLE
feat(helpers): extendPresetMock() to augment preset module mocks

### DIFF
--- a/.changeset/extend-preset-mock-helper.md
+++ b/.changeset/extend-preset-mock-helper.md
@@ -1,0 +1,5 @@
+---
+"vitest-native": minor
+---
+
+New helper `extendPresetMock(pkg, overrides)`: merge overrides into a preset's module mock (and its `default` export) — e.g. to give expo-constants a real `expoConfig` or add an export a library calls that the preset does not model. Undone by `resetAllMocks()`.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ want no RN at all — fast, deterministic, environment-controllable.
 - **`vi.mock('react-native')` works under both engines** — including `importOriginal()`, so you
   can replace one export and keep the rest real. See [Mocking React Native](#mocking-react-native).
 - **Jest-compat layer** — `vitest-native/jest-compat` eases migrating existing Jest suites.
-- **Test helpers** — `setPlatform`, `setDimensions`, `setColorScheme`, `mockNativeModule` for easy state control.
+- **Test helpers** — `setPlatform`, `setDimensions`, `setColorScheme`, `mockNativeModule`, `extendPresetMock` for easy state control.
 - **TypeScript first** — Full type safety across the entire API.
 
 ## How It Works

--- a/packages/vitest-native/docs/versioning.md
+++ b/packages/vitest-native/docs/versioning.md
@@ -23,7 +23,7 @@ and deep paths are not supported even when they happen to resolve.
 | Subpath | Covered exports |
 | --- | --- |
 | `vitest-native` | `reactNative`, `presets`, `disabledPresetNames` |
-| `vitest-native/helpers` | `setPlatform`, `setDimensions`, `setColorScheme`, `setInsets`, `mockNativeModule`, `resetAllMocks` |
+| `vitest-native/helpers` | `setPlatform`, `setDimensions`, `setColorScheme`, `setInsets`, `mockNativeModule`, `extendPresetMock`, `resetAllMocks` |
 | `vitest-native/presets` | the 17 preset factories, by name |
 | `vitest-native/matchers` | `toHaveAnimatedStyle`, `toHaveAnimatedProps`, `animatedMatchers` |
 | `vitest-native/serializer` | `serializer` |

--- a/packages/vitest-native/src/helpers.ts
+++ b/packages/vitest-native/src/helpers.ts
@@ -138,6 +138,10 @@ export function extendPresetMock(pkg: string, overrides: Record<string, any>): b
 function restorePresetMockOverrides(): void {
   for (let i = presetMockOverrides.length - 1; i >= 0; i--) {
     const { target, key, had, previous } = presetMockOverrides[i];
+    // The journal only ever holds keys that passed the guard above, but that
+    // fact lives across a function boundary a static analyzer cannot follow —
+    // restate it locally so the write below is provably safe on its own.
+    if (key === "__proto__" || key === "constructor" || key === "prototype") continue;
     if (had) {
       Object.defineProperty(target, key, {
         configurable: true,

--- a/packages/vitest-native/src/helpers.ts
+++ b/packages/vitest-native/src/helpers.ts
@@ -112,8 +112,24 @@ export function extendPresetMock(pkg: string, overrides: Record<string, any>): b
   }
   for (const target of targets) {
     for (const [key, value] of Object.entries(overrides)) {
-      presetMockOverrides.push({ target, key, had: key in target, previous: target[key] });
-      target[key] = value;
+      // Prototype-pollution guard: assigning these through a computed key would
+      // re-prototype the mock (or worse via a JSON-sourced "__proto__" own key)
+      // instead of adding an export. No preset export can legitimately use them.
+      if (key === "__proto__" || key === "constructor" || key === "prototype") continue;
+      presetMockOverrides.push({
+        target,
+        key,
+        had: Object.prototype.hasOwnProperty.call(target, key),
+        previous: target[key],
+      });
+      // defineProperty writes an own data property without running any setter a
+      // polluted key could reach — the journal above only ever holds safe keys.
+      Object.defineProperty(target, key, {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value,
+      });
     }
   }
   return true;
@@ -122,8 +138,16 @@ export function extendPresetMock(pkg: string, overrides: Record<string, any>): b
 function restorePresetMockOverrides(): void {
   for (let i = presetMockOverrides.length - 1; i >= 0; i--) {
     const { target, key, had, previous } = presetMockOverrides[i];
-    if (had) target[key] = previous;
-    else delete target[key];
+    if (had) {
+      Object.defineProperty(target, key, {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value: previous,
+      });
+    } else {
+      delete target[key];
+    }
   }
   presetMockOverrides = [];
 }

--- a/packages/vitest-native/src/helpers.ts
+++ b/packages/vitest-native/src/helpers.ts
@@ -86,6 +86,48 @@ export function setInsets(insets: {
   }
 }
 
+/** Undo journal for extendPresetMock(), replayed LIFO by resetAllMocks(). */
+type PresetOverrideEntry = {
+  target: Record<string, any>;
+  key: string;
+  had: boolean;
+  previous: any;
+};
+let presetMockOverrides: PresetOverrideEntry[] = [];
+
+/**
+ * Merge overrides into a preset's module mock (and its `default`, when that is
+ * an object) — e.g. to give expo-constants a real `expoConfig` or add an export
+ * a library calls that the preset does not model. Returns `false` when no
+ * preset mock exists for the package. Undone by `resetAllMocks()`.
+ */
+export function extendPresetMock(pkg: string, overrides: Record<string, any>): boolean {
+  const presetMocks = (globalThis as any).__vitest_native_preset_mocks;
+  const mock = presetMocks?.[pkg];
+  if (!mock) return false;
+
+  const targets: Record<string, any>[] = [mock];
+  if (mock.default && typeof mock.default === "object" && mock.default !== mock) {
+    targets.push(mock.default);
+  }
+  for (const target of targets) {
+    for (const [key, value] of Object.entries(overrides)) {
+      presetMockOverrides.push({ target, key, had: key in target, previous: target[key] });
+      target[key] = value;
+    }
+  }
+  return true;
+}
+
+function restorePresetMockOverrides(): void {
+  for (let i = presetMockOverrides.length - 1; i >= 0; i--) {
+    const { target, key, had, previous } = presetMockOverrides[i];
+    if (had) target[key] = previous;
+    else delete target[key];
+  }
+  presetMockOverrides = [];
+}
+
 export function mockNativeModule(name: string, impl: Record<string, any>): void {
   const native = getNativeControl();
   if (native) return native.mockNativeModule(name, impl);
@@ -133,6 +175,9 @@ function clearMockFns(obj: Record<string, any>, visited = new Set()): void {
 }
 
 export function resetAllMocks(): void {
+  // Before the native-engine delegation: extendPresetMock() writes through this
+  // module under both engines, so its undo journal is replayed here.
+  restorePresetMockOverrides();
   const native = getNativeControl();
   if (native) return native.resetAllMocks();
   const mock = getMock();

--- a/packages/vitest-native/tests-native/extend-preset-mock.test.ts
+++ b/packages/vitest-native/tests-native/extend-preset-mock.test.ts
@@ -1,0 +1,37 @@
+/**
+ * extendPresetMock(): augment a preset's module mock with extra or replaced
+ * exports, undone by resetAllMocks(). Uses the auto-detected expo preset
+ * (expo-constants is a devDependency here).
+ */
+import { describe, expect, it } from "vitest";
+import { extendPresetMock, resetAllMocks } from "vitest-native/helpers";
+
+describe("extendPresetMock", () => {
+  it("merges overrides into the preset mock and its default export", async () => {
+    const applied = extendPresetMock("expo-constants", {
+      expoConfig: { name: "my-app", slug: "my-app", scheme: "my-app" },
+      linkingUri: "my-app://",
+    });
+    expect(applied).toBe(true);
+
+    const Constants = (await import("expo-constants")).default;
+    expect(Constants.expoConfig).toEqual({ name: "my-app", slug: "my-app", scheme: "my-app" });
+    expect(Constants.linkingUri).toBe("my-app://");
+  });
+
+  it("is undone by resetAllMocks()", async () => {
+    extendPresetMock("expo-constants", {
+      expoConfig: { name: "temporary" },
+      addedOnlyForThisTest: "x",
+    });
+    resetAllMocks();
+
+    const Constants = (await import("expo-constants")).default;
+    expect(Constants.expoConfig?.name).toBe("test-app");
+    expect("addedOnlyForThisTest" in Constants).toBe(false);
+  });
+
+  it("returns false when no preset mock exists for the package", () => {
+    expect(extendPresetMock("not-a-shadowed-package", { x: 1 })).toBe(false);
+  });
+});

--- a/website/guide/helpers.md
+++ b/website/guide/helpers.md
@@ -61,6 +61,16 @@ mockNativeModule('MyNativeModule', {
 })
 ```
 
+## `extendPresetMock(pkg, overrides)`
+
+Merge overrides into a preset's module mock (and its `default` export, when that is an object) — for example to give `expo-constants` a real `expoConfig`, or to add an export a library calls that the preset does not model. Returns `false` when no preset mock exists for the package. Undone by `resetAllMocks()`.
+
+```ts
+extendPresetMock('expo-constants', {
+  expoConfig: { name: 'my-app', scheme: 'my-app' },
+})
+```
+
 ## `resetAllMocks()`
 
 Reset everything back to defaults — iOS, 390×844, light mode — and clear all spies. Call it in an `afterEach` to keep tests isolated:


### PR DESCRIPTION
Preset mocks are intentionally minimal, and some setups need to add or override a few
exports — e.g. giving expo-constants a real `expoConfig`, or adding the expo-linking
functions a router test needs. Today the only way is writing to the internal
`globalThis.__vitest_native_preset_mocks` registry, which works but couples consumers
to an internal.

This adds a small helper next to `mockNativeModule()`:

```ts
import { extendPresetMock } from 'vitest-native/helpers';

extendPresetMock('expo-constants', {
  expoConfig: { name: 'my-app', scheme: 'my-app' },
});
```

It merges the overrides into the preset mock object (and its `default`, when that is
an object), returns `false` when no preset mock exists for the package, and is undone
by `resetAllMocks()` like everything else in the registry.
