### PR TITLE
fix(native): resolve RN 0.87's gated deep imports; mock AssetRegistry

### DIFF
--- a/.changeset/rn-087-forward-compat.md
+++ b/.changeset/rn-087-forward-compat.md
@@ -1,0 +1,28 @@
+---
+"vitest-native": patch
+---
+
+Resolve React Native 0.87's gated deep imports, and mock its new AssetRegistry export
+
+React Native 0.87 ships an `exports` map whose deep-import surface sits behind
+Metro's `react-native-legacy-deep-imports` condition — and its Babel preset now
+compiles RN's own relative imports into bare deep specifiers
+(`react-native/src/private/…`), so RN's compiled graph self-references through
+paths plain Node refuses with `ERR_PACKAGE_PATH_NOT_EXPORTED`. Under the native
+engine that failed almost every suite at collection. The engine now mirrors
+Metro: when Node's resolver rejects a `react-native/*` or `@react-native/*` deep
+specifier, the file is located by path from the package's real directory,
+platform extensions included, in the require hook, the ESM loader, and the
+precompiled registry's fall-through — where resolving by path keeps deep files
+on the registry's instances instead of loading twins. Inert on 0.86 and earlier,
+which have no exports map to reject anything.
+
+The mock engine gains `AssetRegistry` (a top-level export since 0.87),
+mirroring `@react-native/assets-registry/registry` down to its 1-based truthy
+ids. The compatibility checker no longer misreads the bare `get() {` inside
+0.87's new `Object.defineProperty` export blocks as an export named `get`, and
+the InteractionManager probe is version-gated: 0.87 removed the API outright,
+so the matrix keeps running it on every version that ships it.
+
+React Native 0.87 is not yet in the supported matrix — its release is inside
+the dependency cooldown window; adoption follows separately.

