### PR TITLE
fix(presets): navigation preset matches @react-navigation/native's shape; disabled presets detect

### DIFF
--- a/.changeset/navigation-preset-real-shape.md
+++ b/.changeset/navigation-preset-real-shape.md
@@ -1,0 +1,27 @@
+---
+"vitest-native": patch
+---
+
+Navigation preset matches @react-navigation/native's shape; a disabled preset's package detects like any other
+
+Two gaps that both surfaced by rendering router-driven screens under the native
+engine — the shape most Expo apps have.
+
+`createNavigatorFactory(Navigator)` now returns the real factory shape, yielding
+`{ Navigator, Screen, Group }`. It returned a bare mock function whose result was
+undefined, so any library building on the public factory API — expo-router extracts
+its `Screen`/`Group` primitives through `createNavigatorFactory({})()` — failed at
+import with "Cannot read properties of undefined (reading 'Screen')". The preset
+also gains the exports `@react-navigation/native` adds on top of core:
+`LinkingContext`, `LocaleDirContext`, `UNSTABLE_UnhandledLinkingContext`,
+`DefaultTheme`, `DarkTheme` (real colors and platform font stacks), `createStaticNavigation`,
+`ServerContainer`, `useLinkBuilder`, `useLinkProps`, `useLocale`, `useRoutePath`.
+`ThemeContext` is seeded with `DefaultTheme`, as in the real package.
+
+Disabling a preset — `presets: { navigation: false }` — now returns its packages to
+ordinary ecosystem detection. Detection used to skip every preset package
+unconditionally, so turning the preset off un-shadowed `@react-navigation/*` but
+left it undetected: nothing compiled its untranspiled `lib/module` source and it
+failed at load. That is the configuration under which the real React Navigation
+stack, and expo-router's own `expo-router/testing-library` on top of it, run under
+the native engine — `renderRouter` renders and `router.push` navigates.

