### PR TITLE
fix(native): install React Native's ErrorUtils; gate expo-router end to end

### DIFF
--- a/.changeset/expo-router-consumer-gate.md
+++ b/.changeset/expo-router-consumer-gate.md
@@ -1,0 +1,22 @@
+---
+"vitest-native": patch
+---
+
+Install React Native's ErrorUtils under the native engine; gate expo-router end to end
+
+`global.ErrorUtils` — React Native's error-guard polyfill, installed on device by
+InitializeCore — is read at module scope by Expo's `Expo.fx`
+(`ErrorUtils.getGlobalHandler()`), so importing anything from `expo` under the
+native engine failed with "ErrorUtils is not defined". The engine now installs the
+real `@react-native/js-polyfills` implementation, resolved through the installed
+React Native and compiled by the same hooks as the rest of its sources, once per
+realm; nothing is hand-mocked.
+
+The packed Expo consumer fixture gains an expo-router leg: a real SDK 56 project
+with file-based `app/` routes (a stack layout, a home screen, a dynamic
+`details/[id]` route), tested through expo-router's own `expo-router/testing-library`
+— `renderRouter("./app")`, `testRouter.push`/`back`, `toHavePathname`,
+`useLocalSearchParams` — exactly as its documentation shows and as a jest-expo
+suite already contains. It runs against the real `@react-navigation/*` stack with
+`presets: { navigation: false }` and the jest-compat layer, from a packed install
+in the consumer gate.

--- a/packages/vitest-native/consumer-tests/expo/app/_layout.tsx
+++ b/packages/vitest-native/consumer-tests/expo/app/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from "expo-router";
+
+export default function Layout() {
+  return <Stack />;
+}

--- a/packages/vitest-native/consumer-tests/expo/app/details/[id].tsx
+++ b/packages/vitest-native/consumer-tests/expo/app/details/[id].tsx
@@ -1,0 +1,7 @@
+import { useLocalSearchParams } from "expo-router";
+import { Text } from "react-native";
+
+export default function Details() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  return <Text>details for {id}</Text>;
+}

--- a/packages/vitest-native/consumer-tests/expo/app/index.tsx
+++ b/packages/vitest-native/consumer-tests/expo/app/index.tsx
@@ -1,0 +1,11 @@
+import { Link } from "expo-router";
+import { Text, View } from "react-native";
+
+export default function Home() {
+  return (
+    <View>
+      <Text>home screen</Text>
+      <Link href="/details/42">open details</Link>
+    </View>
+  );
+}