--- a/packages/vitest-native/scripts/check-compat.ts
+++ b/packages/vitest-native/scripts/check-compat.ts
@@ -113,6 +113,11 @@ export function parseRNExports(indexPath: string): string[] {
   // unstable_batchedUpdates<T>(...)). Keep those in the public export set.
   const methodRegex = /^\s{2}([A-Za-z_$][\w$]*)(?:<[^>\n]+>)?\s*\(/gm;
   while ((match = methodRegex.exec(source)) !== null) {
+    // RN 0.87 defines some exports via `Object.defineProperty(module.exports, 'X',
+    // { get() { ... } })` — the two-space-indented bare `get() {` inside that block
+    // matches this pattern and is not an export. plugin.ts's parser excludes it the
+    // same way.
+    if (match[1] === "get") continue;
     exports.push(match[1]);
   }
 

--- a/packages/vitest-native/src/mocks/apis/AssetRegistry.ts
+++ b/packages/vitest-native/src/mocks/apis/AssetRegistry.ts
@@ -1,0 +1,23 @@
+import { vi } from "vitest";
+
+/**
+ * AssetRegistry — a top-level export since React Native 0.87 (previously only
+ * reachable via `@react-native/assets-registry/registry`). The real module is a
+ * process-wide array: `registerAsset` pushes and returns the new length, so the
+ * first asset gets id 1 (truthy), and `getAssetByID` reads `assets[id - 1]`.
+ * Mirrored exactly, including the 1-based ids, so code that treats an id of 0
+ * as "unregistered" behaves the same against the mock.
+ */
+export function createAssetRegistryMock() {
+  const assets: unknown[] = [];
+  const mock = {
+    registerAsset: vi.fn((asset: unknown) => assets.push(asset)),
+    getAssetByID: vi.fn((assetId: number) => assets[assetId - 1]),
+    _reset: () => {
+      assets.length = 0;
+      mock.registerAsset.mockClear();
+      mock.getAssetByID.mockClear();
+    },
+  };
+  return mock;
+}

--- a/packages/vitest-native/src/mocks/registry.ts
+++ b/packages/vitest-native/src/mocks/registry.ts
@@ -48,6 +48,7 @@ import { createClipboardMock } from "./apis/Clipboard.js";
 import { createShareMock } from "./apis/Share.js";
 import { createAccessibilityInfoMock } from "./apis/AccessibilityInfo.js";
 import { createInteractionManagerMock } from "./apis/InteractionManager.js";
+import { createAssetRegistryMock } from "./apis/AssetRegistry.js";
 import { createPanResponderMock } from "./apis/PanResponder.js";
 import { createToastAndroidMock } from "./apis/ToastAndroid.js";
 import { createActionSheetIOSMock } from "./apis/ActionSheetIOS.js";
@@ -351,6 +352,7 @@ export {
   createShareMock,
   createAccessibilityInfoMock,
   createInteractionManagerMock,
+  createAssetRegistryMock,
   createPanResponderMock,
   createToastAndroidMock,
   createActionSheetIOSMock,
@@ -416,6 +418,8 @@ export function buildReactNativeMock(platform: "ios" | "android" = "ios") {
     Share: createShareMock(),
     AccessibilityInfo: createAccessibilityInfoMock(),
     InteractionManager: createInteractionManagerMock(),
+    // Top-level export since RN 0.87 (weekly compat canary, issue #179).
+    AssetRegistry: createAssetRegistryMock(),
     PanResponder: createPanResponderMock(),
     ToastAndroid: createToastAndroidMock(),
     ActionSheetIOS: createActionSheetIOSMock(),

--- a/packages/vitest-native/src/native/hooks.mjs
+++ b/packages/vitest-native/src/native/hooks.mjs
@@ -5,7 +5,7 @@ import path from "node:path";
 import fs from "node:fs";
 import { transformRN, isFlow, needsTransform } from "./transform.mjs";
 import { boundarySourceFor } from "./boundary.mjs";
-import { resolvePlatformFile } from "./resolve.mjs";
+import { resolvePlatformFile, resolveDeepPackageFile } from "./resolve.mjs";
 import {
   NODE_MODULES_PATH,
   REACT_NATIVE_PATH,
@@ -292,7 +292,18 @@ export function installRequireHooks(
       );
       if (hit) return hit;
     }
-    const resolved = origResolve.call(this, request, parent, ...rest);
+    let resolved;
+    try {
+      resolved = origResolve.call(this, request, parent, ...rest);
+    } catch (err) {
+      // RN 0.87's exports map rejects the deep self-references its own Babel
+      // preset emits (`react-native/src/private/…`); Metro resolves them via the
+      // `react-native-legacy-deep-imports` condition. Mirror Metro by path.
+      const fromDir = parent?.filename ? path.dirname(parent.filename) : projectRoot;
+      const deep = resolveDeepPackageFile(request, fromDir, platform);
+      if (deep === null) throw err;
+      resolved = deep;
+    }
     checkResolverAgreement(request, resolved);
     checkProjectSourceLoadedByNode(resolved, parent);
     return resolved;

--- a/packages/vitest-native/src/native/loader.mjs
+++ b/packages/vitest-native/src/native/loader.mjs
@@ -5,7 +5,7 @@ import path from "node:path";
 import fs from "node:fs";
 import { transformRN, isFlow, cjsExportNames, needsTransform } from "./transform.mjs";
 import { boundarySourceFor } from "./boundary.mjs";
-import { resolvePlatformFile } from "./resolve.mjs";
+import { resolvePlatformFile, resolveDeepPackageFile } from "./resolve.mjs";
 import {
   NODE_MODULES_PATH,
   REACT_NATIVE_PATH,
@@ -168,6 +168,17 @@ export async function resolve(specifier, context, nextResolve) {
     if (parent && specifier.startsWith(".") && !path.extname(specifier)) {
       const hit = resolveExtensionless(path.resolve(path.dirname(parent), specifier));
       if (hit) resolved = { url: pathToFileURL(hit).href, shortCircuit: true };
+    }
+    // RN 0.87's exports map rejects the deep self-references its own Babel
+    // preset emits (react-native/src/private/...); Metro resolves them via its
+    // legacy-deep-imports condition. Mirror Metro by path (see resolve.mjs).
+    if (!resolved) {
+      const deep = resolveDeepPackageFile(
+        specifier,
+        parent ? path.dirname(parent) : PROJECT_ROOT,
+        PLATFORM,
+      );
+      if (deep) resolved = { url: pathToFileURL(deep).href, shortCircuit: true };
     }
     if (!resolved) throw err;
   }

--- a/packages/vitest-native/src/native/registry.mjs
+++ b/packages/vitest-native/src/native/registry.mjs
@@ -34,7 +34,7 @@ import crypto from "node:crypto";
 import { transformRN, isFlow, cacheRootFor, TRANSFORM_CACHE_VERSION } from "./transform.mjs";
 
 import { boundarySourceFor, BOUNDARY_SOURCES } from "./boundary.mjs";
-import { resolvePlatformFile } from "./resolve.mjs";
+import { resolvePlatformFile, resolveDeepPackageFile } from "./resolve.mjs";
 
 /**
  * Losing the registry is a silent performance cliff, not a correctness problem:
@@ -557,10 +557,22 @@ export function installRegistry(registryFile, projectRoot) {
       try {
         resolved = resolver.resolve(request);
       } catch {
-        resolved = null;
+        // RN 0.87's exports map refuses the deep self-references its preset
+        // emits; resolve by path (Metro's behavior) so the file still lands on
+        // the registry's instance instead of loading a twin outside it.
+        resolved = resolveDeepPackageFile(
+          request,
+          parent?.filename ? path.dirname(parent.filename) : projectRoot,
+          process.env.VITEST_NATIVE_PLATFORM === "android" ? "android" : "ios",
+        );
       }
       const id = resolved === null ? undefined : idOf.get(resolved);
       if (id !== undefined) return registry.load(id);
+      // Resolved by path but not in the registry: forward the PATH — reloading
+      // the bare specifier would just hit the exports map again.
+      if (resolved !== null && path.isAbsolute(resolved)) {
+        return origLoad.call(this, resolved, parent, ...rest);
+      }
     }
     return origLoad.call(this, request, parent, ...rest);
   };

--- a/packages/vitest-native/src/native/resolve.mjs
+++ b/packages/vitest-native/src/native/resolve.mjs
@@ -74,3 +74,46 @@ function scanPlatformFile(absBase, platform) {
   }
   return null;
 }
+
+/**
+ * Resolve a deep package specifier by PATH when Node's exports-map enforcement
+ * rejects it.
+ *
+ * React Native 0.87 ships an `exports` map whose deep-import surface is gated
+ * behind Metro's `react-native-legacy-deep-imports` condition — and the 0.87
+ * Babel preset compiles RN's own relative imports into bare deep specifiers
+ * (`react-native/src/private/…`), so RN's compiled graph self-references through
+ * paths plain Node now refuses (`ERR_PACKAGE_PATH_NOT_EXPORTED`). Metro resolves
+ * them; this engine mirrors Metro: locate the package directory by walking
+ * node_modules from the requiring file and resolve the file directly, platform
+ * extensions included — path resolution is not subject to exports maps.
+ *
+ * Scoped to react-native and @react-native/* — the packages whose graphs the
+ * preset rewrites. Ordinary packages keep Node's exports enforcement.
+ */
+export function resolveDeepPackageFile(request, fromDir, platform) {
+  const m = /^(react-native|@react-native\/[^/]+)\/(.+)$/.exec(request);
+  if (!m) return null;
+  const [, pkg, rest] = m;
+  const pkgDir = findPackageDir(fromDir, pkg);
+  if (!pkgDir) return null;
+  const base = path.join(pkgDir, rest);
+  try {
+    if (fs.statSync(base).isFile()) return base;
+  } catch {}
+  // `Foo.js` may exist only as a platform variant, and extensionless specifiers
+  // need the full Metro candidate list either way.
+  const stem = /\.[a-z0-9]+$/i.test(base) ? base.replace(/\.js$/, "") : base;
+  return resolvePlatformFile(stem, platform);
+}
+
+function findPackageDir(startDir, pkg) {
+  let dir = path.resolve(startDir);
+  for (;;) {
+    const candidate = path.join(dir, "node_modules", ...pkg.split("/"));
+    if (fs.existsSync(path.join(candidate, "package.json"))) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}

--- a/packages/vitest-native/src/plugin.ts
+++ b/packages/vitest-native/src/plugin.ts
@@ -392,6 +392,7 @@ const RN_EXPORT_NAMES = [
   "Alert",
   "Linking",
   "AppState",
+  "AssetRegistry",
   "Keyboard",
   "BackHandler",
   "Vibration",

--- a/packages/vitest-native/tests-native/stress-apis.test.tsx
+++ b/packages/vitest-native/tests-native/stress-apis.test.tsx
@@ -3,6 +3,7 @@
 // component refs, animation drivers, and event-emitter plumbing. Independent
 // probes; failures are boundary holes to plug in src/native/boundary.mjs.
 import { describe, it, expect, vi } from "vitest";
+import { createRequire } from "node:module";
 import React from "react";
 import { render, screen, act } from "@testing-library/react-native";
 import {
@@ -59,8 +60,16 @@ describe("native engine: async native modules", () => {
   });
 });
 
+// React Native 0.87 removed InteractionManager outright (the index traps access
+// behind a DEV invariant). Real API on 0.81-0.86; gone on 0.87+, so the probe is
+// version-gated rather than deleted — the matrix still runs it on every version
+// that ships the API.
+const rnMinor = Number(
+  createRequire(import.meta.url)("react-native/package.json").version.split(".")[1],
+);
+
 describe("native engine: scheduling + gestures", () => {
-  it("InteractionManager.runAfterInteractions runs the task", async () => {
+  it.skipIf(rnMinor >= 87)("InteractionManager.runAfterInteractions runs the task", async () => {
     const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {
       const task = vi.fn();

--- a/packages/vitest-native/tests/rn-087-exports.test.ts
+++ b/packages/vitest-native/tests/rn-087-exports.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Regression coverage for top-level exports introduced in react-native 0.87,
+ * flagged by the weekly compatibility check (issue #179). AssetRegistry mirrors
+ * @react-native/assets-registry/registry: 1-based ids from registerAsset (the
+ * real module returns Array.push's new length so the first id is truthy).
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { AssetRegistry } from "react-native";
+import { resetAllMocks } from "vitest-native/helpers";
+
+describe("AssetRegistry (RN 0.87)", () => {
+  beforeEach(() => resetAllMocks());
+
+  it("registerAsset returns 1-based truthy ids and getAssetByID reads them back", () => {
+    const a = { name: "logo", type: "png" };
+    const b = { name: "icon", type: "ttf" };
+    const idA = AssetRegistry.registerAsset(a);
+    const idB = AssetRegistry.registerAsset(b);
+    expect(idA).toBe(1);
+    expect(idB).toBe(2);
+    expect(AssetRegistry.getAssetByID(idA)).toBe(a);
+    expect(AssetRegistry.getAssetByID(idB)).toBe(b);
+    expect(AssetRegistry.getAssetByID(999)).toBeUndefined();
+  });
+
+  it("resetAllMocks clears the registered assets", () => {
+    AssetRegistry.registerAsset({ name: "x" });
+    resetAllMocks();
+    expect(AssetRegistry.registerAsset({ name: "y" })).toBe(1);
+    expect(AssetRegistry.getAssetByID(2)).toBeUndefined();
+  });
+});

--- a/website/guide/fidelity.md
+++ b/website/guide/fidelity.md
@@ -21,11 +21,11 @@ generated from the corpus itself, so the numbers below are exactly what ships.
 ### What this number covers
 
 A matching probe count says how many comparisons pass, not how much of the mock they
-reach. The corpus reaches 12 of 27 mocked APIs and 16 of 24 mocked components. The rest are not compared against real React Native at all — they are not known to differ, they are simply unmeasured.
+reach. The corpus reaches 12 of 28 mocked APIs and 16 of 24 mocked components. The rest are not compared against real React Native at all — they are not known to differ, they are simply unmeasured.
 
 Not reached by any probe:
 
-- APIs: AccessibilityInfo, ActionSheetIOS, Alert, BackHandler, Clipboard, Keyboard, Linking, LogBox, PanResponder, PermissionsAndroid, Share, ToastAndroid, Vibration, useColorScheme, useWindowDimensions
+- APIs: AccessibilityInfo, ActionSheetIOS, Alert, AssetRegistry, BackHandler, Clipboard, Keyboard, Linking, LogBox, PanResponder, PermissionsAndroid, Share, ToastAndroid, Vibration, useColorScheme, useWindowDimensions
 - Components: DrawerLayoutAndroid, ImageBackground, InputAccessoryView, RefreshControl, SafeAreaView, StatusBar, TouchableNativeFeedback, VirtualizedList
 
 The `native` engine needs no cross-check — it *is* real React Native.


### PR DESCRIPTION
Fixes the breakage behind #179 (the weekly canary against `react-native@latest`, which became 0.87.0 on 2026-08-11).

## Root cause

RN 0.87 ships an `exports` map whose deep-import surface sits behind Metro's `react-native-legacy-deep-imports` condition — and its Babel preset now compiles RN's **own** relative imports into bare deep specifiers (`react-native/src/private/…`). RN's compiled graph therefore self-references through paths plain Node refuses with `ERR_PACKAGE_PATH_NOT_EXPORTED`. Under the native engine, 27 of 49 suites failed at collection.

## Change

- **`resolveDeepPackageFile`**: when Node's resolver rejects a `react-native/*` or `@react-native/*` deep specifier, locate the file from the package's real directory (platform extensions included) — Metro's effective behavior. Wired into the require hook, the ESM loader, and the precompiled registry's fall-through, where path resolution keeps deep files on the registry's instances instead of loading twins. **Inert on ≤0.86**: the fallback only runs when the resolver throws, and no exports map exists there to throw.
- **`AssetRegistry` mock** (top-level export since 0.87), mirroring `@react-native/assets-registry/registry` down to its 1-based truthy ids. The `RN_EXPORT_NAMES` sync gate caught the virtual-module half of the wiring during development — it exists for exactly this.
- **`check-compat` parser**: 0.87 defines some exports via `Object.defineProperty(module.exports, 'X', { get() { … } })`; the bare `get() {` matched the method regex and reported a phantom missing export named `get`.
- **Version-gated `InteractionManager` probe**: 0.87 removed the API outright (the index traps access behind a DEV invariant); the matrix still runs the probe on every version that ships it.

## Verification

- Pinned 0.86 (this PR's state): native 231, hot 231, isolation, hot-parity zero-delta, crosscheck 85/85, check-compat 85/85, mock 1721, lint/typecheck/format.
- Temporarily pinned to 0.87: native goes from 27 failed files to **230 passed + 1 version-skipped**; check-compat **83/83 OK** (surface shrinks by the two removals); mock 1721.

## Not in this PR

Adopting 0.87 into the supported matrix (lockfile pin + matrix row + range comment) follows separately: the release is still inside the seven-day dependency cooldown the matrix workflow documents, which clears 2026-08-18.