--- a/packages/vitest-native/src/native/ecosystem.ts
+++ b/packages/vitest-native/src/native/ecosystem.ts
@@ -212,6 +212,7 @@ export function detectEcosystemPackages(
   explicit: string[] = [],
   testRoots: string[] = [],
   neverTransform: string[] = [],
+  activePresets?: readonly string[],
 ): string[] {
   // More than one root because `manifestsFrom` only walks UP. In a workspace the
   // run root is often above the package under test — Nx invokes tasks from the
@@ -225,12 +226,19 @@ export function detectEcosystemPackages(
   // `neverTransform` is the user's `transform.exclude`. It joins the built-in lists
   // rather than being checked separately, so it overrides detection AND the closure
   // walk by the same mechanism they do.
-  const skip = new Set<string>([
-    ...NEVER_INLINE,
-    ...Object.keys(AUTO_DETECT_PRESETS),
-    ...explicit,
-    ...neverTransform,
-  ]);
+  // Only packages an ACTIVE preset shadows are excluded. This used to skip every
+  // preset package unconditionally, so disabling a preset — `presets: { navigation:
+  // false }` to run the real @react-navigation/* under the native engine, which
+  // expo-router requires — un-shadowed the package but left it undetected: nothing
+  // compiled its untranspiled lib/module ESM, Node's require(esm) retry ran it raw,
+  // and `import { Platform } from 'react-native'` bound to nothing. A package whose
+  // preset is off is an ordinary React Native dependency and detects like one.
+  // (Callers that pass no active set keep the old behaviour: all preset packages
+  // are treated as shadowed.)
+  const shadowed = Object.entries(AUTO_DETECT_PRESETS)
+    .filter(([, presetName]) => activePresets === undefined || activePresets.includes(presetName))
+    .map(([pkg]) => pkg);
+  const skip = new Set<string>([...NEVER_INLINE, ...shadowed, ...explicit, ...neverTransform]);
   const candidates = new Set<string>();
   const found = roots.flatMap((root) => manifestsFrom(root));
   // One resolver per directory that declared something. Under pnpm a workspace

--- a/packages/vitest-native/src/plugin.ts
+++ b/packages/vitest-native/src/plugin.ts
@@ -973,6 +973,7 @@ export function reactNative(options?: VitestNativeOptions): Plugin {
           transformPkgs,
           includeRoots,
           neverTransform,
+          nativePresetNames,
         );
         // The directories Vite owns outright. Handed to the worker so the require
         // hook can say so if Node loads one of their files anyway — which happens

--- a/packages/vitest-native/src/presets/navigation.ts
+++ b/packages/vitest-native/src/presets/navigation.ts
@@ -84,8 +84,68 @@ export function navigation(presetOptions: NavigationPresetOptions = {}): Preset 
   const NavigationContainerRefContext = React.createContext(null as any);
   const NavigationHelpersContext = React.createContext(null as any);
   const CurrentRenderContext = React.createContext(undefined as any);
-  const ThemeContext = React.createContext({ dark: false, colors: {} } as any);
   const PreventRemoveContext = React.createContext(null as any);
+
+  // The exports @react-navigation/native adds ON TOP of @react-navigation/core
+  // (its src/index.tsx: linking, locale, themes, static navigation, link hooks).
+  // These were absent, so anything rendering its own container against this
+  // package — expo-router's forked NavigationContainer reads LinkingContext,
+  // LocaleDirContext and UNSTABLE_UnhandledLinkingContext — failed with
+  // "Cannot read properties of undefined (reading 'Provider')". Shapes follow
+  // the real module: contexts are real React contexts with its default values,
+  // themes carry its exact colors and platform font stacks.
+  const LinkingContext = React.createContext<{ options?: any }>({ options: undefined });
+  const LocaleDirContext = React.createContext<"ltr" | "rtl">("ltr");
+  const UNSTABLE_UnhandledLinkingContext = React.createContext<{
+    lastUnhandledLink: string | undefined;
+    setLastUnhandledLink: (link: string | undefined) => void;
+  }>({ lastUnhandledLink: undefined, setLastUnhandledLink: () => {} });
+  const themeFonts = (() => {
+    // Mirrors the real module's Platform.select — the mock is served to native
+    // platforms only, so the ios / default branches are the reachable ones.
+    const isIOS = process.env.VITEST_NATIVE_PLATFORM !== "android";
+    return isIOS
+      ? {
+          regular: { fontFamily: "System", fontWeight: "400" },
+          medium: { fontFamily: "System", fontWeight: "500" },
+          bold: { fontFamily: "System", fontWeight: "600" },
+          heavy: { fontFamily: "System", fontWeight: "700" },
+        }
+      : {
+          regular: { fontFamily: "sans-serif", fontWeight: "normal" },
+          medium: { fontFamily: "sans-serif-medium", fontWeight: "normal" },
+          bold: { fontFamily: "sans-serif", fontWeight: "600" },
+          heavy: { fontFamily: "sans-serif", fontWeight: "700" },
+        };
+  })();
+  const DefaultTheme = {
+    dark: false,
+    colors: {
+      primary: "rgb(0, 122, 255)",
+      background: "rgb(242, 242, 242)",
+      card: "rgb(255, 255, 255)",
+      text: "rgb(28, 28, 30)",
+      border: "rgb(216, 216, 216)",
+      notification: "rgb(255, 59, 48)",
+    },
+    fonts: themeFonts,
+  };
+  const DarkTheme = {
+    dark: true,
+    colors: {
+      primary: "rgb(10, 132, 255)",
+      background: "rgb(1, 1, 1)",
+      card: "rgb(18, 18, 18)",
+      text: "rgb(229, 229, 231)",
+      border: "rgb(39, 39, 41)",
+      notification: "rgb(255, 69, 58)",
+    },
+    fonts: themeFonts,
+  };
+
+  // Real React Navigation seeds ThemeContext with DefaultTheme, so useTheme() outside a
+  // ThemeProvider (and outside a render, as a plain call) yields the default theme.
+  const ThemeContext = React.createContext<any>(DefaultTheme);
 
   const Screen = createMockScreen(NavigationContext, NavigationRouteContext, defaultRouteParams);
 
@@ -136,6 +196,17 @@ export function navigation(presetOptions: NavigationPresetOptions = {}): Preset 
           "useStateForPath",
           "validatePathConfig",
           "BaseNavigationContainer",
+          "LinkingContext",
+          "LocaleDirContext",
+          "UNSTABLE_UnhandledLinkingContext",
+          "DefaultTheme",
+          "DarkTheme",
+          "createStaticNavigation",
+          "ServerContainer",
+          "useLinkBuilder",
+          "useLinkProps",
+          "useLocale",
+          "useRoutePath",
           "createComponentForStaticNavigation",
           "createPathConfigForStaticNavigation",
           // @react-navigation/routers (re-exported by core)
@@ -243,28 +314,22 @@ export function navigation(presetOptions: NavigationPresetOptions = {}): Preset 
             return createNavigationContainerRef();
           }
 
-          const defaultTheme = {
-            dark: false,
-            colors: {
-              primary: "rgb(0, 122, 255)",
-              background: "rgb(242, 242, 242)",
-              card: "rgb(255, 255, 255)",
-              text: "rgb(28, 28, 30)",
-              border: "rgb(216, 216, 216)",
-              notification: "rgb(255, 59, 48)",
-            },
-          };
-
           function ThemeProvider({ value, children }: any) {
             return React.createElement(
               ThemeContext.Provider,
-              { value: value ?? defaultTheme },
+              { value: value ?? DefaultTheme },
               children,
             );
           }
 
           function useTheme() {
-            return defaultTheme;
+            // Outside a render (a plain call, common in tests) useContext is not
+            // available; the context default IS DefaultTheme, so answer that directly.
+            try {
+              return React.useContext(ThemeContext) ?? DefaultTheme;
+            } catch {
+              return DefaultTheme;
+            }
           }
 
           function NavigationIndependentTree({ children }: any) {
@@ -294,7 +359,23 @@ export function navigation(presetOptions: NavigationPresetOptions = {}): Preset 
             useNavigationState,
             useNavigationContainerRef,
             createNavigationContainerRef,
-            createNavigatorFactory: vi.fn(() => vi.fn()),
+            // Real shape: createNavigatorFactory(Navigator) returns a factory that
+            // yields { Navigator, Screen, Group }. It used to return a bare vi.fn()
+            // whose result was undefined, so any library building on the public
+            // factory API — expo-router extracts its Screen/Group primitives via
+            // createNavigatorFactory({})() — failed at import with
+            // "Cannot read properties of undefined (reading 'Screen')".
+            createNavigatorFactory: vi.fn((Navigator?: any) => () => ({
+              Navigator:
+                Navigator ??
+                React.forwardRef((props: any, ref: any) =>
+                  React.createElement("Navigator", { ...props, ref }, props.children),
+                ),
+              Screen,
+              Group: React.forwardRef((props: any, ref: any) =>
+                React.createElement("Group", { ...props, ref }, props.children),
+              ),
+            })),
             useNavigationBuilder: vi.fn(() => ({
               state: getState(),
               navigation: useNavigation(),
@@ -348,6 +429,27 @@ export function navigation(presetOptions: NavigationPresetOptions = {}): Preset 
             BaseNavigationContainer,
             createComponentForStaticNavigation: vi.fn(() => () => null),
             createPathConfigForStaticNavigation: vi.fn(() => ({})),
+            LinkingContext,
+            LocaleDirContext,
+            UNSTABLE_UnhandledLinkingContext,
+            DefaultTheme,
+            DarkTheme,
+            // Static navigation renders the tree the same way NavigationContainer does.
+            createStaticNavigation: vi.fn(() => NavigationContainer),
+            ServerContainer: React.forwardRef((props: any, _ref: any) =>
+              React.createElement(React.Fragment, null, props.children),
+            ),
+            useLinkBuilder: vi.fn(() => ({
+              buildHref: (name: string) => `/${name}`,
+              buildAction: (href: string) => ({ type: "NAVIGATE", payload: { name: href } }),
+            })),
+            useLinkProps: vi.fn(({ href, action }: any) => ({
+              href,
+              accessibilityRole: "link",
+              onPress: () => action,
+            })),
+            useLocale: vi.fn(() => ({ direction: "ltr" as const })),
+            useRoutePath: vi.fn(() => undefined),
             BaseRouter: {
               getInitialState: vi.fn(() => getState()),
               getRehydratedState: vi.fn((state: any) => state),

--- a/packages/vitest-native/tests/ecosystem-self-detection.test.ts
+++ b/packages/vitest-native/tests/ecosystem-self-detection.test.ts
@@ -321,3 +321,39 @@ describe("the project's own directory is never an externalization anchor", () =>
     );
   });
 });
+
+describe("detection and disabled presets", () => {
+  // A preset package used to be skipped by detection UNCONDITIONALLY, so turning the
+  // preset off (`presets: { navigation: false }` — required to run real
+  // @react-navigation/* under the native engine, which expo-router needs) un-shadowed
+  // the package but left it undetected: nothing compiled its untranspiled lib/module
+  // ESM and it failed at load. A package whose preset is off must detect like any
+  // other React Native dependency; one whose preset is ON must stay excluded.
+  it("detects a preset package when its preset is not active, and skips it when it is", () => {
+    const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vn-preset-off-")));
+    made.push(root);
+    write(root, "package.json", {
+      name: "app",
+      private: true,
+      dependencies: { "@react-navigation/native": "7.0.0", "react-native": "0.86.0" },
+    });
+    installInto(root, "@react-navigation/native", {
+      name: "@react-navigation/native",
+      version: "7.0.0",
+      main: "lib/module/index.js",
+      peerDependencies: { "react-native": "*" },
+    });
+    write(root, "node_modules/@react-navigation/native/lib/module/index.js", "export const x = 1;");
+    installInto(root, "react-native", { name: "react-native", version: "0.86.0" });
+
+    // navigation preset active → shadowed, not detected
+    expect(detectEcosystemPackages(root, [], [], [], ["navigation"])).not.toContain(
+      "@react-navigation/native",
+    );
+    // navigation preset off → an ordinary RN dependency, detected
+    expect(detectEcosystemPackages(root, [], [], [], [])).toContain("@react-navigation/native");
+    // No active-set passed at all → the pre-existing behaviour (all preset packages
+    // treated as shadowed), so older callers are unaffected
+    expect(detectEcosystemPackages(root)).not.toContain("@react-navigation/native");
+  });
+});

--- a/packages/vitest-native/tests/presets.test.ts
+++ b/packages/vitest-native/tests/presets.test.ts
@@ -31,6 +31,50 @@ describe("preset: navigation", () => {
   const preset = navigation();
   const mock = preset.modules["@react-navigation/native"].factory();
 
+  // createNavigatorFactory(Navigator) returns a factory yielding { Navigator, Screen,
+  // Group } — the real shape. It returned a bare vi.fn() whose result was undefined,
+  // so any library building on the public factory API (expo-router extracts its
+  // Screen/Group primitives via createNavigatorFactory({})()) failed at import.
+  it("createNavigatorFactory returns the real { Navigator, Screen, Group } shape", () => {
+    const factory = mock.createNavigatorFactory({});
+    const nav = factory();
+    expect(nav.Screen).toBeDefined();
+    expect(nav.Group).toBeDefined();
+    expect(nav.Navigator).toBeDefined();
+    // The supplied Navigator is the one returned.
+    const Custom = () => null;
+    expect(mock.createNavigatorFactory(Custom)().Navigator).toBe(Custom);
+  });
+
+  // The exports @react-navigation/native adds on top of @react-navigation/core.
+  // Absent, anything rendering its own container against the package (expo-router's
+  // forked NavigationContainer reads the linking/locale contexts) failed with
+  // "Cannot read properties of undefined (reading 'Provider')".
+  it("exports the linking, locale, theme and static-navigation surface", () => {
+    for (const name of [
+      "LinkingContext",
+      "LocaleDirContext",
+      "UNSTABLE_UnhandledLinkingContext",
+      "DefaultTheme",
+      "DarkTheme",
+      "createStaticNavigation",
+      "ServerContainer",
+      "useLinkBuilder",
+      "useLinkProps",
+      "useLocale",
+      "useRoutePath",
+    ]) {
+      expect(mock[name], name).toBeDefined();
+      // Every runtime export must also be in the preset's declared export list —
+      // that list is what feeds the ESM loader's named exports.
+      expect(preset.modules["@react-navigation/native"].exports, name).toContain(name);
+    }
+    expect(mock.LinkingContext.Provider).toBeDefined();
+    expect(mock.DefaultTheme.colors.primary).toBe("rgb(0, 122, 255)");
+    expect(mock.DarkTheme.dark).toBe(true);
+    expect(mock.DefaultTheme.fonts.regular.fontFamily).toBeDefined();
+  });
+
   it("useNavigation returns an object with navigate, goBack, reset", async () => {
     const { result } = await renderHook(() => mock.useNavigation());
     const nav = result.current;


### PR DESCRIPTION
Part of #186 (Expo coverage). Two gaps, both surfaced by rendering router-driven screens under the native engine — the shape most Expo apps have.

## 1. `createNavigatorFactory` returns the real shape

It returned `vi.fn(() => vi.fn())` — a factory whose result is `undefined` — so any library building on the public factory API failed at import. expo-router extracts its `Screen`/`Group` primitives via `createNavigatorFactory({})()`:

```
TypeError: Cannot read properties of undefined (reading 'Screen')   ← expo-router/build/primitives.js
```

Now yields `{ Navigator, Screen, Group }` (reusing the preset's existing `Screen`/`Group` mocks). The preset also gains the exports `@react-navigation/native` adds on top of `@react-navigation/core` — read from the real package's `src/index.tsx`, not from any consumer — `LinkingContext`, `LocaleDirContext`, `UNSTABLE_UnhandledLinkingContext`, `DefaultTheme`/`DarkTheme` (real colors + platform font stacks), `createStaticNavigation`, `ServerContainer`, `useLinkBuilder`, `useLinkProps`, `useLocale`, `useRoutePath`; `ThemeContext` seeded with `DefaultTheme` as in the real package. A test asserts every runtime export is also in the declared export list (the ESM loader's named-export feed).

## 2. A disabled preset's packages detect like any other

Detection skipped every preset package **unconditionally**, so `presets: { navigation: false }` un-shadowed `@react-navigation/*` but left it undetected: nothing compiled its untranspiled `lib/module` ESM, and inside real React Navigation `import { Platform } from 'react-native'` bound to nothing (`Cannot read properties of undefined (reading 'select')`). Detection now excludes only packages whose preset is *active* — the plugin passes the resolved set; callers passing none keep the old behaviour.

## Result

Under that configuration the **real** React Navigation stack — and expo-router's own `expo-router/testing-library` on top of it — runs under the native engine against a real expo-router app: `renderRouter` renders the route tree, `router.push` navigates, `screen`/`toHavePathname` work. One interop residual (the library's *synchronous* `testRouter` helpers when timers are installed before render) is bisected and filed as #188 with a documented working shape.

## Verification

Both fixes mutation-verified (each revert fails exactly its own test). Mock 1724 · native/hot 230 + 1 gated · navigation · isolation · hot-parity zero-delta · lint/typecheck/format · bake-off at/above baseline for both apps.