--- a/packages/vitest-native/consumer-tests/expo/package.json
+++ b/packages/vitest-native/consumer-tests/expo/package.json
@@ -3,15 +3,23 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:router": "vitest run --config vitest.router.config.mts"
   },
   "dependencies": {
     "@testing-library/react-native": "13.3.3",
     "expo": "56.0.11",
     "expo-constants": "56.0.18",
+    "expo-linking": "56.0.14",
+    "expo-router": "56.2.10",
     "expo-status-bar": "56.0.4",
     "react": "19.2.4",
     "react-native": "0.85.3",
+    "react-native-gesture-handler": "2.31.1",
+    "react-native-reanimated": "4.3.1",
+    "react-native-safe-area-context": "5.7.0",
+    "react-native-screens": "4.25.2",
+    "react-native-worklets": "0.8.3",
     "react-test-renderer": "19.2.4"
   },
   "devDependencies": {

--- a/packages/vitest-native/consumer-tests/expo/router-tests/router.test.tsx
+++ b/packages/vitest-native/consumer-tests/expo/router-tests/router.test.tsx
@@ -1,0 +1,36 @@
+import { renderRouter, screen, testRouter } from "expo-router/testing-library";
+import { expect, test } from "vitest";
+import React from "react";
+import { Text } from "react-native";
+
+// expo-router's OWN testing library, as its documentation shows — no wrapper, no
+// re-installed timers, helpers called plainly. This is the code a jest-expo suite
+// already contains; the point of the gate is that it ports verbatim.
+
+test("renders the app/ route tree and navigates with testRouter (file-based routes)", () => {
+  renderRouter("./app", { initialUrl: "/" });
+  expect(screen.getByText("home screen")).toBeTruthy();
+  expect(screen).toHavePathname("/");
+
+  testRouter.push("/details/42");
+  expect(screen.getByText("details for 42")).toBeTruthy();
+  expect(screen).toHavePathname("/details/42");
+
+  testRouter.back();
+  expect(screen).toHavePathname("/");
+  expect(screen.getByText("home screen")).toBeTruthy();
+});
+
+test("renders an in-memory route context (the unit-test shape)", () => {
+  renderRouter(
+    {
+      index: () => <Text>memory home</Text>,
+      about: () => <Text>memory about</Text>,
+    },
+    { initialUrl: "/about" },
+  );
+  expect(screen.getByText("memory about")).toBeTruthy();
+  expect(screen).toHavePathname("/about");
+  testRouter.replace("/");
+  expect(screen.getByText("memory home")).toBeTruthy();
+});

--- a/packages/vitest-native/consumer-tests/expo/vitest.router.config.mts
+++ b/packages/vitest-native/consumer-tests/expo/vitest.router.config.mts
@@ -1,0 +1,22 @@
+import { defineConfig } from "vitest/config";
+import { reactNative } from "vitest-native";
+import { jestCompatSetup, jestMockTransform } from "vitest-native/jest-compat";
+
+// Router-driven screens run against the REAL @react-navigation/* stack: expo-router's
+// ExpoRoot is a React Navigation navigator (useNavigationBuilder + descriptors), so
+// the navigation preset — a mock for unit-testing individual screens — is switched
+// off for this project and the real packages are auto-detected and compiled like any
+// other React Native dependency. Screens/gesture-handler/reanimated keep their presets.
+//
+// expo-router's own testing library is written for Jest (module-scope jest.mock,
+// jest.useFakeTimers inside renderRouter), so the jest-compat layer is part of the
+// configuration — the same layer a migrated jest-expo suite already brings.
+export default defineConfig({
+  plugins: [reactNative({ engine: "native", presets: { navigation: false } }), jestMockTransform()],
+  test: {
+    environment: "node",
+    globals: true,
+    setupFiles: [jestCompatSetup],
+    include: ["router-tests/**/*.test.tsx"],
+  },
+});

--- a/packages/vitest-native/scripts/test-consumers.mjs
+++ b/packages/vitest-native/scripts/test-consumers.mjs
@@ -83,6 +83,14 @@ try {
     // own runtime there — a twin-runtime defect (stamped @vitest/snapshot, stamped
     // vi) passes every workspace gate and burns only real installs. This leg is the
     // only gate that loads the hot runtime the way a consumer does.
+    // The Expo fixture also runs its router leg: expo-router's own testing library
+    // against the REAL @react-navigation stack (navigation preset off), driving
+    // file-based app/ routes with testRouter — the code a jest-expo suite already
+    // contains, ported verbatim. Only meaningful from a packed install, where the
+    // whole Expo SDK is a real dependency graph rather than the workspace's subset.
+    if (fixture === "expo") {
+      run("npm", ["run", "test:router"], fixtureRoot);
+    }
     if (fixture === "current-rn") {
       // npm installs the fixture's local probe packages as SYMLINKS (and npm 11
       // dropped install-links), whose real path sits outside node_modules — where

--- a/packages/vitest-native/src/native/globals.mjs
+++ b/packages/vitest-native/src/native/globals.mjs
@@ -1,3 +1,5 @@
+import { createRequire } from "node:module";
+import path from "node:path";
 // Globals React Native core expects at runtime, ported from react-native/jest/setup.js.
 export function installGlobals() {
   const g = globalThis;
@@ -129,4 +131,34 @@ function installExpoGlobal(g) {
     getViewConfig: () => null,
     reloadAppAsync: () => Promise.resolve(),
   };
+}
+
+/**
+ * `global.ErrorUtils` — React Native's error-guard polyfill (installed on device by
+ * InitializeCore via @react-native/js-polyfills, and by Jest's RN preset as a setup
+ * polyfill). The native engine deliberately does not run InitializeCore, and this
+ * global was the one piece of it that library code reads at MODULE SCOPE: Expo's
+ * `Expo.fx` calls `ErrorUtils.getGlobalHandler()` while loading, so any Expo import
+ * under the native engine failed with "ErrorUtils is not defined".
+ *
+ * The real polyfill is used, not a hand mock: it is Flow-typed, so this must run
+ * AFTER the require hooks are installed (they compile it like the rest of the
+ * @react-native/* sources), and it is resolved from the project so the version
+ * matches the installed React Native. Idempotent per realm. Silent when the
+ * polyfill package is absent (a partial install) — nothing else here depends on it.
+ */
+export function installErrorUtils(projectRoot) {
+  const g = globalThis;
+  if (g.ErrorUtils) return;
+  try {
+    const req = createRequire(path.join(projectRoot, "package.json"));
+    // Resolved via react-native's own dependency, the way InitializeCore reaches it.
+    const rnDir = path.dirname(req.resolve("react-native/package.json"));
+    const errorGuard = createRequire(path.join(rnDir, "package.json")).resolve(
+      "@react-native/js-polyfills/error-guard",
+    );
+    req(errorGuard);
+  } catch {
+    // Not installed; leave the global undefined rather than shipping a lookalike.
+  }
 }

--- a/packages/vitest-native/src/native/setup.mjs
+++ b/packages/vitest-native/src/native/setup.mjs
@@ -4,7 +4,7 @@
 import { createRequire, register } from "node:module";
 import path from "node:path";
 import { expect, vi } from "vitest";
-import { installGlobals } from "./globals.mjs";
+import { installGlobals, installErrorUtils } from "./globals.mjs";
 import { installRequireHooks } from "./hooks.mjs";
 import { installRegistry } from "./registry.mjs";
 import { enableV8CompileCache } from "./compile-cache.mjs";
@@ -172,6 +172,8 @@ if (process.env.VITEST_NATIVE_RN_REGISTRY) {
   }
 }
 installRequireHooks(projectRoot, nodeTransformPkgs, platform, reactNativeVersion, assetExts);
+// After the hooks: the polyfill is Flow-typed and compiled by them (see globals.mjs).
+installErrorUtils(projectRoot);
 
 // Build the mock objects now that the require hooks are installed (preset
 // factories may lazily resolve react-native at render time).

--- a/packages/vitest-native/src/native/worker.mjs
+++ b/packages/vitest-native/src/native/worker.mjs
@@ -13,7 +13,7 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import { isMainThread, parentPort, threadId } from "node:worker_threads";
 import { init, runBaseTests, setupEnvironment } from "vitest/worker";
-import { installGlobals } from "./globals.mjs";
+import { installGlobals, installErrorUtils } from "./globals.mjs";
 import { installRequireHooks } from "./hooks.mjs";
 import { installHotReset } from "./reset.mjs";
 import { installRegistry } from "./registry.mjs";
@@ -69,6 +69,8 @@ if (process.env.VITEST_NATIVE_RN_REGISTRY) {
   installRegistry(process.env.VITEST_NATIVE_RN_REGISTRY, projectRoot);
 }
 installRequireHooks(projectRoot, transformPkgs, platform, reactNativeVersion, assetExts);
+// After the hooks: the polyfill is Flow-typed and compiled by them (see globals.mjs).
+installErrorUtils(projectRoot);
 try {
   const req = createRequire(path.join(projectRoot, "package.json"));
   const RN = req("react-native");

--- a/packages/vitest-native/tests-native/globals.test.ts
+++ b/packages/vitest-native/tests-native/globals.test.ts
@@ -47,3 +47,24 @@ describe("native engine: fabricated expo native-module stubs", () => {
     expect(modules.SomeFabricatedModule.getOverriddenAsync()).toBe("explicit");
   });
 });
+
+describe("native engine: ErrorUtils", () => {
+  // React Native's error-guard polyfill, installed on device by InitializeCore and
+  // read at MODULE SCOPE by Expo's Expo.fx (`ErrorUtils.getGlobalHandler()`), so
+  // without it every Expo import under the native engine failed with
+  // "ErrorUtils is not defined". The REAL @react-native/js-polyfills implementation
+  // is installed, not a lookalike.
+  it("installs React Native's real error-guard as global.ErrorUtils", () => {
+    const ErrorUtils = (globalThis as Record<string, any>).ErrorUtils;
+    expect(ErrorUtils).toBeDefined();
+    expect(typeof ErrorUtils.getGlobalHandler).toBe("function");
+    expect(typeof ErrorUtils.setGlobalHandler).toBe("function");
+    expect(typeof ErrorUtils.applyWithGuard).toBe("function");
+    // Round-trips a handler the way Expo.fx does at load.
+    const previous = ErrorUtils.getGlobalHandler();
+    const handler = () => {};
+    ErrorUtils.setGlobalHandler(handler);
+    expect(ErrorUtils.getGlobalHandler()).toBe(handler);
+    ErrorUtils.setGlobalHandler(previous);
+  });
+});


### PR DESCRIPTION
Part of #186. Two things:

## `global.ErrorUtils` under the native engine

React Native's error-guard polyfill (installed on device by `InitializeCore`) is read at **module scope** by Expo's `Expo.fx` — `ErrorUtils.getGlobalHandler()` — so importing anything from `expo` under the native engine failed with `ErrorUtils is not defined`. The engine now installs the **real** `@react-native/js-polyfills` implementation: resolved through the installed `react-native` (the way `InitializeCore` reaches it), compiled by the same hooks as the rest of RN's Flow sources, once per realm. It runs *after* the require hooks in both the setup file and the hot worker (the polyfill is Flow-typed). Nothing is hand-mocked. Mutation-verified — no-oping the install fails the new `globals.test.ts` case in both engines.

## expo-router gated end to end, from a packed install

The Expo consumer fixture becomes a real SDK 56 project with file-based `app/` routes — a stack `_layout`, a home screen with a `Link`, a dynamic `details/[id]` route reading `useLocalSearchParams` — tested through expo-router's **own** `expo-router/testing-library`:

```tsx
renderRouter("./app", { initialUrl: "/" });
testRouter.push("/details/42");
expect(screen.getByText("details for 42")).toBeTruthy();
testRouter.back();
expect(screen).toHavePathname("/");
```

exactly as its documentation shows and as a jest-expo suite already contains — no wrapper, helpers called plainly (#188 was closed as invalid: the earlier "residual" was a probe artifact, an outer async `act` around the helper's own sync `act`). The leg runs against the real `@react-navigation/*` stack (`presets: { navigation: false }`, per #189) with the jest-compat layer, as a new `test:router` script the consumer harness runs from the packed install. Router deps are pinned to SDK 56's bundled versions — the set `npx expo install` produces.

Full battery green (mock 1721, native/hot 231 + 1 gated, isolation, hot-parity zero-delta, crosscheck, lint/typecheck/format); router leg 2/2.