### PR TITLE
fix: null-prototype the mock registries against prototype-polluting names

### DIFF
--- a/.changeset/null-proto-mock-registries.md
+++ b/.changeset/null-proto-mock-registries.md
@@ -1,0 +1,5 @@
+---
+"vitest-native": patch
+---
+
+Mock registries are null-prototype objects, so a module or package name of `__proto__` becomes an ordinary entry instead of re-prototyping the registry. Hardens the published `mockNativeModule()` surface against prototype-polluting names — the same class CodeQL flagged on `extendPresetMock()`.

--- a/packages/vitest-native/src/native/globals.mjs
+++ b/packages/vitest-native/src/native/globals.mjs
@@ -21,7 +21,7 @@ export function installGlobals() {
   g.IS_REACT_ACT_ENVIRONMENT = true;
   g.IS_REACT_NATIVE_TEST_ENVIRONMENT = true;
   g.__fbBatchedBridgeConfig = { remoteModuleConfig: [], localModulesConfig: [] };
-  g.__vitest_native_module_mocks = g.__vitest_native_module_mocks || {};
+  g.__vitest_native_module_mocks = g.__vitest_native_module_mocks || Object.create(null);
 
   installExpoGlobal(g);
 }

--- a/packages/vitest-native/src/native/setup.mjs
+++ b/packages/vitest-native/src/native/setup.mjs
@@ -176,7 +176,7 @@ installRequireHooks(projectRoot, nodeTransformPkgs, platform, reactNativeVersion
 // Build the mock objects now that the require hooks are installed (preset
 // factories may lazily resolve react-native at render time).
 const g = globalThis;
-g.__vitest_native_preset_mocks = g.__vitest_native_preset_mocks || {};
+g.__vitest_native_preset_mocks = g.__vitest_native_preset_mocks || Object.create(null);
 for (const { pkg, mod, presetName } of presetDefs) {
   g.__vitest_native_preset_mocks[pkg] = mod.factory();
   if (diagnostics) {

--- a/packages/vitest-native/src/setup.ts
+++ b/packages/vitest-native/src/setup.ts
@@ -200,7 +200,7 @@ const presets = explicitPresetNames
 
 // Initialize a global store for preset mocks so that virtual modules
 // (served by the plugin's load() hook) can read them at runtime.
-g.__vitest_native_preset_mocks = g.__vitest_native_preset_mocks || {};
+g.__vitest_native_preset_mocks = g.__vitest_native_preset_mocks || Object.create(null);
 
 // Preset mocks are handled by:
 // 1. The plugin's resolveId() redirecting ESM imports to virtual modules

--- a/packages/vitest-native/tests-native/control-surface.test.ts
+++ b/packages/vitest-native/tests-native/control-surface.test.ts
@@ -49,3 +49,17 @@ describe("native engine: resetAllMocks restores driven state", () => {
     expect(NativeModules.VitestResetProbe?.ping?.()).not.toBe("pong");
   });
 });
+
+describe("native engine: mock registries resist prototype-polluting names", () => {
+  it("a module named __proto__ becomes an ordinary registry entry", () => {
+    const registry = (globalThis as Record<string, any>).__vitest_native_module_mocks;
+    const protoBefore = Object.getPrototypeOf(registry);
+    mockNativeModule("__proto__", { marker: () => "owned" });
+    // The registry was not re-prototyped, and unrelated lookups are unaffected.
+    expect(Object.getPrototypeOf(registry)).toBe(protoBefore);
+    expect(registry.SomeUnrelatedModule).toBeUndefined();
+    // The key landed as a plain own property (null-prototype registry).
+    expect(Object.keys(registry)).toContain("__proto__");
+    expect(({}as Record<string, any>).marker).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Follow-up to the CodeQL finding on #173, applied to the same class on the pre-existing published surface: `mockNativeModule(name, impl)` assigns the caller-supplied name into a plain-object registry (`setup.mjs`), so a name of `"__proto__"` re-prototyped the registry instead of registering a module.

The module-mock and preset-mock registries are now created with `Object.create(null)`, which makes `"__proto__"` an ordinary own key wherever the registries are written — no behavior change for consumers (lookups, `Object.values` sweeps, spreads, and the truthy `||` guards are all prototype-agnostic; an audit found no `hasOwnProperty`-style calls on these objects).

Regression test in `control-surface.test.ts`, mutation-verified: restoring a plain-object registry fails it on the re-prototyped registry. Full suites green (mock 1719, native 228).